### PR TITLE
fix: detect node-exporter by its metrics, not by a job label

### DIFF
--- a/internal/api/cluster_handlers.go
+++ b/internal/api/cluster_handlers.go
@@ -265,10 +265,20 @@ func (h *Handlers) HandleMonitoringStatus(w http.ResponseWriter, r *http.Request
 	var anySuccess bool
 	wg.Add(2)
 
-	// Query node-exporter targets
+	// Query node-exporter targets.
+	//
+	// Detection is by the presence of node-exporter's own metrics, not by a
+	// `job` label: the job name is chosen by whoever writes the Prometheus
+	// config, and a collector that scrapes nodes fleet-wide rather than
+	// per-cluster commonly names it something else entirely. node_uname_info is
+	// emitted by node-exporter's uname collector in every deployment, and it is
+	// also exactly what useInstanceResolver needs to map a Swarm node to an
+	// instance label -- so this asks the question the UI actually depends on.
+	// A configured but unreachable target used to report as detected and then
+	// render empty panels.
 	go func() {
 		defer wg.Done()
-		results, err := h.promClient.InstantQuery(ctx, `up{job="node-exporter"}`)
+		results, err := h.promClient.InstantQuery(ctx, `count by (instance) (node_uname_info)`)
 		if err != nil {
 			slog.Warn("monitoring status: node-exporter query failed", "error", err)
 			return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -379,7 +379,7 @@ func TestHandleMonitoringStatus_WithPrometheus(t *testing.T) {
 		query := r.URL.Query().Get("query")
 		var body string
 		switch {
-		case strings.Contains(query, "node-exporter"):
+		case strings.Contains(query, "node_uname_info"):
 			body = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"instance":"host1:9100"},"value":[1,"1"]},{"metric":{"instance":"host2:9100"},"value":[1,"1"]}]}}`
 		case strings.Contains(query, "cadvisor"):
 			body = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"instance":"host1:8080"},"value":[1,"1"]},{"metric":{"instance":"host2:8080"},"value":[1,"1"]}]}}`


### PR DESCRIPTION
The monitoring-status probe asked `up{job="node-exporter"}`. `job` is chosen by whoever writes the Prometheus config, not by node-exporter, so the check only ever passed for deployments that happened to pick that exact name. A collector that scrapes hosts fleet-wide rather than per-cluster typically names the job after its own purpose, and Cetacean then reports node-exporter as undetected while it is running and healthy — greeting the user with "node-exporter not detected" over a set of blank node panels.

Ask for `count by (instance) (node_uname_info)` instead. node-exporter's `uname` collector emits that series in every deployment, and it is the same series `useInstanceResolver` already needs to map a Swarm node hostname to an `instance` label. The probe now tests exactly the data the node panels depend on: if it comes back empty, the panels could not have rendered anyway.

- Response shape is unchanged: `nodeExporter: { targets, nodes }`.
- No new configuration, no new fields.
- `len(results)` keeps its meaning — `count by (instance)` returns one result per instance, as `up{...}` did per target.

## Compatibility

For the reference stack in this repo — `prometheus.yml` job `node-exporter`, DNS SD on `tasks.node-exporter`, `mode: global`, default collectors so `uname` is on — both queries return the same number: one `node_uname_info` series per instance, one instance per node.

Four cases diverge, and none of them makes an existing setup worse:

| Case | Before | After | Effect in the UI |
|---|---|---|---|
| Target configured but scrape-failing >5m | counted, reports detected | not counted | Banner now says "reporting on X of N nodes" instead of staying silent over blank panels. More truthful. |
| Prometheus also scrapes non-Swarm hosts | Swarm targets only | every host with node metrics, so `targets` may exceed `nodes` | None. `MonitoringStatus` renders only on `targets === 0` or `targets < nodes`, so an over-count is invisible. |
| node-exporter run with the `uname` collector disabled | detected | not detected | Panels were already blank — `useInstanceResolver` needs the same series. More truthful. |
| Task rescheduled, previous overlay IP stale for <5m | old target leaves SD at once | briefly counts both IPs | None, same reason as row 2. |

The one that would actually be a regression — a count rendering as "node-exporter reporting on 55 of 5 nodes" — cannot occur, because that string is gated on `targets < nodes`.

`internal/api` tests pass. The fixture in `handlers_test.go` keys on the query string and was updated to match.

Note `up{job="cadvisor"}` a few lines below has the same shape. Left alone here to keep the change small — happy to follow up if you want it.