### PR TITLE
chore(frontend): cut lint warnings from 91 to 36 by removing the false positives

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -20,6 +20,10 @@
     "react/jsx-no-constructed-context-values": "warn",
     "react/no-this-in-sfc": "error",
     "react/no-array-index-key": "off",
+    // Every report is a `cell: ({ ID }) => <Link…>` render prop in a DataTable
+    // column definition. Those are not components — React never mounts them as
+    // one — so the stale-state hazard the rule warns about cannot occur.
+    "react/no-unstable-nested-components": ["warn", { "allowAsProps": true }],
     "react-hooks/rules-of-hooks": "error",
     "react/refs": "error",
     // React Compiler rules, added to oxlint's `correctness` category in 1.7x
@@ -46,6 +50,10 @@
         "varsIgnorePattern": "^_"
       }
     ],
+    // Private fields deliberately stashed on objects owned by other libraries:
+    // `_rawData` on a Chart.js dataset, `_elkHeight` on a React Flow node's
+    // data, `_values` in vendored shadcn slider code.
+    "no-underscore-dangle": ["warn", { "allow": ["_values", "_rawData", "_elkHeight"] }],
     "no-shadow": "off",
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "eqeqeq": ["error", "smart"],
@@ -68,5 +76,15 @@
   "env": {
     "builtin": true
   },
-  "ignorePatterns": ["dist/**"]
+  "ignorePatterns": ["dist/**"],
+  "overrides": [
+    {
+      // Tests drive sequences that have to happen in order — a reconnect
+      // attempt, then the next one — so awaiting inside the loop is the point.
+      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "no-await-in-loop": "off"
+      }
+    }
+  ]
 }

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -209,7 +209,7 @@ export default function DataTable<T>({
     observer.observe(sentinelRef.current);
 
     return () => observer.disconnect();
-  }, [hasMore]);
+  }, [hasMore, onLoadMoreRef]);
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {

--- a/frontend/src/hooks/useAsyncAction.ts
+++ b/frontend/src/hooks/useAsyncAction.ts
@@ -22,28 +22,31 @@ export function useAsyncAction(options?: AsyncActionOptions) {
 
   const toastRef = useLatestRef(options?.toast);
 
-  const execute = useCallback(async (action: () => Promise<unknown>, errorMessage: string) => {
-    setLoading(true);
-    setError(null);
-    setCause(null);
+  const execute = useCallback(
+    async (action: () => Promise<unknown>, errorMessage: string) => {
+      setLoading(true);
+      setError(null);
+      setCause(null);
 
-    try {
-      await action();
-    } catch (caught) {
-      if (mountedRef.current) {
-        setError(getErrorMessage(caught, errorMessage));
-        setCause(caught);
+      try {
+        await action();
+      } catch (caught) {
+        if (mountedRef.current) {
+          setError(getErrorMessage(caught, errorMessage));
+          setCause(caught);
 
-        if (toastRef.current) {
-          showErrorToast(caught, errorMessage);
+          if (toastRef.current) {
+            showErrorToast(caught, errorMessage);
+          }
+        }
+      } finally {
+        if (mountedRef.current) {
+          setLoading(false);
         }
       }
-    } finally {
-      if (mountedRef.current) {
-        setLoading(false);
-      }
-    }
-  }, []);
+    },
+    [toastRef],
+  );
 
   return { loading, error, cause, execute };
 }

--- a/frontend/src/hooks/useDebouncedInvalidation.ts
+++ b/frontend/src/hooks/useDebouncedInvalidation.ts
@@ -31,7 +31,7 @@ export function useDebouncedInvalidation(
           void queryClient.invalidateQueries({ queryKey: [...key] });
         }
       }, delay);
-    }, [queryClient, delay]),
+    }, [queryClient, delay, queryKeysRef]),
   );
 
   useEffect(() => {

--- a/frontend/src/hooks/useEscapeCancel.ts
+++ b/frontend/src/hooks/useEscapeCancel.ts
@@ -31,5 +31,5 @@ export function useEscapeCancel(active: boolean, onCancel: () => void) {
     document.addEventListener("keydown", handler, true);
 
     return () => document.removeEventListener("keydown", handler, true);
-  }, [active]);
+  }, [active, callbackRef]);
 }

--- a/frontend/src/hooks/useHotkeys.ts
+++ b/frontend/src/hooks/useHotkeys.ts
@@ -81,5 +81,5 @@ export function useHotkeys(hotkeys: HotkeyMap) {
         clearTimeout(timerRef.current);
       }
     };
-  }, []);
+  }, [hotkeysRef]);
 }

--- a/frontend/src/hooks/useResourceStream.ts
+++ b/frontend/src/hooks/useResourceStream.ts
@@ -68,7 +68,7 @@ export function useResourceStream(path: string, listener: SSEListener) {
     });
 
     return () => stream.close();
-  }, [path]);
+  }, [path, listenerRef]);
 
   return { connected };
 }

--- a/frontend/src/hooks/useSwarmQuery.ts
+++ b/frontend/src/hooks/useSwarmQuery.ts
@@ -199,7 +199,7 @@ export function useSwarmQuery<T>(
           void queryClient.invalidateQueries({ queryKey: key });
         }
       },
-      [queryClient],
+      [queryClient, queryKeyRef, getIdRef],
     ),
   );
 

--- a/frontend/src/pages/Topology.tsx
+++ b/frontend/src/pages/Topology.tsx
@@ -129,7 +129,7 @@ function useElkLayout(rawNodes: Node[], rawEdges: Edge[]) {
     return () => {
       cancelled = true;
     };
-  }, [structureKey]);
+  }, [structureKey, nodesRef, edgesRef]);
 
   // Patch node data in-place when only display data changes (replicas, status, etc.)
   useEffect(() => {


### PR DESCRIPTION
Rebased onto current `main`, now including the oxlint 1.81 / oxfmt 0.66 bump (#183). Counts below are measured under that tooling.

`oxlint` reports 91 warnings on `main`, most of them not defects. This removes the ones that were never real and fixes the handful that were:

- **`no-unstable-nested-components` (35 → 0)** — every report is a `cell: ({ ID }) => <Link…>` render prop in a `DataTable` column definition. React never mounts those as components, so the stale-state hazard the rule describes cannot occur. Enabled `allowAsProps`.
- **`no-underscore-dangle` (4 → 0)** — private fields deliberately stashed on objects owned by other libraries (`_rawData` on a Chart.js dataset, `_elkHeight` on a React Flow node, `_values` in vendored shadcn slider code). Allow-listed by name, so a new one still gets reported.
- **`no-await-in-loop` (3 → 0)** — only in tests, which drive ordered sequences (a reconnect attempt, then the next) where awaiting in the loop is the point. Turned off for `*.test.ts(x)` only.
- **`exhaustive-effect-dependencies` / `exhaustive-deps` (real)** — seven effects and one `useCallback` were missing a `useRef` object from their dependency array. Refs are stable identities, so these are no-ops at runtime, but the rule is right that they belong there.

Warnings after: **36**, all genuine and left for follow-up — `set-state-in-effect` (14), `exhaustive-effect-dependencies` (10), `static-components` (3), `no-deriving-state-in-effects` (3), `incompatible-library` (2), and four singletons.

Verified locally: `npm run lint` exits 0, `oxfmt --check` clean, `tsc -b --noEmit` clean, 671 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oMRxgQVKcZjnuB6WLx4wE