### PR TITLE
fix(website): pin @astrojs/mdx to v6 for astro 6 compatibility

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,7 +8,7 @@
       "name": "website",
       "version": "1.0.0",
       "dependencies": {
-        "@astrojs/mdx": "^7.0.0",
+        "@astrojs/mdx": "^6.0.3",
         "@astrojs/sitemap": "^3.7.3",
         "@fontsource-variable/geist": "^5.2.9",
         "@scalar/api-reference": "^1.62.1",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.0.tgz",
-      "integrity": "sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-6.0.3.tgz",
+      "integrity": "sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.0",
@@ -160,8 +160,8 @@
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-satteri": "^0.3.1-alpha.0",
-        "astro": "^7.0.0-alpha.0"
+        "@astrojs/markdown-satteri": "0.3.0",
+        "astro": "^6.4.0"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-satteri": {

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "lint": "oxlint"
   },
   "dependencies": {
-    "@astrojs/mdx": "^7.0.0",
+    "@astrojs/mdx": "^6.0.3",
     "@astrojs/sitemap": "^3.7.3",
     "@fontsource-variable/geist": "^5.2.9",
     "@scalar/api-reference": "^1.62.1",


### PR DESCRIPTION
## Problem

PR #45 bumped `@astrojs/mdx` from 5.0.6 to 7.0.0, but astro is still on v6. `@astrojs/mdx@7` declares `peer astro@^7.0.0`, so `astro build` now fails on `main` with an `ERESOLVE` peer conflict — the Pages deploy (`pages.yml`, which is **not** a required status check) has been red since #45 merged.

## Fix

Pin `@astrojs/mdx` to `^6.0.3`, whose peer is `astro@^6.4.0` (satisfied by the resolved `astro@6.4.8`). This keeps the mdx integration as current as possible for the astro-6 line without pulling in the astro 7 major, which is a breaking upgrade that needs its own migration (astro 7 currently fails the build with a Vite SSR entry error).

Verified locally: `astro build` completes and Pagefind indexes all 12 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)