### PR TITLE
feat(mcp): record consent so approved clients do not re-prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - AI agents can now ask for Cetacean's recommendations directly, optionally only the critical ones, and clients that support interactive apps render them grouped by severity — picking one asks the agent to look into it
 - AI agents can now list a whole resource type over MCP — every service, node, task, stack, config, secret, network, or volume the caller may see, paged — rather than searching for resources one name at a time
 - Cetacean can now export traces to an OpenTelemetry collector via `CETACEAN_OTEL_ENDPOINT`. Every MCP request and tool call is recorded, and a call from an agent that is already tracing joins that agent's trace instead of starting its own, so the agent's turn and the cluster change it caused appear together
-- Approving an MCP client is now remembered, so you are asked once instead of every time its access expires. Cetacean asks again if the client changes its name or where it sends you, if you revoke its access, or if a stolen token is detected
+- Approving an MCP client is now remembered, so you are asked once instead of every time its access expires. Cetacean asks again if the client changes its name or where it sends you, if you revoke its access, or if a stolen token is detected. An approval lasts 90 days and is renewed each time you approve; set `CETACEAN_MCP_CONSENT_TTL` to change that, or to `0` to always be asked
 
 ### Changed
 - MCP authorization responses now identify the issuer (RFC 9207), so a client configured with several authorization servers cannot be tricked into redeeming a code at the wrong one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - AI agents can now ask for Cetacean's recommendations directly, optionally only the critical ones, and clients that support interactive apps render them grouped by severity — picking one asks the agent to look into it
 - AI agents can now list a whole resource type over MCP — every service, node, task, stack, config, secret, network, or volume the caller may see, paged — rather than searching for resources one name at a time
 - Cetacean can now export traces to an OpenTelemetry collector via `CETACEAN_OTEL_ENDPOINT`. Every MCP request and tool call is recorded, and a call from an agent that is already tracing joins that agent's trace instead of starting its own, so the agent's turn and the cluster change it caused appear together
+- Approving an MCP client is now remembered, so you are asked once instead of every time its access expires. Cetacean asks again if the client changes its name or where it sends you, if you revoke its access, or if a stolen token is detected
 
 ### Changed
 - MCP authorization responses now identify the issuer (RFC 9207), so a client configured with several authorization servers cannot be tricked into redeeming a code at the wrong one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ docker stack deploy -c compose.monitoring.yaml monitoring  # Deploy standalone m
 | `CETACEAN_MCP_SIGNING_KEY` | auto-generated | No (HMAC-SHA256 JWT signing key) |
 | `CETACEAN_MCP_ACCESS_TOKEN_TTL` | `1h` | No |
 | `CETACEAN_MCP_REFRESH_TOKEN_TTL` | `720h` | No |
+| `CETACEAN_MCP_CONSENT_TTL` | `2160h` | No (how long a remembered approval lasts; `0` always prompts) |
 | `CETACEAN_MCP_MAX_CONCURRENT_TASKS` | `32` | No (cap on in-flight task-augmented tool calls) |
 | `CETACEAN_MCP_REQUIRE_RESOURCE_INDICATOR` | `true` | No (require RFC 8707 `resource` on authorize/token) |
 | `CETACEAN_MCP_DCR_ENABLED` | `true` | No (RFC 7591 Dynamic Client Registration) |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -110,6 +110,25 @@ URL — a token minted for one Cetacean deployment cannot be replayed against an
 are required by default. Refresh tokens are opaque, rotate single-use, and carry an absolute grant-family lifetime;
 presenting a rotated token revokes the whole family (theft detection).
 
+### Remembered approvals
+
+Approving a client is remembered, so you are asked once rather than every time
+its refresh token expires. A record ties your identity to that client, the MCP
+endpoint it asked for, and a fingerprint of the client's name and redirect URIs
+as you were shown them.
+
+You are asked again when any of those change — including when a client updates
+its own metadata document, since a client identified by URL controls what that
+document says — and when the grant is revoked or Cetacean detects a stolen
+refresh token. Clients that registered dynamically are never remembered: their
+metadata is self-reported.
+
+Approvals live in `mcp-tokens.json` beside the refresh tokens. Note the file's
+threat model differs between the two: refresh tokens are stored as SHA-256
+hashes, which are useless to anyone who steals the file, while an approval is a
+capability — anyone able to *write* the file could pre-approve a client. The
+file is mode `0600`, and as always an attacker with host access has already won.
+
 ### `cert` mode and `CETACEAN_MCP_AUTH_BYPASS`
 
 mTLS client-certificate auth can't drive a browser consent flow, so OAuth is not used in `cert` mode. Set
@@ -390,13 +409,15 @@ nowhere while looking configured.
 
 ## Known limitations (current release)
 
-- **Refresh tokens survive a restart; nothing else does.** They are written to `mcp-tokens.json` in the data
-  directory (see [`storage.data_dir`](configuration.md)) on every issue, rotation and revocation, so an authorized
-  client stays authorized. DCR registrations and authorization codes are still in-memory: a client whose registration
-  is lost re-registers via the discovery chain on the next `401`, and a code lost mid-flow is indistinguishable from an
-  expired one at its 60-second TTL. Access-token JWTs are stateless and remain valid until they expire, unless
+- **Refresh tokens and consent approvals survive a restart; nothing else does.** They are written to
+  `mcp-tokens.json` in the data directory (see [`storage.data_dir`](configuration.md)) on every issue, rotation,
+  revocation, and approval, so an authorized client stays authorized and does not have to be re-approved. DCR
+  registrations and authorization codes are still in-memory: a client whose registration is lost re-registers via
+  the discovery chain on the next `401`, and a code lost mid-flow is indistinguishable from an expired one at its
+  60-second TTL. Access-token JWTs are stateless and remain valid until they expire, unless
   `CETACEAN_MCP_SIGNING_KEY` is unset — an auto-generated key changes on every restart, which invalidates them. Set it
-  to keep access tokens valid too.
+  to keep access tokens valid too. See [Remembered approvals](#remembered-approvals) for what makes a stored approval
+  stop applying.
 - **Durability is not shared.** The token file is local. Multi-replica deployments are not supported: authorization codes
   live in one replica's memory for their 60-second lifetime, and an unset `CETACEAN_MCP_SIGNING_KEY` leaves each
   replica signing with a different key.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -123,6 +123,19 @@ document says — and when the grant is revoked or Cetacean detects a stolen
 refresh token. Clients that registered dynamically are never remembered: their
 metadata is self-reported.
 
+An approval is also a lease, not a permanent grant. It lasts
+`CETACEAN_MCP_CONSENT_TTL` (default `2160h`, 90 days) from the moment you
+approved, and approving again renews it. The lease exists because revoking an
+approval means presenting a token from its grant family, and that family is torn
+down once its refresh token expires — so without one, an approval belonging to a
+long-unused client would keep authorizing silently with no handle left to
+withdraw it. The default deliberately outlives the 30-day refresh token, since
+not re-prompting when that token expires is the whole point of remembering.
+
+Set `CETACEAN_MCP_CONSENT_TTL=0` to turn remembering off entirely: nothing is
+recorded, existing records stop being honoured, and every authorization reaches
+a human.
+
 Approvals live in `mcp-tokens.json` beside the refresh tokens. Note the file's
 threat model differs between the two: refresh tokens are stored as SHA-256
 hashes, which are useless to anyone who steals the file, while an approval is a
@@ -242,6 +255,7 @@ Docker version conflict.
 | `CETACEAN_MCP_SIGNING_KEY` | auto-generated | HMAC-SHA256 JWT signing key |
 | `CETACEAN_MCP_ACCESS_TOKEN_TTL` | `1h` | Access token lifetime |
 | `CETACEAN_MCP_REFRESH_TOKEN_TTL` | `720h` | Refresh token lifetime (30 days) |
+| `CETACEAN_MCP_CONSENT_TTL` | `2160h` | How long a remembered approval lasts (90 days); `0` disables remembering |
 | `CETACEAN_MCP_MAX_CONCURRENT_TASKS` | `32` | Cap on in-flight task-augmented tool calls |
 | `CETACEAN_MCP_REQUIRE_RESOURCE_INDICATOR` | `true` | Require the RFC 8707 `resource` parameter |
 | `CETACEAN_MCP_DCR_ENABLED` | `true` | Enable Dynamic Client Registration |

--- a/docs/specs/2026-09-02-mcp-consent-records-design.md
+++ b/docs/specs/2026-09-02-mcp-consent-records-design.md
@@ -1,0 +1,222 @@
+# MCP consent records
+
+**Issue:** [#160](https://github.com/Radiergummi/cetacean/issues/160)
+**Depends on:** [#74](https://github.com/Radiergummi/cetacean/issues/74), merged as `0f71654e`
+**Status:** design approved, not implemented
+
+Record a user's consent decision so an already-approved MCP client does not
+re-prompt on every authorization request.
+
+## What exists today
+
+`internal/mcp/oauth/consent.go` renders the consent page and handles CSRF (a
+nonce cookie plus an HMAC token over `nonce|state`). Nothing writes "user X
+approved client Y". `handleAuthorizeGET` validates the request, resolves the
+client's metadata, requires an identity from the auth middleware, and then
+always renders the form.
+
+Consent is remembered only _implicitly_, by a refresh token existing: a client
+holding one never returns to `/oauth/authorize`, so the user is not re-prompted
+until the grant expires (720h by default) or is revoked.
+
+## Value, stated honestly
+
+Smaller than it first appears. Now that #74 persists refresh tokens, the consent
+page already appears about once a month per client. A consent record turns that
+into "once, until revoked". That is a UX improvement, not a durability fix, and
+it should not be mistaken for one.
+
+## Decisions
+
+### The fingerprint covers what the user saw
+
+A DCR registration is frozen at registration time, but CIMD — the recommended
+path since 2026-07-28 — puts the metadata at a URL the client controls and may
+change at any moment, including its `redirect_uris`. A record saying "user
+approved `https://foo.example/client.json`" would otherwise auto-approve a later
+flow redirecting somewhere the user never saw.
+
+The fingerprint is a domain-separated SHA-256 over the client's `client_name`
+and its **sorted** `redirect_uris` — precisely the two things the consent page
+displays. A rename, an added URI, a removed URI or an edited URI all re-prompt.
+Reordering does not: array order in a client-controlled document carries no
+meaning, and re-prompting on it would be noise.
+
+Rejected: hashing the whole fetched document. Strictly safer, but it re-prompts
+on cosmetic edits (`logo_uri`, contacts), and a prompt that fires for reasons the
+user cannot see trains people to click Approve without reading — which costs more
+security than the extra fields buy. Also rejected: `redirect_uris` alone, the
+issue's stated minimum, which would let a client silently rename itself and
+inherit an approval granted to a different name.
+
+Note this risk is _created_ by combining consent records with CIMD. Neither
+alone has it.
+
+### Verified clients only
+
+`resolveClientMeta` already returns `verified` — true on the CIMD path, where
+identity is proven by fetching the URL that _is_ the `client_id`, and false on
+the DCR path, where metadata is self-reported. Only verified clients get a
+record; a DCR client always prompts.
+
+Beyond the self-reporting argument, a DCR `client_id` is a random string held in
+an in-memory, LRU-evicted registry. It does not survive a restart, so a record
+keyed on one would be dead weight at best.
+
+### Matching is exact
+
+A record matches only when subject, `client_id`, RFC 8707 `resource` and
+fingerprint all match. Keying on `resource` means an approval for one MCP
+endpoint never covers another.
+
+The in-memory map is keyed on subject + `client_id` + `resource`, and the
+fingerprint lives in the value rather than the key. So a client whose metadata
+changed re-prompts, and approving *replaces* the stale record instead of
+accumulating a second one — a user can never hold two live approvals for the
+same client, one of which they no longer remember granting.
+
+### Records do not expire
+
+The issue asks for "once, until revoked". Any TTL quietly reintroduces
+re-prompting, which is the thing being removed. Records are small and bounded by
+(subject × client × resource) in practice.
+
+### Revocation and theft clear consent; expiry does not
+
+`RefreshTokenStore.revokeGrantLocked` is reached from three callers, and they
+must not behave alike:
+
+| Caller                            | Clears consent | Why                                                                                                                                                              |
+| --------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RevokeGrant` (RFC 7009 endpoint) | Yes            | A record outliving revocation degrades revoke into "grant one more silent re-authorization", which is worse than not revoking because it appears to have worked. |
+| `Rotate`, theft branch            | Yes            | A replayed token burned the family. Silently re-granting on the next authorize is exactly wrong.                                                                 |
+| `Rotate`, expiry branch           | **No**         | Consent outliving the refresh token is the entire feature.                                                                                                       |
+
+The decision therefore cannot live inside `revokeGrantLocked`. It returns the
+family's identity — read from its live token, of which a family has exactly
+one — and each caller
+decides. `RevokeGrant` returns what it revoked, and `RotateResult` carries the
+burned family's `Data` on the theft path, which also removes the existing
+limitation that "callers that need to log the affected subject must record it at
+issue time".
+
+## Design
+
+### Components
+
+- **`ConsentStore`** (`internal/mcp/oauth/consent_store.go`) — `Remember`,
+  `Allows`, `Forget`, `Snapshot`, `Restore`. Mirrors `RefreshTokenStore`: a
+  mutex, a map, and an on-change hook fired after the lock is released.
+- **`consentFingerprint(meta *ClientMetadata) string`** — the hash above.
+- **`stateFile`** (`internal/mcp/oauth/persist.go`) — owns the path and writes
+  both stores as one file.
+
+### One file, two stores
+
+Two stores cannot each hold their own persist func: each would write the file
+from its own snapshot and clobber the other's. `stateFile` owns the path,
+snapshots both stores, and writes. Each store's hook becomes a plain `func()`
+into it.
+
+This revises what #74 landed: `SetPersistFunc(func(RefreshTokenSnapshot))`
+becomes `SetOnChange(func())`. Both stores keep the existing discipline — the
+hook fires only after the mutex is released, because taking a snapshot acquires
+it, and only when state actually changed.
+
+### File format v2
+
+```json
+{
+  "version": 2,
+  "timestamp": "...",
+  "tokens":   { "<hash>": { ... } },
+  "consumed": { "<hash>": "<grantId>" },
+  "grants":   { "<grantId>": ["<hash>"] },
+  "consent": [
+    {
+      "subject":     "user@example.com",
+      "clientId":    "https://example.com/client.json",
+      "resource":    "https://cetacean.example.com/mcp",
+      "fingerprint": "<base64url sha256>",
+      "grantedAt":   "..."
+    }
+  ]
+}
+```
+
+Consent is a slice on disk — readable, and it avoids inventing an encoding for a
+composite map key built from three free-form strings — and a map keyed on
+subject + client + resource in memory. A v1 file loads with no records, the way
+`cache/snapshot.go` already handles v1 against v2. The filename stays
+`mcp-tokens.json`: renaming buys nothing and would silently drop tokens for
+anyone tracking main.
+
+### Authorization flow
+
+In `handleAuthorizeGET`, after every existing validation and the identity check:
+
+```
+fingerprint := consentFingerprint(meta)
+if verified && consent.Allows(subject, clientID, effectiveResource, fingerprint) {
+    issue code, redirect
+    return
+}
+render the consent page
+```
+
+Skipping the page means GET issues a code and redirects rather than rendering a
+form. That is ordinary for an OAuth authorization endpoint, and `redirect_uri`
+has already been exact-matched against the client's registered set before this
+point, so a silently issued code still lands only where the client registered.
+No CSRF token is involved because no form is submitted.
+
+GET currently computes the effective resource via `ValidateResourceIndicator`
+and discards it; it now keeps it, since the record is keyed on it.
+
+The code-issuing tail of `handleAuthorizePOST` is extracted into a helper both
+paths call, removing the duplication that would otherwise appear.
+
+On approve, `handleAuthorizePOST` calls `Remember` when `verified`.
+
+### The consent page says so
+
+The page gains one line stating the decision will be remembered until revoked.
+Turning "approve once" into "approve until revoked" without telling the person
+is not consent.
+
+## Threat model
+
+This differs from #74 and must not inherit that issue's assessment by proximity.
+
+The refresh-token half of the file holds SHA-256 hashes; stealing it gains an
+attacker nothing, because the hashes are not usable credentials. Its risk is
+confidentiality only.
+
+A consent record is a **capability**. Someone able to _write_ the file can inject
+a pre-approval and complete an authorization flow with no human in the loop.
+Same `0600`, same "an attacker with host access has already won" caveat — but the
+property being protected changes from confidentiality to integrity, and the
+documentation should say that rather than let the reader generalize from #74.
+
+## Testing
+
+- Fingerprint: stable under `redirect_uris` reordering; changes on rename, and
+  on an added, removed or edited URI.
+- `Allows` returns false on a mismatched subject, `client_id`, `resource` or
+  fingerprint.
+- A GET with a matching record redirects with a code and renders no form.
+- A GET re-prompts after the client's metadata changes.
+- A DCR (unverified) client records nothing and always prompts.
+- `RevokeGrant` clears the record; a subsequent authorize prompts.
+- Theft clears the record.
+- **Expiry does not clear the record.**
+- A v1 file loads with no records; a v2 file round-trips through disk.
+
+## Out of scope
+
+- **Revoking consent from the UI.** There is no way to list or drop a record
+  other than revoking the token. Worth doing; not this issue.
+- **JTI denylist for immediate access-token revocation.** Unchanged by this work
+  and tracked separately.
+- **Multi-replica.** The file is local. Already broken for other reasons; see
+  #74.

--- a/docs/specs/2026-09-02-mcp-consent-records-design.md
+++ b/docs/specs/2026-09-02-mcp-consent-records-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#160](https://github.com/Radiergummi/cetacean/issues/160)
 **Depends on:** [#74](https://github.com/Radiergummi/cetacean/issues/74), merged as `0f71654e`
-**Status:** design approved, not implemented
+**Status:** implemented
 
 Record a user's consent decision so an already-approved MCP client does not
 re-prompt on every authorization request.
@@ -111,7 +111,7 @@ issue time".
   mutex, a map, and an on-change hook fired after the lock is released.
 - **`consentFingerprint(meta *ClientMetadata) string`** — the hash above.
 - **`stateFile`** (`internal/mcp/oauth/persist.go`) — owns the path and writes
-  both stores as one file.
+  both stores as one file, under its own mutex.
 
 ### One file, two stores
 
@@ -119,6 +119,17 @@ Two stores cannot each hold their own persist func: each would write the file
 from its own snapshot and clobber the other's. `stateFile` owns the path,
 snapshots both stores, and writes. Each store's hook becomes a plain `func()`
 into it.
+
+Being the single writer takes a mutex, held across the snapshot and the rename
+that publishes it. Two concurrent mutations — reachable now that two independent
+stores point here — would otherwise snapshot at different moments and rename in
+either order, publishing a view taken before the other's mutation and silently
+dropping a token or an approval still live in memory. The temp file also gets a
+unique name instead of a fixed `path + ".tmp"`: within the process the mutex
+settles it, but two processes sharing a data directory would truncate the same
+temp file and interleave bytes into it, and the rename would publish something
+that does not parse. A lost update is survivable; unparseable bytes cost every
+client a re-authorization.
 
 This revises what #74 landed: `SetPersistFunc(func(RefreshTokenSnapshot))`
 becomes `SetOnChange(func())`. Both stores keep the existing discipline — the
@@ -163,7 +174,7 @@ if verified && consent.Allows(subject, clientID, effectiveResource, fingerprint)
     issue code, redirect
     return
 }
-render the consent page
+render the consent page, carrying fingerprint
 ```
 
 Skipping the page means GET issues a code and redirects rather than rendering a
@@ -176,9 +187,46 @@ GET currently computes the effective resource via `ValidateResourceIndicator`
 and discards it; it now keeps it, since the record is keyed on it.
 
 The code-issuing tail of `handleAuthorizePOST` is extracted into a helper both
-paths call, removing the duplication that would otherwise appear.
+paths call, removing the duplication that would otherwise appear. So is the
+consent-page render, which GET and POST both reach.
 
 On approve, `handleAuthorizePOST` calls `Remember` when `verified`.
+
+### The fingerprint travels from the GET, not resolved again on the POST
+
+The claim above — an approval is bound to a fingerprint of what the user was
+shown — is not delivered by fingerprinting on the POST. `resolveClientMeta`
+runs twice: once on GET to render the page, once on POST to act on it. The CIMD
+fetcher's 1h cache usually hides the gap, but a consent tab open longer than
+that, a restart or an eviction makes the POST re-fetch, and it would then record
+a fingerprint of a document the user never saw. Every later authorize would
+silently issue codes against a redirect URI set nobody approved — precisely the
+attack the fingerprint exists to prevent.
+
+So the fingerprint is computed once, on GET, and carried into the POST as a
+hidden form field, folded into the existing CSRF HMAC. That HMAC already covers
+`nonce` and `state` and is already verified on every POST, so binding the
+fingerprint to it adds no new trust machinery: a token verifies only for the
+fingerprint it was issued with, which makes the submitted value unforgeable
+without making it secret.
+
+The HMAC's fields are length-prefixed rather than `|`-joined, the same
+discipline `consentFingerprint` and `consentKey` already apply. `state` is
+client-chosen and may contain any byte, so a separator alone would let one
+field's content spell another's.
+
+On POST, after CSRF verification passes, the metadata is re-resolved as before
+and compared against the submitted fingerprint. If they differ the client
+changed while the user was deciding: **re-prompt** — render the page again from
+the fresh metadata with a fresh CSRF nonce — rather than issue a code or record
+anything. The record is written with the submitted fingerprint, now proven
+current.
+
+The fingerprint is computed and carried for unverified (DCR) clients too. It is
+never remembered for them, but a uniform path costs one hash and no branch, and
+the comparison still re-prompts when the name or redirect URI on screen went
+stale — an LRU eviction and re-registration rather than a document edit, but the
+user is equally owed a page describing the client about to receive the code.
 
 ### The consent page says so
 
@@ -208,11 +256,20 @@ documentation should say that rather than let the reader generalize from #74.
   fingerprint.
 - A GET with a matching record redirects with a code and renders no form.
 - A GET re-prompts after the client's metadata changes.
+- Approving through the consent page records the approval, and the next GET
+  skips the page — driven through the real handlers, not by seeding the store.
+- A client whose metadata changes between the GET and the POST re-prompts and
+  records nothing; the re-prompt is itself approvable.
+- A tampered fingerprint fails the CSRF check outright.
 - A DCR (unverified) client records nothing and always prompts.
+- The consent page states that a verified client's approval is remembered, and
+  does not state it for an unverified one.
 - `RevokeGrant` clears the record; a subsequent authorize prompts.
-- Theft clears the record.
+- Theft clears the record, driven through the token endpoint.
 - **Expiry does not clear the record.**
-- A v1 file loads with no records; a v2 file round-trips through disk.
+- A v1 file — with a populated token map, so a nested rather than flattened
+  `RefreshTokenSnapshot` embedding would be caught — loads with no records and
+  keeps its refresh tokens; a v2 file round-trips through disk.
 
 ## Out of scope
 

--- a/docs/specs/2026-09-02-mcp-consent-records-design.md
+++ b/docs/specs/2026-09-02-mcp-consent-records-design.md
@@ -40,7 +40,9 @@ The fingerprint is a domain-separated SHA-256 over the client's `client_name`
 and its **sorted** `redirect_uris` — precisely the two things the consent page
 displays. A rename, an added URI, a removed URI or an edited URI all re-prompt.
 Reordering does not: array order in a client-controlled document carries no
-meaning, and re-prompting on it would be noise.
+meaning, and re-prompting on it would be noise. Fields are length-prefixed so
+no two distinct tuples can produce the same byte stream, including when a
+field itself contains the delimiter.
 
 Rejected: hashing the whole fetched document. Strictly safer, but it re-prompts
 on cosmetic edits (`logo_uri`, contacts), and a prompt that fires for reasons the

--- a/docs/specs/2026-09-02-mcp-consent-records-plan.md
+++ b/docs/specs/2026-09-02-mcp-consent-records-plan.md
@@ -1,0 +1,1668 @@
+# MCP Consent Records Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remember a user's consent decision so an already-approved MCP client is not re-prompted on every authorization request.
+
+**Architecture:** A `ConsentStore` mirroring the existing `RefreshTokenStore` — mutex, map, change hook — sharing the OAuth state file with it. Because two stores cannot each own the write, a `stateFile` coordinator takes ownership of the path and snapshots both. `handleAuthorizeGET` skips the consent page when a record matches, and revocation and theft detection clear records while expiry deliberately does not.
+
+**Tech Stack:** Go 1.26.6, stdlib only (`crypto/sha256`, `slices`, `sync`), `github.com/goccy/go-json` for the file, `log/slog` for warnings.
+
+**Spec:** `docs/specs/2026-09-02-mcp-consent-records-design.md`
+
+## Global Constraints
+
+- Package is `internal/mcp/oauth`. All new files live there.
+- On-disk file is `<data_dir>/mcp-tokens.json`, mode `0600`, atomic tmp + rename + fsync. Do not rename the file.
+- File format goes from version 1 to version 2. A v1 file must load without error and yield zero consent records.
+- Consent records are written **only** for clients where `resolveClientMeta` returned `verified == true` (the CIMD path).
+- A store's change hook fires **after** its mutex is released and **only** when state actually changed. Taking a snapshot acquires the mutex; firing the hook while holding it deadlocks.
+- Every write failure is logged with `slog.Warn` and swallowed. The server keeps working from memory.
+- Run `gofmt -w` on every file you touch. `golangci-lint run ./internal/...` must report `0 issues` before each commit.
+- Comments explain *why*, not *what*. Match the density of the surrounding file.
+
+---
+
+### Task 1: Give the persistence layer ownership of the file
+
+Today `RefreshTokenStore` holds a `persist func(RefreshTokenSnapshot)` and writes the file itself. A second store cannot be added that way — each would write the whole file from its own snapshot and clobber the other. This task introduces the coordinator with no change in behaviour and no change to the file format.
+
+**Files:**
+- Modify: `internal/mcp/oauth/persist.go`
+- Modify: `internal/mcp/oauth/store.go`
+- Modify: `internal/mcp/oauth/server.go`
+- Test: `internal/mcp/oauth/persist_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `type oauthState struct` (unexported, embeds `RefreshTokenSnapshot`); `func writeState(path string, state oauthState) error`; `func readState(path string) (oauthState, error)`; `type stateFile struct { path string; tokens *RefreshTokenStore }` with method `func (f *stateFile) write()`; `func (s *RefreshTokenStore) SetOnChange(fn func())`. `RefreshTokenSnapshot` loses its `Version` and `Timestamp` fields.
+
+- [ ] **Step 1: Update the existing tests to the new seams**
+
+In `internal/mcp/oauth/persist_test.go`, replace the `restart` helper and every use of `persistRefreshTokens`:
+
+```go
+// restart round-trips a store through the on-disk format the way a process
+// restart does, so a test asserts against what actually survives rather than
+// against the in-memory maps it started from.
+func restart(t *testing.T, s *RefreshTokenStore, path string) *RefreshTokenStore {
+	t.Helper()
+
+	if err := writeState(path, oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: s.Snapshot(),
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	restored := NewRefreshTokenStore()
+	restored.Restore(state.RefreshTokenSnapshot)
+
+	return restored
+}
+
+// onDisk reads back what the store has written without going through it, so
+// these tests assert on the file rather than on the store's own memory.
+func onDisk(t *testing.T, path string) oauthState {
+	t.Helper()
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	return state
+}
+
+// persisting wires a store to a file the way NewServer does.
+func persisting(s *RefreshTokenStore, path string) {
+	file := &stateFile{path: path, tokens: s}
+	s.SetOnChange(file.write)
+}
+```
+
+Then in each of `TestIssueIsWrittenThrough`, `TestRotateIsWrittenThrough`, `TestRevokeIsWrittenThrough`, `TestUnknownTokenRotationDoesNotWrite` and `TestUnknownTokenRevocationDoesNotWrite`, replace `s.SetPersistFunc(persistRefreshTokens(path))` with `persisting(s, path)`.
+
+In `TestExpiredGrantFamilyIsDroppedOnLoad`, replace the write/restore block:
+
+```go
+	if err := writeState(path, oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: snap,
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	restored := NewRefreshTokenStore()
+	restored.Restore(onDisk(t, path).RefreshTokenSnapshot)
+```
+
+In `TestRefreshTokenFileIsPrivateAndAtomic`, replace the write call:
+
+```go
+	if err := writeState(path, oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: s.Snapshot(),
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+```
+
+In `TestReadRefreshTokensRejectsUnreadableFiles`, rename the call from `readRefreshTokens(tc.path)` to `readState(tc.path)`.
+
+In `TestServerWithoutTokenStorePathKeepsTokensInMemory`, change the wiring assertion:
+
+```go
+	if s.refreshTokens.onChange != nil {
+		t.Error("a server with no token store path should install no change hook")
+	}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/mcp/oauth/ 2>&1 | head -20`
+Expected: FAIL, build error — `undefined: writeState`, `undefined: readState`, `undefined: oauthState`, `undefined: oauthStateVersion`, `undefined: stateFile`, `s.refreshTokens.onChange undefined`.
+
+- [ ] **Step 3: Split the snapshot from the file in `persist.go`**
+
+Replace the version constant and the `RefreshTokenSnapshot` declaration:
+
+```go
+// oauthStateVersion is the on-disk format version. Bump it whenever the shape
+// below changes incompatibly; readState refuses anything newer.
+const oauthStateVersion = 1
+
+// RefreshTokenSnapshot is the serializable state of a RefreshTokenStore.
+//
+// The store's own types are unexported, and deliberately stay that way: this
+// is a separate, explicit shape so the file format is not hostage to a field
+// rename inside the store.
+//
+// What lands on disk is not a credential. Tokens are keyed by their SHA-256
+// hash exactly as they are in memory, so the file holds an identity mapping —
+// who a hash belongs to — and never anything a client could present.
+type RefreshTokenSnapshot struct {
+	Tokens   map[string]RefreshTokenSnapEntry `json:"tokens"`
+	Consumed map[string]string                `json:"consumed"`
+	Grants   map[string][]string              `json:"grants"`
+}
+
+// oauthState is the file itself: everything the OAuth server keeps across a
+// restart, under one version and one timestamp. The store snapshots are
+// embedded so the wire format stays flat.
+type oauthState struct {
+	Version              int       `json:"version"`
+	Timestamp            time.Time `json:"timestamp"`
+	RefreshTokenSnapshot           // tokens, consumed, grants
+}
+```
+
+In `Snapshot()`, delete the `Version` and `Timestamp` fields from the returned literal so it reads:
+
+```go
+	return RefreshTokenSnapshot{
+		Tokens:   tokens,
+		Consumed: consumed,
+		Grants:   grants,
+	}
+```
+
+- [ ] **Step 4: Rename the file functions and add the coordinator**
+
+Rename `writeRefreshTokens` to `writeState` and change its parameter, and rename `readRefreshTokens` to `readState`:
+
+```go
+// writeState serializes the OAuth state to path using a temporary file and an
+// atomic rename, so a crash mid-write leaves the previous file intact.
+func writeState(path string, state oauthState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal oauth state: %w", err)
+	}
+	// ... body unchanged, with error strings reworded from
+	// "refresh tokens" to "oauth state" ...
+}
+
+// readState reads a file written by writeState.
+func readState(path string) (oauthState, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is operator-configured
+	if err != nil {
+		return oauthState{}, fmt.Errorf("read oauth state: %w", err)
+	}
+
+	var state oauthState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return oauthState{}, fmt.Errorf("unmarshal oauth state: %w", err)
+	}
+
+	if state.Version < 1 || state.Version > oauthStateVersion {
+		return oauthState{}, fmt.Errorf(
+			"unsupported oauth state version: got %d, supported 1..%d",
+			state.Version,
+			oauthStateVersion,
+		)
+	}
+
+	return state, nil
+}
+```
+
+Delete `persistRefreshTokens` entirely and add the coordinator in its place:
+
+```go
+// stateFile owns the OAuth server's durable state on disk.
+//
+// The stores cannot each hold their own writer: they share one file, so each
+// would serialize the whole thing from its own view and drop the other's. The
+// file is the single writer, and every store points its change hook here.
+type stateFile struct {
+	path   string
+	tokens *RefreshTokenStore
+}
+
+// write serializes every store's current state. A failed write is logged and
+// swallowed: the state is already live in memory, so refusing to serve would
+// turn a durability problem into an outage. The operator learns that a restart
+// will cost a re-authorization, which is the behaviour they had before this
+// file existed.
+func (f *stateFile) write() {
+	state := oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: f.tokens.Snapshot(),
+	}
+
+	if err := writeState(f.path, state); err != nil {
+		slog.Warn(
+			"MCP OAuth state write failed; tokens will not survive a restart",
+			"error", err,
+			"path", f.path,
+		)
+	}
+}
+```
+
+- [ ] **Step 5: Replace the store's persist hook in `store.go`**
+
+Change the struct field and its two methods:
+
+```go
+	// onChange is called after every mutation, always with mu released. Nil
+	// when the store is memory-only.
+	onChange func()
+}
+
+// SetOnChange installs the callback fired after every mutation. Call it during
+// setup, before the store serves any request: it is not guarded by the mutex,
+// because a hook swapped mid-flight would race the mutations it records.
+func (s *RefreshTokenStore) SetOnChange(fn func()) {
+	s.onChange = fn
+}
+
+// writeThrough notifies the owner of the durable state that it changed. It
+// must be called with mu released, since the owner takes a snapshot, which
+// acquires it.
+func (s *RefreshTokenStore) writeThrough() {
+	if s.onChange == nil {
+		return
+	}
+
+	s.onChange()
+}
+```
+
+- [ ] **Step 6: Rewire `NewServer` in `server.go`**
+
+Replace the `cfg.TokenStorePath != ""` block:
+
+```go
+	refreshTokens := NewRefreshTokenStore()
+	if cfg.TokenStorePath != "" {
+		// A missing file is the normal first start. Anything else — corrupt
+		// JSON, bad permissions, a version from a newer build — costs every
+		// client a re-authorization, so it is worth an operator's attention.
+		// Neither is fatal: the server comes up empty and clients re-authorize,
+		// exactly as they did before the store existed.
+		if state, err := readState(cfg.TokenStorePath); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				slog.Info("no MCP OAuth state yet", "path", cfg.TokenStorePath)
+			} else {
+				slog.Warn(
+					"could not read MCP OAuth state; clients must re-authorize",
+					"error", err,
+					"path", cfg.TokenStorePath,
+				)
+			}
+		} else {
+			refreshTokens.Restore(state.RefreshTokenSnapshot)
+			slog.Info("loaded MCP OAuth state", "grants", len(state.Grants))
+		}
+
+		file := &stateFile{path: cfg.TokenStorePath, tokens: refreshTokens}
+		refreshTokens.SetOnChange(file.write)
+	}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `gofmt -w internal/mcp/oauth/ && go test ./internal/mcp/oauth/`
+Expected: PASS. Then `go build ./... && golangci-lint run ./internal/...` → `0 issues`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/mcp/oauth/persist.go internal/mcp/oauth/store.go internal/mcp/oauth/server.go internal/mcp/oauth/persist_test.go
+git commit -m "refactor(mcp): let the state file own the write, not the store
+
+Two stores cannot each hold a writer for one file: each would serialize
+the whole thing from its own view and drop the other's. stateFile owns
+the path and snapshots every store; a store now only announces that it
+changed. No behaviour or format change."
+```
+
+---
+
+### Task 2: Fingerprint what the consent page showed
+
+**Files:**
+- Create: `internal/mcp/oauth/consent_store.go`
+- Test: `internal/mcp/oauth/consent_store_test.go`
+
+**Interfaces:**
+- Consumes: `ClientMetadata` from `cimd.go` (fields `ClientName string`, `RedirectURIs []string`).
+- Produces: `func consentFingerprint(meta *ClientMetadata) string`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/mcp/oauth/consent_store_test.go`:
+
+```go
+package oauth
+
+import (
+	"testing"
+)
+
+func TestConsentFingerprintIgnoresRedirectURIOrder(t *testing.T) {
+	// CIMD documents are client-controlled and array order carries no meaning,
+	// so re-prompting on a reordering would be noise.
+	a := consentFingerprint(&ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"http://localhost:1/cb", "http://localhost:2/cb"},
+	})
+	b := consentFingerprint(&ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"http://localhost:2/cb", "http://localhost:1/cb"},
+	})
+
+	if a != b {
+		t.Errorf("reordering redirect_uris changed the fingerprint: %q vs %q", a, b)
+	}
+}
+
+func TestConsentFingerprintChangesWithTheDecision(t *testing.T) {
+	base := &ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"http://localhost:1/cb"},
+	}
+	baseline := consentFingerprint(base)
+
+	tests := []struct {
+		name string
+		meta *ClientMetadata
+	}{
+		{
+			name: "renamed",
+			meta: &ClientMetadata{
+				ClientName:   "Totally Different",
+				RedirectURIs: []string{"http://localhost:1/cb"},
+			},
+		},
+		{
+			name: "redirect uri added",
+			meta: &ClientMetadata{
+				ClientName:   "Acme CLI",
+				RedirectURIs: []string{"http://localhost:1/cb", "http://evil.example/cb"},
+			},
+		},
+		{
+			name: "redirect uri removed",
+			meta: &ClientMetadata{
+				ClientName:   "Acme CLI",
+				RedirectURIs: nil,
+			},
+		},
+		{
+			name: "redirect uri edited",
+			meta: &ClientMetadata{
+				ClientName:   "Acme CLI",
+				RedirectURIs: []string{"http://localhost:1/cb2"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := consentFingerprint(tc.meta); got == baseline {
+				t.Error("fingerprint did not change, so a stale approval would carry over")
+			}
+		})
+	}
+}
+
+func TestConsentFingerprintSeparatesFields(t *testing.T) {
+	// Without a separator between the name and the URIs, ("ab", "c") and
+	// ("a", "bc") would hash alike and one client could impersonate another.
+	a := consentFingerprint(&ClientMetadata{ClientName: "ab", RedirectURIs: []string{"c"}})
+	b := consentFingerprint(&ClientMetadata{ClientName: "a", RedirectURIs: []string{"bc"}})
+
+	if a == b {
+		t.Error("concatenation collision: two different clients share a fingerprint")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/mcp/oauth/ -run TestConsentFingerprint 2>&1 | head`
+Expected: FAIL, build error — `undefined: consentFingerprint`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/mcp/oauth/consent_store.go`:
+
+```go
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"slices"
+)
+
+// consentFingerprintDomain separates this hash from every other use of
+// SHA-256 in the package, so a value from one can never be mistaken for the
+// other, and lets a future change to what is fingerprinted invalidate old
+// records rather than silently reinterpret them.
+const consentFingerprintDomain = "cetacean-consent-v1"
+
+// consentFingerprint hashes what the consent page showed the user: the
+// client's name, and the exact set of URIs it may receive a code at.
+//
+// A CIMD client controls its own metadata document and may change it at any
+// time. Binding a remembered approval to this hash means a rename or a new
+// redirect_uri re-prompts, so an approval can never be inherited by a client
+// the user would not recognise, or redirect somewhere they never saw.
+//
+// The URIs are sorted because array order in a client-controlled document
+// carries no meaning; re-prompting on a reordering would be noise. Fields are
+// NUL-separated so ("ab", "c") cannot hash the same as ("a", "bc").
+func consentFingerprint(meta *ClientMetadata) string {
+	uris := slices.Clone(meta.RedirectURIs)
+	slices.Sort(uris)
+
+	h := sha256.New()
+	h.Write([]byte(consentFingerprintDomain))
+	h.Write([]byte{0})
+	h.Write([]byte(meta.ClientName))
+
+	for _, uri := range uris {
+		h.Write([]byte{0})
+		h.Write([]byte(uri))
+	}
+
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `gofmt -w internal/mcp/oauth/ && go test ./internal/mcp/oauth/ -run TestConsentFingerprint -v 2>&1 | tail -20`
+Expected: PASS, 3 tests plus 4 subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcp/oauth/consent_store.go internal/mcp/oauth/consent_store_test.go
+git commit -m "feat(mcp): fingerprint the client metadata a user consented to
+
+A CIMD client controls its own metadata document. Binding a remembered
+approval to a hash of the name and redirect URIs the consent page showed
+means a rename or a new redirect_uri re-prompts, rather than inheriting
+an approval the user never gave."
+```
+
+---
+
+### Task 3: The consent store
+
+**Files:**
+- Modify: `internal/mcp/oauth/consent_store.go`
+- Test: `internal/mcp/oauth/consent_store_test.go`
+
+**Interfaces:**
+- Consumes: `consentFingerprint` from Task 2.
+- Produces: `type ConsentRecord struct { Subject, ClientID, Resource, Fingerprint string; GrantedAt time.Time }`; `func NewConsentStore() *ConsentStore`; `func (s *ConsentStore) SetOnChange(fn func())`; `func (s *ConsentStore) Allows(subject, clientID, resource, fingerprint string) bool`; `func (s *ConsentStore) Remember(subject, clientID, resource, fingerprint string)`; `func (s *ConsentStore) Forget(subject, clientID, resource string)`; `func (s *ConsentStore) Snapshot() []ConsentRecord`; `func (s *ConsentStore) Restore(records []ConsentRecord)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/mcp/oauth/consent_store_test.go` (and add `"time"` to its imports):
+
+```go
+const (
+	testSubject     = "user@example.com"
+	testClientID    = "https://example.com/client.json"
+	testResource    = "https://cetacean.example.com/mcp"
+	testFingerprint = "fingerprint-a"
+)
+
+func TestConsentStoreRemembersAnApproval(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	if !s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Error("a remembered approval should be allowed")
+	}
+}
+
+func TestConsentStoreRequiresAnExactMatch(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	tests := []struct {
+		name                                        string
+		subject, clientID, resource, fingerprint    string
+	}{
+		{
+			name:  "another user",
+			subject: "someone@example.com", clientID: testClientID,
+			resource: testResource, fingerprint: testFingerprint,
+		},
+		{
+			name:  "another client",
+			subject: testSubject, clientID: "https://other.example/client.json",
+			resource: testResource, fingerprint: testFingerprint,
+		},
+		{
+			// RFC 8707: an approval for one MCP endpoint must not cover another.
+			name:  "another resource",
+			subject: testSubject, clientID: testClientID,
+			resource: "https://other.example.com/mcp", fingerprint: testFingerprint,
+		},
+		{
+			// The client changed its metadata after the approval.
+			name:  "changed metadata",
+			subject: testSubject, clientID: testClientID,
+			resource: testResource, fingerprint: "fingerprint-b",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if s.Allows(tc.subject, tc.clientID, tc.resource, tc.fingerprint) {
+				t.Error("a non-matching request should re-prompt")
+			}
+		})
+	}
+}
+
+func TestConsentStoreReplacesAStaleRecord(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, "fingerprint-a")
+	s.Remember(testSubject, testClientID, testResource, "fingerprint-b")
+
+	// A user must never hold two live approvals for one client, one of which
+	// they no longer remember granting.
+	if got := len(s.Snapshot()); got != 1 {
+		t.Errorf("records = %d, want the stale one replaced", got)
+	}
+	if s.Allows(testSubject, testClientID, testResource, "fingerprint-a") {
+		t.Error("the replaced approval should no longer be allowed")
+	}
+}
+
+func TestConsentStoreForgets(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+	s.Forget(testSubject, testClientID, testResource)
+
+	if s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Error("a forgotten approval should re-prompt")
+	}
+}
+
+func TestConsentStoreNotifiesOnlyOnRealChanges(t *testing.T) {
+	s := NewConsentStore()
+
+	var writes int
+	s.SetOnChange(func() { writes++ })
+
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+	s.Remember(testSubject, testClientID, testResource, testFingerprint) // identical
+	s.Forget(testSubject, "https://unknown.example/client.json", testResource)
+
+	// Re-approving an unchanged client and forgetting an unknown one change
+	// nothing, and a whole-file rewrite for each would be work for no reason.
+	if writes != 1 {
+		t.Errorf("writes = %d, want 1 (only the first Remember changed state)", writes)
+	}
+}
+
+func TestConsentStoreSnapshotIsDeterministic(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember("b@example.com", testClientID, testResource, testFingerprint)
+	s.Remember("a@example.com", testClientID, testResource, testFingerprint)
+
+	// Map iteration order is random; an unsorted snapshot would rewrite the
+	// file with reordered records on every unrelated change.
+	first := s.Snapshot()
+	for range 5 {
+		next := s.Snapshot()
+		for i := range first {
+			if first[i].Subject != next[i].Subject {
+				t.Fatal("snapshot order is not stable")
+			}
+		}
+	}
+	if first[0].Subject != "a@example.com" {
+		t.Errorf("first record = %q, want the sorted-first subject", first[0].Subject)
+	}
+}
+
+func TestConsentStoreRestoreReplacesState(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember("stale@example.com", testClientID, testResource, testFingerprint)
+
+	s.Restore([]ConsentRecord{{
+		Subject:     testSubject,
+		ClientID:    testClientID,
+		Resource:    testResource,
+		Fingerprint: testFingerprint,
+		GrantedAt:   time.Now(),
+	}})
+
+	if s.Allows("stale@example.com", testClientID, testResource, testFingerprint) {
+		t.Error("Restore should replace state, not merge into it")
+	}
+	if !s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Error("the restored record should be allowed")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/mcp/oauth/ -run TestConsentStore 2>&1 | head`
+Expected: FAIL, build error — `undefined: NewConsentStore`, `undefined: ConsentRecord`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `internal/mcp/oauth/consent_store.go`, adding `"slices"` (already imported), `"strings"`, `"sync"` and `"time"` to the import block:
+
+```go
+// ConsentRecord is one remembered approval: this user approved this client,
+// as it looked at the time, for this MCP endpoint.
+type ConsentRecord struct {
+	Subject     string    `json:"subject"`
+	ClientID    string    `json:"clientId"`
+	Resource    string    `json:"resource"`
+	Fingerprint string    `json:"fingerprint"`
+	GrantedAt   time.Time `json:"grantedAt"`
+}
+
+// ConsentStore remembers approvals so an already-approved client does not
+// re-prompt on every authorization request.
+//
+// Unlike the refresh token store, whose file holds only hashes and is
+// therefore a confidentiality concern, a consent record is a capability:
+// anyone able to write it can pre-approve a client and complete an
+// authorization with no human in the loop. The file is mode 0600 and the
+// caveat is the usual one — an attacker with host access has already won —
+// but the property being protected is integrity, not secrecy.
+type ConsentStore struct {
+	mu      sync.Mutex
+	records map[string]ConsentRecord
+
+	// onChange is called after every mutation that changed state, always with
+	// mu released. Nil when the store is memory-only.
+	onChange func()
+}
+
+// NewConsentStore returns a ready-to-use ConsentStore.
+func NewConsentStore() *ConsentStore {
+	return &ConsentStore{
+		records: make(map[string]ConsentRecord),
+	}
+}
+
+// SetOnChange installs the callback fired after every mutation. Call it during
+// setup, before the store serves any request: it is not guarded by the mutex,
+// because a hook swapped mid-flight would race the mutations it records.
+func (s *ConsentStore) SetOnChange(fn func()) {
+	s.onChange = fn
+}
+
+// writeThrough notifies the owner of the durable state that it changed. It
+// must be called with mu released, since the owner takes a snapshot, which
+// acquires it.
+func (s *ConsentStore) writeThrough() {
+	if s.onChange == nil {
+		return
+	}
+
+	s.onChange()
+}
+
+// consentKey identifies the approval, without the fingerprint: the fingerprint
+// lives in the value, so a client whose metadata changed replaces its stale
+// record rather than accumulating a second one alongside it.
+//
+// NUL cannot appear in a subject, an https:// client_id or a resource URL, so
+// joining on it cannot let one triple spell another.
+func consentKey(subject, clientID, resource string) string {
+	return strings.Join([]string{subject, clientID, resource}, "\x00")
+}
+
+// Allows reports whether this exact approval was remembered — same user, same
+// client, same MCP endpoint, and the same client metadata they were shown.
+func (s *ConsentStore) Allows(subject, clientID, resource, fingerprint string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, exists := s.records[consentKey(subject, clientID, resource)]
+
+	return exists && record.Fingerprint == fingerprint
+}
+
+// Remember records an approval, replacing any earlier one for the same user,
+// client and resource.
+func (s *ConsentStore) Remember(subject, clientID, resource, fingerprint string) {
+	key := consentKey(subject, clientID, resource)
+
+	s.mu.Lock()
+	existing, exists := s.records[key]
+	unchanged := exists && existing.Fingerprint == fingerprint
+	if !unchanged {
+		s.records[key] = ConsentRecord{
+			Subject:     subject,
+			ClientID:    clientID,
+			Resource:    resource,
+			Fingerprint: fingerprint,
+			GrantedAt:   time.Now(),
+		}
+	}
+	s.mu.Unlock()
+
+	// Re-approving an unchanged client changes nothing durable, and rewriting
+	// the whole file for it would be work for no reason.
+	if unchanged {
+		return
+	}
+
+	s.writeThrough()
+}
+
+// Forget drops an approval. Called when a grant is revoked or burned for
+// theft, so revocation cannot degrade into "grant one more silent
+// re-authorization".
+func (s *ConsentStore) Forget(subject, clientID, resource string) {
+	key := consentKey(subject, clientID, resource)
+
+	s.mu.Lock()
+	_, existed := s.records[key]
+	delete(s.records, key)
+	s.mu.Unlock()
+
+	if !existed {
+		return
+	}
+
+	s.writeThrough()
+}
+
+// Snapshot returns the records in a stable order. Map iteration is random, and
+// an unsorted snapshot would rewrite the file with reordered records on every
+// unrelated change.
+func (s *ConsentStore) Snapshot() []ConsentRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records := make([]ConsentRecord, 0, len(s.records))
+	for _, record := range s.records {
+		records = append(records, record)
+	}
+
+	slices.SortFunc(records, func(a, b ConsentRecord) int {
+		if c := strings.Compare(a.Subject, b.Subject); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.ClientID, b.ClientID); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.Resource, b.Resource)
+	})
+
+	return records
+}
+
+// Restore replaces the store's state from a snapshot.
+func (s *ConsentStore) Restore(records []ConsentRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.records = make(map[string]ConsentRecord, len(records))
+	for _, record := range records {
+		s.records[consentKey(record.Subject, record.ClientID, record.Resource)] = record
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `gofmt -w internal/mcp/oauth/ && go test ./internal/mcp/oauth/ -run TestConsent && go test -race ./internal/mcp/oauth/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcp/oauth/consent_store.go internal/mcp/oauth/consent_store_test.go
+git commit -m "feat(mcp): add the consent store
+
+Remembers an approval per user, client and RFC 8707 resource, carrying
+the fingerprint of the metadata it was granted against. Matching is
+exact on all four, so a changed client re-prompts and replaces its
+stale record rather than accumulating a second one."
+```
+
+---
+
+### Task 4: Persist consent records (file format v2)
+
+**Files:**
+- Modify: `internal/mcp/oauth/persist.go`
+- Modify: `internal/mcp/oauth/server.go`
+- Test: `internal/mcp/oauth/consent_store_test.go`
+
+**Interfaces:**
+- Consumes: `oauthState`, `stateFile`, `writeState`, `readState` from Task 1; `ConsentStore`, `ConsentRecord` from Task 3.
+- Produces: `oauthState.Consent []ConsentRecord`; `stateFile.consent *ConsentStore`; `Server.consent *ConsentStore`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/mcp/oauth/consent_store_test.go` (add `"os"` to its imports):
+
+```go
+func TestConsentSurvivesRestart(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	cfg := ServerConfig{
+		Issuer:         "https://cetacean.test",
+		MCPResource:    testResource,
+		MCP:            config.MCPConfig{AccessTokenTTL: time.Hour, RefreshTokenTTL: 720 * time.Hour},
+		SigningKey:     []byte("test-signing-key-32bytes-padded!!"),
+		TokenStorePath: path,
+	}
+
+	before := NewServer(cfg)
+	before.consent.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	// A second Server over the same path stands in for the process restarting.
+	after := NewServer(cfg)
+
+	if !after.consent.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Fatal("an approval granted before the restart should still be allowed")
+	}
+}
+
+func TestConsentIsWrittenThrough(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	consent := NewConsentStore()
+	tokens := NewRefreshTokenStore()
+	file := &stateFile{path: path, tokens: tokens, consent: consent}
+	consent.SetOnChange(file.write)
+
+	consent.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if state.Version != oauthStateVersion {
+		t.Errorf("version = %d, want %d", state.Version, oauthStateVersion)
+	}
+	if len(state.Consent) != 1 {
+		t.Fatalf("consent records on disk = %d, want 1", len(state.Consent))
+	}
+	if state.Consent[0].Fingerprint != testFingerprint {
+		t.Errorf("fingerprint = %q", state.Consent[0].Fingerprint)
+	}
+}
+
+func TestVersion1FileLoadsWithoutConsent(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	// A file written before consent records existed. It must load, not error:
+	// an operator upgrading should keep their refresh tokens.
+	v1 := []byte(`{"version":1,"tokens":{},"consumed":{},"grants":{}}`)
+	if err := os.WriteFile(path, v1, 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("a v1 file should still load: %v", err)
+	}
+	if len(state.Consent) != 0 {
+		t.Errorf("consent records = %d, want none", len(state.Consent))
+	}
+}
+```
+
+Add the config import if it is not already present in this file: `"github.com/radiergummi/cetacean/internal/config"`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/mcp/oauth/ -run 'TestConsentSurvives|TestConsentIsWritten|TestVersion1' 2>&1 | head`
+Expected: FAIL, build error — `unknown field consent in struct literal of type stateFile`, `before.consent undefined`, `state.Consent undefined`.
+
+- [ ] **Step 3: Add consent to the file format**
+
+In `internal/mcp/oauth/persist.go`, bump the version and extend the state:
+
+```go
+// oauthStateVersion is the on-disk format version. Bump it whenever the shape
+// below changes incompatibly; readState refuses anything newer.
+//
+// v2 added consent records. A v1 file loads and yields none, which is exactly
+// the pre-upgrade behaviour: every client is prompted once more, then
+// remembered.
+const oauthStateVersion = 2
+```
+
+```go
+type oauthState struct {
+	Version              int       `json:"version"`
+	Timestamp            time.Time `json:"timestamp"`
+	RefreshTokenSnapshot           // tokens, consumed, grants
+
+	// Consent is a slice rather than a map: it is readable in the file, and it
+	// avoids inventing an encoding for a composite key built from three
+	// free-form strings.
+	Consent []ConsentRecord `json:"consent,omitempty"`
+}
+```
+
+Extend the coordinator:
+
+```go
+type stateFile struct {
+	path    string
+	tokens  *RefreshTokenStore
+	consent *ConsentStore
+}
+
+func (f *stateFile) write() {
+	state := oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: f.tokens.Snapshot(),
+		Consent:              f.consent.Snapshot(),
+	}
+
+	if err := writeState(f.path, state); err != nil {
+		slog.Warn(
+			"MCP OAuth state write failed; tokens and approvals will not survive a restart",
+			"error", err,
+			"path", f.path,
+		)
+	}
+}
+```
+
+- [ ] **Step 4: Wire the store into the server**
+
+In `internal/mcp/oauth/server.go`, add the field to `Server`:
+
+```go
+type Server struct {
+	cfg           ServerConfig
+	tokenIssuer   *TokenIssuer
+	cimd          *CIMDFetcher
+	authCodes     *AuthCodeStore
+	refreshTokens *RefreshTokenStore
+	consent       *ConsentStore
+	clients       *ClientRegistry // nil when DCREnabled is false
+}
+```
+
+In `NewServer`, construct it and extend the persistence block:
+
+```go
+	refreshTokens := NewRefreshTokenStore()
+	consent := NewConsentStore()
+
+	if cfg.TokenStorePath != "" {
+		// ... the existing read + log block, unchanged, plus: ...
+		} else {
+			refreshTokens.Restore(state.RefreshTokenSnapshot)
+			consent.Restore(state.Consent)
+			slog.Info("loaded MCP OAuth state",
+				"grants", len(state.Grants),
+				"approvals", len(state.Consent),
+			)
+		}
+
+		file := &stateFile{path: cfg.TokenStorePath, tokens: refreshTokens, consent: consent}
+		refreshTokens.SetOnChange(file.write)
+		consent.SetOnChange(file.write)
+	}
+```
+
+and add `consent: consent,` to the returned `&Server{...}` literal.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `gofmt -w internal/mcp/oauth/ && go test ./internal/mcp/oauth/ && go build ./...`
+Expected: PASS, and every pre-existing test still passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/mcp/oauth/persist.go internal/mcp/oauth/server.go internal/mcp/oauth/consent_store_test.go
+git commit -m "feat(mcp): persist consent records alongside refresh tokens
+
+File format goes to v2. A v1 file loads and yields no records, so an
+upgrading operator keeps their refresh tokens and is prompted once more
+per client."
+```
+
+---
+
+### Task 5: Revocation and theft clear consent; expiry does not
+
+`revokeGrantLocked` is reached from three callers and they must not behave alike. The decision cannot live inside it, so it reports the family's identity and each caller decides.
+
+**Files:**
+- Modify: `internal/mcp/oauth/store.go`
+- Modify: `internal/mcp/oauth/server.go`
+- Test: `internal/mcp/oauth/consent_store_test.go`
+
+**Interfaces:**
+- Consumes: `ConsentStore.Forget` from Task 3; `Server.consent` from Task 4.
+- Produces: `func (s *RefreshTokenStore) RevokeGrant(token string) (RefreshTokenData, bool)` (was `func(string)`); `revokeGrantLocked(grantID string) (RefreshTokenData, bool)`; `RotateResult.Data` populated on the theft path.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/mcp/oauth/consent_store_test.go`:
+
+```go
+// consentServer builds a Server with a memory-only state file and one
+// remembered approval for the token it returns.
+func consentServer(t *testing.T) (*Server, string) {
+	t.Helper()
+
+	s := newTestServer(t)
+	s.consent.Remember(testSubject, testClientID, s.cfg.MCPResource, testFingerprint)
+
+	token := s.refreshTokens.Issue(RefreshTokenData{
+		Subject:  testSubject,
+		ClientID: testClientID,
+		Resource: s.cfg.MCPResource,
+	}, time.Hour)
+
+	return s, token
+}
+
+func TestRevocationClearsConsent(t *testing.T) {
+	s, token := consentServer(t)
+
+	data, ok := s.refreshTokens.RevokeGrant(token)
+	if !ok {
+		t.Fatal("revoking a live token should report what it revoked")
+	}
+	s.consent.Forget(data.Subject, data.ClientID, data.Resource)
+
+	// A record outliving revocation degrades revoke into "grant one more
+	// silent re-authorization", which is worse than not revoking because it
+	// appears to have worked.
+	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("revocation should have cleared the approval")
+	}
+}
+
+func TestTheftClearsConsent(t *testing.T) {
+	s, token := consentServer(t)
+
+	rotated := s.refreshTokens.Rotate(token, time.Hour)
+	if !rotated.OK {
+		t.Fatal("the first rotation should succeed")
+	}
+
+	replay := s.refreshTokens.Rotate(token, time.Hour)
+	if !replay.Theft {
+		t.Fatal("re-presenting a consumed token should be detected as theft")
+	}
+	if replay.Data.Subject != testSubject {
+		t.Fatalf("theft result should name the burned family, got subject %q", replay.Data.Subject)
+	}
+	s.consent.Forget(replay.Data.Subject, replay.Data.ClientID, replay.Data.Resource)
+
+	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("a burned grant family should not leave a silent re-grant behind")
+	}
+}
+
+func TestExpiryDoesNotClearConsent(t *testing.T) {
+	s := newTestServer(t)
+	s.consent.Remember(testSubject, testClientID, s.cfg.MCPResource, testFingerprint)
+
+	expired := s.refreshTokens.Issue(RefreshTokenData{
+		Subject:  testSubject,
+		ClientID: testClientID,
+		Resource: s.cfg.MCPResource,
+	}, -time.Second)
+
+	if s.refreshTokens.Rotate(expired, time.Hour).OK {
+		t.Fatal("an expired token should not rotate")
+	}
+
+	// Consent outliving the refresh token is the entire point of the feature.
+	if !s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("expiry must not clear consent")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/mcp/oauth/ -run 'ClearsConsent|DoesNotClearConsent' 2>&1 | head`
+Expected: FAIL — `s.refreshTokens.RevokeGrant(token) used as value` (it returns nothing today), and `TestTheftClearsConsent` failing on `replay.Data.Subject` being empty.
+
+- [ ] **Step 3: Make the store report what it revoked**
+
+In `internal/mcp/oauth/store.go`, change `revokeGrantLocked` to report the family's identity:
+
+```go
+// revokeGrantLocked removes every hash ever associated with grantID from both
+// tokens and consumed, then drops the grant record. It returns the identity
+// the family belonged to, read from its live token — a family has exactly one,
+// unless it has already expired.
+//
+// Whether revoking a family should also drop the user's consent record is the
+// caller's decision, not this function's: an explicit revocation and a theft
+// must clear it, and an expiry must not, because consent outliving the refresh
+// token is the point of remembering it. Must be called with s.mu held.
+func (s *RefreshTokenStore) revokeGrantLocked(grantID string) (RefreshTokenData, bool) {
+	hashes := s.grants[grantID]
+
+	var (
+		owner RefreshTokenData
+		found bool
+	)
+
+	for _, h := range hashes {
+		if entry, live := s.tokens[h]; live && !found {
+			owner = entry.data
+			owner.Groups = append([]string(nil), entry.data.Groups...)
+			found = true
+		}
+
+		delete(s.tokens, h)
+		delete(s.consumed, h)
+	}
+
+	delete(s.grants, grantID)
+
+	return owner, found
+}
+```
+
+In `rotate`, populate the theft result and discard the identity on the expiry path:
+
+```go
+	if grantID, isConsumed := s.consumed[oldHash]; isConsumed {
+		// Naming the burned family lets the caller clear the user's consent
+		// record and log who was affected, neither of which was possible when
+		// this returned a zero result.
+		owner, _ := s.revokeGrantLocked(grantID)
+
+		return RotateResult{Theft: true, Data: owner}, true
+	}
+```
+
+```go
+	if time.Now().After(entry.expiresAt) {
+		// The identity is deliberately dropped: an expired grant must not
+		// clear the user's consent.
+		s.revokeGrantLocked(entry.data.grantID)
+
+		return RotateResult{}, true
+	}
+```
+
+Update the `RotateResult` doc comment, replacing the sentence claiming `Data` is zero on theft:
+
+```go
+// RotateResult is returned by RefreshTokenStore.Rotate. On the theft path Data
+// names the family that was burned, so the caller can clear its consent record
+// and log the affected subject.
+```
+
+Also update the step-2 comment inside `Rotate`'s algorithm doc block, which currently says the grant family is burned "and Data is intentionally zero".
+
+Change `RevokeGrant` to return what it revoked:
+
+```go
+// RevokeGrant revokes every token in the grant family that contains the given
+// token, whether that token is currently live or already consumed. It returns
+// the identity the family belonged to, so the caller can clear the matching
+// consent record, and false when the token belongs to no known family.
+func (s *RefreshTokenStore) RevokeGrant(token string) (RefreshTokenData, bool) {
+	owner, revoked := s.revokeGrant(token)
+	if revoked {
+		s.writeThrough()
+	}
+
+	return owner, revoked
+}
+
+// revokeGrant revokes the family and reports whether one was found. A token
+// belonging to no known family is a no-op, and must not write.
+func (s *RefreshTokenStore) revokeGrant(token string) (RefreshTokenData, bool) {
+	h := hashToken(token)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Determine grantID from either the live tokens map or the consumed map.
+	grantID := ""
+	if entry, exists := s.tokens[h]; exists {
+		grantID = entry.data.grantID
+	} else if id, exists := s.consumed[h]; exists {
+		grantID = id
+	}
+
+	if grantID == "" {
+		return RefreshTokenData{}, false
+	}
+
+	owner, _ := s.revokeGrantLocked(grantID)
+
+	return owner, true
+}
+```
+
+- [ ] **Step 4: Clear consent from the two handlers**
+
+In `internal/mcp/oauth/server.go`, in `HandleRevoke`:
+
+```go
+	token := r.FormValue("token") // #nosec G120 -- bounded above
+	if token != "" {
+		// Revoking must also drop the approval, or the next authorization
+		// request is granted silently and revocation only appeared to work.
+		if data, revoked := s.refreshTokens.RevokeGrant(token); revoked {
+			s.consent.Forget(data.Subject, data.ClientID, data.Resource)
+		}
+	}
+```
+
+In the refresh-grant path, immediately inside the existing `if result.Theft {` block and before whatever it already does:
+
+```go
+	if result.Theft {
+		// A replayed token means someone else holds a copy. Re-prompting is
+		// the point: the next authorization must reach a human.
+		s.consent.Forget(result.Data.Subject, result.Data.ClientID, result.Data.Resource)
+```
+
+- [ ] **Step 5: Fix the other call sites**
+
+`RevokeGrant` now returns two values. Search for every remaining caller and discard the results where the identity is not needed:
+
+Run: `grep -rn "RevokeGrant(" internal/ | grep -v "func "`
+
+In `internal/mcp/oauth/server_test.go` and `store_test.go`, change bare statement calls `s.refreshTokens.RevokeGrant(rt)` to `_, _ = s.refreshTokens.RevokeGrant(rt)` only where the compiler complains; a bare call as a statement remains valid Go and needs no change.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `gofmt -w internal/mcp/oauth/ && go test ./internal/mcp/oauth/ && go test -race ./internal/mcp/... && golangci-lint run ./internal/...`
+Expected: PASS and `0 issues`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcp/oauth/store.go internal/mcp/oauth/server.go internal/mcp/oauth/consent_store_test.go
+git commit -m "feat(mcp): clear consent on revocation and theft, never on expiry
+
+revokeGrantLocked is reached from three callers that must not behave
+alike, so it now reports the family's identity and each caller decides.
+An approval outliving revocation would make revoke a lie; one cleared by
+expiry would defeat the point of remembering it."
+```
+
+---
+
+### Task 6: Skip the consent page for an approved client
+
+**Files:**
+- Modify: `internal/mcp/oauth/server.go`
+- Modify: `internal/mcp/oauth/consent.go`
+- Modify: `docs/mcp.md`
+- Modify: `CHANGELOG.md`
+- Test: `internal/mcp/oauth/consent_store_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–5.
+- Produces: `func (s *Server) issueCodeAndRedirect(w http.ResponseWriter, r *http.Request, p authorizedRequest)`; `type authorizedRequest struct`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/mcp/oauth/consent_store_test.go` (add `"net/http"`, `"net/http/httptest"`, `"net/url"`, `"strings"` and `"github.com/radiergummi/cetacean/internal/auth"` to its imports):
+
+```go
+// authorizeGET drives a GET /oauth/authorize for a CIMD client whose metadata
+// document is served by a local test server, and returns the response.
+func authorizeGET(t *testing.T, s *Server, clientID, redirectURI string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "/oauth/authorize?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {computeS256Challenge("verifier-verifier-verifier-1234")},
+		"code_challenge_method": {"S256"},
+		"state":                 {"xyz"},
+		"resource":              {s.cfg.MCPResource},
+	}.Encode()
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), &auth.Identity{
+		Subject:  testSubject,
+		Provider: "none",
+	}))
+
+	w := httptest.NewRecorder()
+	s.HandleAuthorize(w, req)
+
+	return w
+}
+
+func TestApprovedClientSkipsTheConsentPage(t *testing.T) {
+	s, clientID, redirectURI, meta := cimdServer(t)
+	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(meta))
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (redirect with a code)", w.Code, http.StatusFound)
+	}
+
+	location, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	if location.Query().Get("code") == "" {
+		t.Error("no authorization code in the redirect")
+	}
+	if strings.Contains(w.Body.String(), "Authorization Request") {
+		t.Error("the consent page was rendered despite a matching approval")
+	}
+}
+
+func TestChangedMetadataRePrompts(t *testing.T) {
+	s, clientID, redirectURI, _ := cimdServer(t)
+
+	// An approval granted against different metadata than the client now
+	// publishes must not carry over.
+	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, "fingerprint-from-before")
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (the consent page)", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), "Authorization Request") {
+		t.Error("expected the consent page to be rendered")
+	}
+}
+```
+
+Add the `cimdServer` helper to the same file. It reuses `serveMetadata` from `cimd_test.go`:
+
+```go
+// cimdServer stands up a CIMD client whose metadata document is served over
+// TLS from loopback, and returns a Server wired to fetch it.
+func cimdServer(t *testing.T) (srv *Server, clientID, redirectURI string, meta *ClientMetadata) {
+	t.Helper()
+
+	published := ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"https://example.com/cb"},
+	}
+
+	var documentURL string
+	httpSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveMetadata(documentURL, published)(w, r)
+	}))
+	t.Cleanup(httpSrv.Close)
+	documentURL = httpSrv.URL + "/client.json"
+
+	srv = newTestServer(t)
+
+	// The document is served with a self-signed certificate, so the fetcher
+	// needs the test server's client to trust it. newTestServer already sets
+	// AllowLoopback.
+	srv.cimd.Client = httpSrv.Client()
+
+	// consentFingerprint reads only ClientName and RedirectURIs, so this local
+	// copy fingerprints identically to the fetched document.
+	return srv, documentURL, published.RedirectURIs[0], &published
+}
+```
+
+And add the case the spec calls for that the two tests above do not cover — an unverified client must never skip the page, even with a record that matches perfectly:
+
+```go
+func TestDynamicallyRegisteredClientNeverSkipsTheConsentPage(t *testing.T) {
+	s := newTestServer(t)
+
+	const clientID = "dcr-generated-client-id"
+	const redirectURI = "http://127.0.0.1:1/cb"
+
+	s.clients.register(&ClientRegistration{
+		ClientID:     clientID,
+		ClientName:   "Self-Registered CLI",
+		RedirectURIs: []string{redirectURI},
+	})
+
+	// Seed a record that matches on every field. It must still be ignored:
+	// a DCR client's metadata is self-reported, so a fingerprint over it
+	// proves nothing about who the client is.
+	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(&ClientMetadata{
+		ClientName:   "Self-Registered CLI",
+		RedirectURIs: []string{redirectURI},
+	}))
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (the consent page)", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), "Authorization Request") {
+		t.Error("an unverified client skipped the consent page")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/mcp/oauth/ -run 'ConsentPage|RePrompts' 2>&1 | head`
+Expected: FAIL — `TestApprovedClientSkipsTheConsentPage` gets status 200 and the consent page, because nothing consults the store yet. `TestChangedMetadataRePrompts` and `TestDynamicallyRegisteredClientNeverSkipsTheConsentPage` pass already, since nothing skips the page yet; they are the regression guards for step 4.
+
+- [ ] **Step 3: Extract the code-issuing tail**
+
+In `internal/mcp/oauth/server.go`, add above `handleAuthorizeGET`:
+
+```go
+// authorizedRequest carries the validated parameters of an authorization
+// request that is ready to receive a code.
+type authorizedRequest struct {
+	clientID      string
+	redirectURI   string
+	codeChallenge string
+	resource      string
+	state         string
+	subject       string
+	groups        []string
+}
+
+// issueCodeAndRedirect mints an authorization code and redirects the browser
+// back to the client with it. Both the consent-page POST and the skipped-consent
+// GET path end here, so they cannot drift apart.
+func (s *Server) issueCodeAndRedirect(
+	w http.ResponseWriter,
+	r *http.Request,
+	p authorizedRequest,
+) {
+	rawCode := s.authCodes.Issue(AuthCodeData{
+		ClientID:      p.clientID,
+		RedirectURI:   p.redirectURI,
+		CodeChallenge: p.codeChallenge,
+		Resource:      p.resource,
+		Subject:       p.subject,
+		Groups:        p.groups,
+	}, authCodeTTL)
+
+	redirectURI, _ := url.Parse(p.redirectURI)
+	q := redirectURI.Query()
+	q.Set("code", rawCode)
+
+	if p.state != "" {
+		q.Set("state", p.state)
+	}
+
+	// RFC 9207: name the issuer in the authorization response so a client
+	// configured with several authorization servers cannot be tricked into
+	// redeeming this code at the wrong one (mix-up attack).
+	q.Set("iss", s.cfg.issuerID())
+	redirectURI.RawQuery = q.Encode()
+
+	//nolint:gosec // G710: p.redirectURI was exact-matched against the client's registered redirect_uris (HasRedirectURI) by both callers before reaching here; this is a pre-validated URI, not open redirect.
+	http.Redirect(w, r, redirectURI.String(), http.StatusFound)
+}
+```
+
+Then replace the tail of `handleAuthorizePOST`, from the `// Issue authorization code.` comment to the end of the function, with:
+
+```go
+	// Clear the CSRF cookie — the flow is complete.
+	clearCSRFCookie(w, secure)
+
+	// Remembering is limited to verified clients. A DCR client's metadata is
+	// self-reported and its client_id does not survive a restart, so a record
+	// keyed on one would be worthless at best.
+	if verified {
+		s.consent.Remember(identity.Subject, clientID, effectiveResource, consentFingerprint(meta))
+	}
+
+	s.issueCodeAndRedirect(w, r, authorizedRequest{
+		clientID:      clientID,
+		redirectURI:   redirectURIRaw,
+		codeChallenge: codeChallenge,
+		resource:      effectiveResource,
+		state:         state,
+		subject:       identity.Subject,
+		groups:        identity.Groups,
+	})
+}
+```
+
+`handleAuthorizePOST` currently discards the `verified` return of `resolveClientMeta`; change `meta, _, errMsg := s.resolveClientMeta(r, clientID)` to `meta, verified, errMsg := s.resolveClientMeta(r, clientID)`.
+
+- [ ] **Step 4: Consult the store in the GET path**
+
+In `handleAuthorizeGET`, capture the effective resource by changing
+
+```go
+	if _, err := ValidateResourceIndicator(
+```
+
+to
+
+```go
+	effectiveResource, err := ValidateResourceIndicator(
+```
+
+(and adjust the following `err != nil` block accordingly, keeping the same `invalid_target` redirect).
+
+Then insert this immediately after the identity check and before `issueCSRFNonce`:
+
+```go
+	// A remembered approval skips the page. Only for verified clients, and only
+	// when the metadata still hashes to what the user was shown — a CIMD client
+	// controls its own document and could otherwise redirect an inherited
+	// approval somewhere the user never saw.
+	//
+	// Issuing a code from a GET is ordinary for an authorization endpoint, and
+	// redirect_uri was exact-matched against the client's registered set above,
+	// so a silently issued code still lands only where the client registered.
+	if verified &&
+		s.consent.Allows(identity.Subject, clientID, effectiveResource, consentFingerprint(meta)) {
+		s.issueCodeAndRedirect(w, r, authorizedRequest{
+			clientID:      clientID,
+			redirectURI:   redirectURIRaw,
+			codeChallenge: codeChallenge,
+			resource:      effectiveResource,
+			state:         state,
+			subject:       identity.Subject,
+			groups:        identity.Groups,
+		})
+
+		return
+	}
+```
+
+- [ ] **Step 5: Tell the user the decision is remembered**
+
+In `internal/mcp/oauth/consent.go`, add a field to `consentData`:
+
+```go
+type consentData struct {
+	ClientName          string
+	Verified            bool
+	Remembered          bool
+	RedirectURI         string
+	// ... rest unchanged ...
+}
+```
+
+and add this line to the template immediately after the `warning` div:
+
+```html
+{{if .Remembered}}<div class="warning">Approving will be remembered for <strong>{{.ClientName}}</strong> until you revoke its access.</div>{{end}}
+```
+
+In `handleAuthorizeGET`'s `renderConsent` call, set `Remembered: verified` — turning "approve once" into "approve until revoked" without saying so is not consent, and an unverified client is not remembered, so it must not claim to be.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `gofmt -w internal/mcp/oauth/ && go test ./internal/mcp/oauth/ && go test -race ./internal/mcp/...`
+Expected: PASS, including every pre-existing authorize test.
+
+- [ ] **Step 7: Update the docs**
+
+In `docs/mcp.md`, replace the first "Known limitations" bullet's closing sentences about consent, and add a short section under the authorization documentation describing the behaviour:
+
+```markdown
+### Remembered approvals
+
+Approving a client is remembered, so you are asked once rather than every time
+its refresh token expires. A record ties your identity to that client, the MCP
+endpoint it asked for, and a fingerprint of the client's name and redirect URIs
+as you were shown them.
+
+You are asked again when any of those change — including when a client updates
+its own metadata document, since a client identified by URL controls what that
+document says — and when the grant is revoked or Cetacean detects a stolen
+refresh token. Clients that registered dynamically are never remembered: their
+metadata is self-reported.
+
+Approvals live in `mcp-tokens.json` beside the refresh tokens. Note the file's
+threat model differs between the two: refresh tokens are stored as SHA-256
+hashes, which are useless to anyone who steals the file, while an approval is a
+capability — anyone able to *write* the file could pre-approve a client. The
+file is mode `0600`, and as always an attacker with host access has already won.
+```
+
+In `CHANGELOG.md`, add under `### Added` in `[Unreleased]`:
+
+```markdown
+- Approving an MCP client is now remembered, so you are asked once instead of every time its access expires. Cetacean asks again if the client changes its name or where it sends you, if you revoke its access, or if a stolen token is detected
+```
+
+- [ ] **Step 8: Verify everything**
+
+Run: `go build ./... && go test ./... && golangci-lint run ./internal/... . && golangci-lint fmt --diff ./... 2>&1 | diff /dev/null -`
+Expected: all pass, `0 issues`, no formatting diff.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/mcp/oauth/server.go internal/mcp/oauth/consent.go internal/mcp/oauth/consent_store_test.go docs/mcp.md CHANGELOG.md
+git commit -m "feat(mcp): skip the consent page for an approved client
+
+A verified client whose metadata still matches what the user was shown
+receives a code without a prompt. Both paths now share one
+code-issuing helper, and the page says approving will be remembered."
+```

--- a/docs/specs/2026-09-02-mcp-consent-records-plan.md
+++ b/docs/specs/2026-09-02-mcp-consent-records-plan.md
@@ -338,7 +338,7 @@ changed. No behaviour or format change."
 
 **Interfaces:**
 - Consumes: `ClientMetadata` from `cimd.go` (fields `ClientName string`, `RedirectURIs []string`).
-- Produces: `func consentFingerprint(meta *ClientMetadata) string`.
+- Produces: `func consentFingerprint(meta *ClientMetadata) string`; `func hashField(h hash.Hash, field string)`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -445,6 +445,8 @@ package oauth
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"hash"
 	"slices"
 )
 
@@ -453,6 +455,18 @@ import (
 // other, and lets a future change to what is fingerprinted invalidate old
 // records rather than silently reinterpret them.
 const consentFingerprintDomain = "cetacean-consent-v1"
+
+// hashField writes a length-prefixed field, so the hash is an unambiguous
+// encoding of its inputs. A separator byte is not enough: client_name comes
+// from a JSON document the client controls, and JSON can encode any byte
+// including the separator, letting one field's content spill into the next
+// and two different clients share a fingerprint.
+func hashField(h hash.Hash, field string) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(field)))
+	h.Write(length[:])
+	h.Write([]byte(field))
+}
 
 // consentFingerprint hashes what the consent page showed the user: the
 // client's name, and the exact set of URIs it may receive a code at.
@@ -464,19 +478,18 @@ const consentFingerprintDomain = "cetacean-consent-v1"
 //
 // The URIs are sorted because array order in a client-controlled document
 // carries no meaning; re-prompting on a reordering would be noise. Fields are
-// NUL-separated so ("ab", "c") cannot hash the same as ("a", "bc").
+// length-prefixed so no two distinct tuples can produce the same byte stream,
+// including when a field itself contains the delimiter.
 func consentFingerprint(meta *ClientMetadata) string {
 	uris := slices.Clone(meta.RedirectURIs)
 	slices.Sort(uris)
 
 	h := sha256.New()
-	h.Write([]byte(consentFingerprintDomain))
-	h.Write([]byte{0})
-	h.Write([]byte(meta.ClientName))
+	hashField(h, consentFingerprintDomain)
+	hashField(h, meta.ClientName)
 
 	for _, uri := range uris {
-		h.Write([]byte{0})
-		h.Write([]byte(uri))
+		hashField(h, uri)
 	}
 
 	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -75,6 +75,7 @@ type fileMCP struct {
 	SigningKey      *string `toml:"signing_key"`
 	AccessTokenTTL  *string `toml:"access_token_ttl"`
 	RefreshTokenTTL *string `toml:"refresh_token_ttl"`
+	ConsentTTL      *string `toml:"consent_ttl"`
 
 	// MaxConcurrentTasks caps in-flight task-augmented tool calls.
 	MaxConcurrentTasks *int          `toml:"max_concurrent_tasks"`

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -36,6 +36,16 @@ type MCPConfig struct {
 	// RefreshTokenTTL is how long MCP refresh tokens remain valid.
 	RefreshTokenTTL time.Duration
 
+	// ConsentTTL is how long a remembered approval keeps letting a client skip
+	// the consent screen. It must outlive RefreshTokenTTL to be useful at all —
+	// the point of remembering is that an expired refresh token does not cost
+	// the operator a second prompt — but it cannot be unbounded: an approval is
+	// only revocable by presenting a token from its grant family, so once that
+	// family lapses an unbounded record would keep authorizing silently with no
+	// way left to withdraw it. Zero or negative disables remembering entirely,
+	// so every authorization is prompted.
+	ConsentTTL time.Duration
+
 	// RequireResourceIndicator requires RFC 8707 resource indicators in token requests.
 	RequireResourceIndicator bool
 
@@ -71,12 +81,14 @@ type MCPConfig struct {
 // DefaultMCPConfig returns an MCPConfig populated with sensible defaults.
 func DefaultMCPConfig() MCPConfig {
 	return MCPConfig{
-		Enabled:                  false,
-		OperationsLevel:          OpsInherit,
-		Issuer:                   "",
-		SigningKey:               "",
-		AccessTokenTTL:           time.Hour,
-		RefreshTokenTTL:          720 * time.Hour,
+		Enabled:         false,
+		OperationsLevel: OpsInherit,
+		Issuer:          "",
+		SigningKey:      "",
+		AccessTokenTTL:  time.Hour,
+		RefreshTokenTTL: 720 * time.Hour,
+		ConsentTTL:      2160 * time.Hour, // 90d, well past the refresh token's 30d
+
 		RequireResourceIndicator: true,
 		MaxConcurrentTasks:       32,
 		DCREnabled:               true,
@@ -112,6 +124,7 @@ func loadMCP(fm *fileMCP) (MCPConfig, error) {
 		fRefreshTTL    *string
 		fOpsLevel      *int
 		fRequireRI     *bool
+		fConsentTTL    *string
 		fMaxTasks      *int
 		fDCREnabled    *bool
 		fDCRRateLimit  *int
@@ -125,6 +138,7 @@ func loadMCP(fm *fileMCP) (MCPConfig, error) {
 		fSigningKey = fm.SigningKey
 		fAccessTTL = fm.AccessTokenTTL
 		fRefreshTTL = fm.RefreshTokenTTL
+		fConsentTTL = fm.ConsentTTL
 		fOpsLevel = fm.OperationsLevel
 		fMaxTasks = fm.MaxConcurrentTasks
 		if fm.OAuth != nil {
@@ -152,6 +166,16 @@ func loadMCP(fm *fileMCP) (MCPConfig, error) {
 		"CETACEAN_MCP_REFRESH_TOKEN_TTL",
 		fRefreshTTL,
 		def.RefreshTokenTTL,
+	)
+	if err != nil {
+		return MCPConfig{}, err
+	}
+
+	consentTTL, err := resolveDuration(
+		nil,
+		"CETACEAN_MCP_CONSENT_TTL",
+		fConsentTTL,
+		def.ConsentTTL,
 	)
 	if err != nil {
 		return MCPConfig{}, err
@@ -217,6 +241,7 @@ func loadMCP(fm *fileMCP) (MCPConfig, error) {
 		),
 		AccessTokenTTL:     accessTTL,
 		RefreshTokenTTL:    refreshTTL,
+		ConsentTTL:         consentTTL,
 		MaxConcurrentTasks: maxConcurrentTasks,
 		RequireResourceIndicator: resolveBool(
 			nil,

--- a/internal/config/mcp_test.go
+++ b/internal/config/mcp_test.go
@@ -17,6 +17,16 @@ func TestMCPConfigDefaults(t *testing.T) {
 	if cfg.RefreshTokenTTL != 720*time.Hour {
 		t.Errorf("refresh token TTL = %v, want 720h", cfg.RefreshTokenTTL)
 	}
+
+	// A remembered approval must outlive the refresh token, or remembering
+	// buys nothing: skipping the prompt once the token expires is the point.
+	if cfg.ConsentTTL <= cfg.RefreshTokenTTL {
+		t.Errorf(
+			"consent TTL = %v, want longer than the refresh token TTL %v",
+			cfg.ConsentTTL,
+			cfg.RefreshTokenTTL,
+		)
+	}
 	if cfg.OperationsLevel != OpsInherit {
 		t.Errorf("operations level = %v, want OpsInherit", cfg.OperationsLevel)
 	}
@@ -42,6 +52,7 @@ func TestMCPConfigFromEnv(t *testing.T) {
 	t.Setenv("CETACEAN_MCP_SIGNING_KEY", "test-secret")
 	t.Setenv("CETACEAN_MCP_ACCESS_TOKEN_TTL", "2h")
 	t.Setenv("CETACEAN_MCP_REFRESH_TOKEN_TTL", "48h")
+	t.Setenv("CETACEAN_MCP_CONSENT_TTL", "96h")
 	t.Setenv("CETACEAN_MCP_OPERATIONS_LEVEL", "2")
 	t.Setenv("CETACEAN_MCP_REQUIRE_RESOURCE_INDICATOR", "false")
 	t.Setenv("CETACEAN_MCP_DCR_ENABLED", "false")
@@ -66,6 +77,9 @@ func TestMCPConfigFromEnv(t *testing.T) {
 	}
 	if cfg.MCP.RefreshTokenTTL != 48*time.Hour {
 		t.Errorf("refresh TTL = %v, want 48h", cfg.MCP.RefreshTokenTTL)
+	}
+	if cfg.MCP.ConsentTTL != 96*time.Hour {
+		t.Errorf("consent TTL = %v, want 96h", cfg.MCP.ConsentTTL)
 	}
 	if cfg.MCP.OperationsLevel != OpsConfiguration {
 		t.Errorf("ops level = %v, want OpsConfiguration", cfg.MCP.OperationsLevel)

--- a/internal/mcp/oauth/consent.go
+++ b/internal/mcp/oauth/consent.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"html/template"
 	"net/http"
 	"time"
@@ -54,7 +55,7 @@ var consentTemplate = template.Must(template.New("consent").Parse(`<!DOCTYPE htm
 <div class="warning">
   This will grant <strong>{{.ClientName}}</strong> access to your Cetacean instance. Only approve if you trust this application.
 </div>
-{{if .Remembered}}<div class="warning">Approving will be remembered for <strong>{{.ClientName}}</strong> until you revoke its access.</div>{{end}}
+{{if .RememberedFor}}<div class="warning">Approving will be remembered for <strong>{{.ClientName}}</strong> for {{.RememberedFor}}, or until you revoke its access.</div>{{end}}
 <form method="POST" action="{{.ActionURL}}">
   <input type="hidden" name="response_type" value="{{.ResponseType}}">
   <input type="hidden" name="client_id" value="{{.ClientID}}">
@@ -95,9 +96,14 @@ var errorTemplate = template.Must(template.New("error").Parse(`<!DOCTYPE html>
 
 // consentData holds the template variables for the consent page.
 type consentData struct {
-	ClientName          string
-	Verified            bool
-	Remembered          bool
+	ClientName string
+	Verified   bool
+
+	// RememberedFor is how long this approval will be remembered, already
+	// humanized. Empty when it will not be remembered at all, which is what
+	// the template gates the disclosure on.
+	RememberedFor string
+
 	RedirectURI         string
 	Subject             string
 	Email               string
@@ -241,4 +247,19 @@ func verifyCSRFToken(r *http.Request, signingKey []byte) bool {
 	)
 
 	return hmac.Equal([]byte(r.FormValue("csrf_token")), []byte(expected))
+}
+
+// humanizeDuration renders a lifetime for the consent page. Approval lifetimes
+// are configured in hours but read to a person in days, which is the unit the
+// page is describing.
+func humanizeDuration(d time.Duration) string {
+	if days := int(d.Hours() / 24); days >= 1 {
+		if days == 1 {
+			return "1 day"
+		}
+
+		return fmt.Sprintf("%d days", days)
+	}
+
+	return d.String()
 }

--- a/internal/mcp/oauth/consent.go
+++ b/internal/mcp/oauth/consent.go
@@ -63,6 +63,7 @@ var consentTemplate = template.Must(template.New("consent").Parse(`<!DOCTYPE htm
   <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}">
   <input type="hidden" name="state" value="{{.State}}">
   <input type="hidden" name="resource" value="{{.Resource}}">
+  <input type="hidden" name="consent_fingerprint" value="{{.Fingerprint}}">
   <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
   <div class="actions">
     <button type="submit" name="decision" value="approve" class="btn-approve">Approve</button>
@@ -107,7 +108,12 @@ type consentData struct {
 	CodeChallengeMethod string
 	State               string
 	Resource            string
-	CSRFToken           string
+
+	// Fingerprint hashes the metadata this page was rendered from. It rides
+	// along in a hidden field and is covered by CSRFToken, so the POST can
+	// tell whether the client changed while the user was deciding.
+	Fingerprint string
+	CSRFToken   string
 }
 
 // renderConsent writes the consent page with security headers.
@@ -137,14 +143,47 @@ func setConsentHeaders(w http.ResponseWriter) {
 	w.Header().Set("Pragma", "no-cache")
 }
 
+// consentFingerprintField is the hidden form field carrying the fingerprint of
+// the client metadata the consent page was rendered from. It is not a secret —
+// the CSRF HMAC over it is what makes it unforgeable.
+const consentFingerprintField = "consent_fingerprint"
+
+// csrfMAC derives the CSRF token from the nonce and the request parameters it
+// must stay bound to. Both issuing and verifying go through here so the two
+// cannot drift apart.
+//
+// The fingerprint is covered because the recorded approval must be bound to
+// what the user was *shown*: the metadata is resolved on GET to render the
+// page and again on POST to act on it, and a CIMD document can change (or its
+// cache entry lapse) in between. Folding it into the MAC that is already
+// verified on every POST carries the GET's view forward without adding a
+// second piece of trust machinery.
+//
+// Fields are length-prefixed via hashField rather than joined with a
+// separator. state is client-chosen and may contain any byte, so a plain
+// "nonce|state|fingerprint" would let one field's content spell another's and
+// a token issued for one pair verify for a different one. This is the same
+// discipline consentFingerprint and consentKey already apply, for the same
+// reason.
+func csrfMAC(signingKey []byte, nonce, state, fingerprint string) string {
+	mac := hmac.New(sha256.New, signingKey)
+	hashField(mac, nonce)
+	hashField(mac, state)
+	hashField(mac, fingerprint)
+
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
 // issueCSRFNonce generates a random nonce, sets a short-lived signed cookie,
-// and returns the CSRF token (HMAC of nonce+state). The cookie is HttpOnly
-// and SameSite=Strict. When secure is true (issuer is HTTPS) the cookie is
-// also marked Secure.
+// and returns the CSRF token (an HMAC over nonce, state and the client
+// metadata fingerprint the page is being rendered from). The cookie is
+// HttpOnly and SameSite=Strict. When secure is true (issuer is HTTPS) the
+// cookie is also marked Secure.
 func issueCSRFNonce(
 	w http.ResponseWriter,
 	signingKey []byte,
 	state string,
+	fingerprint string,
 	secure bool,
 ) (token string, nonce string) {
 	b := make([]byte, 16)
@@ -152,12 +191,7 @@ func issueCSRFNonce(
 		panic("mcp/oauth: crypto/rand failure: " + err.Error())
 	}
 	nonce = base64.RawURLEncoding.EncodeToString(b)
-
-	mac := hmac.New(sha256.New, signingKey)
-	mac.Write([]byte(nonce))
-	mac.Write([]byte("|"))
-	mac.Write([]byte(state))
-	token = base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	token = csrfMAC(signingKey, nonce, state, fingerprint)
 
 	//nolint:gosec // G124: cookie is HttpOnly + SameSite=Strict; Secure is true on HTTPS issuers and intentionally off only for loopback HTTP dev, which gosec can't prove from the variable.
 	http.SetCookie(w, &http.Cookie{
@@ -190,21 +224,21 @@ func clearCSRFCookie(w http.ResponseWriter, secure bool) {
 }
 
 // verifyCSRFToken validates the CSRF token from the form against the nonce
-// stored in the cookie.
+// stored in the cookie. A token verifies only for the state and the metadata
+// fingerprint it was issued for, so the caller can trust the submitted
+// fingerprint as the one the consent page actually displayed.
 func verifyCSRFToken(r *http.Request, signingKey []byte) bool {
 	cookie, err := r.Cookie(csrfCookieName)
 	if err != nil {
 		return false
 	}
-	nonce := cookie.Value
-	state := r.FormValue("state")
-	submittedToken := r.FormValue("csrf_token")
 
-	mac := hmac.New(sha256.New, signingKey)
-	mac.Write([]byte(nonce))
-	mac.Write([]byte("|"))
-	mac.Write([]byte(state))
-	expected := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	expected := csrfMAC(
+		signingKey,
+		cookie.Value,
+		r.FormValue("state"),
+		r.FormValue(consentFingerprintField),
+	)
 
-	return hmac.Equal([]byte(submittedToken), []byte(expected))
+	return hmac.Equal([]byte(r.FormValue("csrf_token")), []byte(expected))
 }

--- a/internal/mcp/oauth/consent.go
+++ b/internal/mcp/oauth/consent.go
@@ -54,6 +54,7 @@ var consentTemplate = template.Must(template.New("consent").Parse(`<!DOCTYPE htm
 <div class="warning">
   This will grant <strong>{{.ClientName}}</strong> access to your Cetacean instance. Only approve if you trust this application.
 </div>
+{{if .Remembered}}<div class="warning">Approving will be remembered for <strong>{{.ClientName}}</strong> until you revoke its access.</div>{{end}}
 <form method="POST" action="{{.ActionURL}}">
   <input type="hidden" name="response_type" value="{{.ResponseType}}">
   <input type="hidden" name="client_id" value="{{.ClientID}}">
@@ -95,6 +96,7 @@ var errorTemplate = template.Must(template.New("error").Parse(`<!DOCTYPE html>
 type consentData struct {
 	ClientName          string
 	Verified            bool
+	Remembered          bool
 	RedirectURI         string
 	Subject             string
 	Email               string

--- a/internal/mcp/oauth/consent_store.go
+++ b/internal/mcp/oauth/consent_store.go
@@ -6,6 +6,9 @@ import (
 	"encoding/binary"
 	"hash"
 	"slices"
+	"strings"
+	"sync"
+	"time"
 )
 
 // consentFingerprintDomain separates this hash from every other use of
@@ -51,4 +54,175 @@ func consentFingerprint(meta *ClientMetadata) string {
 	}
 
 	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+// ConsentRecord is one remembered approval: this user approved this client,
+// as it looked at the time, for this MCP endpoint.
+type ConsentRecord struct {
+	Subject     string    `json:"subject"`
+	ClientID    string    `json:"clientId"`
+	Resource    string    `json:"resource"`
+	Fingerprint string    `json:"fingerprint"`
+	GrantedAt   time.Time `json:"grantedAt"`
+}
+
+// ConsentStore remembers approvals so an already-approved client does not
+// re-prompt on every authorization request.
+//
+// Unlike the refresh token store, whose file holds only hashes and is
+// therefore a confidentiality concern, a consent record is a capability:
+// anyone able to write it can pre-approve a client and complete an
+// authorization with no human in the loop. The file is mode 0600 and the
+// caveat is the usual one — an attacker with host access has already won —
+// but the property being protected is integrity, not secrecy.
+type ConsentStore struct {
+	mu      sync.Mutex
+	records map[string]ConsentRecord
+
+	// onChange is called after every mutation that changed state, always with
+	// mu released. Nil when the store is memory-only.
+	onChange func()
+}
+
+// NewConsentStore returns a ready-to-use ConsentStore.
+func NewConsentStore() *ConsentStore {
+	return &ConsentStore{
+		records: make(map[string]ConsentRecord),
+	}
+}
+
+// SetOnChange installs the callback fired after every mutation. Call it during
+// setup, before the store serves any request: it is not guarded by the mutex,
+// because a hook swapped mid-flight would race the mutations it records.
+func (s *ConsentStore) SetOnChange(fn func()) {
+	s.onChange = fn
+}
+
+// writeThrough notifies the owner of the durable state that it changed. It
+// must be called with mu released, since the owner takes a snapshot, which
+// acquires it.
+func (s *ConsentStore) writeThrough() {
+	if s.onChange == nil {
+		return
+	}
+
+	s.onChange()
+}
+
+// consentKeyDomain separates this hash from every other use of SHA-256 in the
+// package, so a value from one can never be mistaken for the other.
+const consentKeyDomain = "cetacean-consent-key-v1"
+
+// consentKey identifies the approval, without the fingerprint: the fingerprint
+// lives in the value, so a client whose metadata changed replaces its stale
+// record rather than accumulating a second one alongside it.
+//
+// A subject can originate from an OIDC token claim, and JSON can encode any
+// byte including NUL, so a plain separator-joined string cannot rule out one
+// triple's bytes spelling another's — e.g. ("a\x00b", "c", "d") and
+// ("a", "b\x00c", "d") would join identically. Each field is instead
+// length-prefixed via hashField before being folded into a SHA-256, so the
+// composition is unambiguous regardless of what bytes a field contains.
+func consentKey(subject, clientID, resource string) string {
+	h := sha256.New()
+	hashField(h, consentKeyDomain)
+	hashField(h, subject)
+	hashField(h, clientID)
+	hashField(h, resource)
+
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+// Allows reports whether this exact approval was remembered — same user, same
+// client, same MCP endpoint, and the same client metadata they were shown.
+func (s *ConsentStore) Allows(subject, clientID, resource, fingerprint string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, exists := s.records[consentKey(subject, clientID, resource)]
+
+	return exists && record.Fingerprint == fingerprint
+}
+
+// Remember records an approval, replacing any earlier one for the same user,
+// client and resource.
+func (s *ConsentStore) Remember(subject, clientID, resource, fingerprint string) {
+	key := consentKey(subject, clientID, resource)
+
+	s.mu.Lock()
+	existing, exists := s.records[key]
+	unchanged := exists && existing.Fingerprint == fingerprint
+	if !unchanged {
+		s.records[key] = ConsentRecord{
+			Subject:     subject,
+			ClientID:    clientID,
+			Resource:    resource,
+			Fingerprint: fingerprint,
+			GrantedAt:   time.Now(),
+		}
+	}
+	s.mu.Unlock()
+
+	// Re-approving an unchanged client changes nothing durable, and rewriting
+	// the whole file for it would be work for no reason.
+	if unchanged {
+		return
+	}
+
+	s.writeThrough()
+}
+
+// Forget drops an approval. Called when a grant is revoked or burned for
+// theft, so revocation cannot degrade into "grant one more silent
+// re-authorization".
+func (s *ConsentStore) Forget(subject, clientID, resource string) {
+	key := consentKey(subject, clientID, resource)
+
+	s.mu.Lock()
+	_, existed := s.records[key]
+	delete(s.records, key)
+	s.mu.Unlock()
+
+	if !existed {
+		return
+	}
+
+	s.writeThrough()
+}
+
+// Snapshot returns the records in a stable order. Map iteration is random, and
+// an unsorted snapshot would rewrite the file with reordered records on every
+// unrelated change.
+func (s *ConsentStore) Snapshot() []ConsentRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records := make([]ConsentRecord, 0, len(s.records))
+	for _, record := range s.records {
+		records = append(records, record)
+	}
+
+	slices.SortFunc(records, func(a, b ConsentRecord) int {
+		if c := strings.Compare(a.Subject, b.Subject); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.ClientID, b.ClientID); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.Resource, b.Resource)
+	})
+
+	return records
+}
+
+// Restore replaces the store's state from a snapshot.
+func (s *ConsentStore) Restore(records []ConsentRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.records = make(map[string]ConsentRecord, len(records))
+	for _, record := range records {
+		s.records[consentKey(record.Subject, record.ClientID, record.Resource)] = record
+	}
 }

--- a/internal/mcp/oauth/consent_store.go
+++ b/internal/mcp/oauth/consent_store.go
@@ -3,6 +3,8 @@ package oauth
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"hash"
 	"slices"
 )
 
@@ -11,6 +13,18 @@ import (
 // other, and lets a future change to what is fingerprinted invalidate old
 // records rather than silently reinterpret them.
 const consentFingerprintDomain = "cetacean-consent-v1"
+
+// hashField writes a length-prefixed field, so the hash is an unambiguous
+// encoding of its inputs. A separator byte is not enough: client_name comes
+// from a JSON document the client controls, and JSON can encode any byte
+// including the separator, letting one field's content spill into the next
+// and two different clients share a fingerprint.
+func hashField(h hash.Hash, field string) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(field)))
+	h.Write(length[:])
+	h.Write([]byte(field))
+}
 
 // consentFingerprint hashes what the consent page showed the user: the
 // client's name, and the exact set of URIs it may receive a code at.
@@ -22,19 +36,18 @@ const consentFingerprintDomain = "cetacean-consent-v1"
 //
 // The URIs are sorted because array order in a client-controlled document
 // carries no meaning; re-prompting on a reordering would be noise. Fields are
-// NUL-separated so ("ab", "c") cannot hash the same as ("a", "bc").
+// length-prefixed so no two distinct tuples can produce the same byte stream,
+// including when a field itself contains the delimiter.
 func consentFingerprint(meta *ClientMetadata) string {
 	uris := slices.Clone(meta.RedirectURIs)
 	slices.Sort(uris)
 
 	h := sha256.New()
-	h.Write([]byte(consentFingerprintDomain))
-	h.Write([]byte{0})
-	h.Write([]byte(meta.ClientName))
+	hashField(h, consentFingerprintDomain)
+	hashField(h, meta.ClientName)
 
 	for _, uri := range uris {
-		h.Write([]byte{0})
-		h.Write([]byte(uri))
+		hashField(h, uri)
 	}
 
 	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))

--- a/internal/mcp/oauth/consent_store.go
+++ b/internal/mcp/oauth/consent_store.go
@@ -1,0 +1,41 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"slices"
+)
+
+// consentFingerprintDomain separates this hash from every other use of
+// SHA-256 in the package, so a value from one can never be mistaken for the
+// other, and lets a future change to what is fingerprinted invalidate old
+// records rather than silently reinterpret them.
+const consentFingerprintDomain = "cetacean-consent-v1"
+
+// consentFingerprint hashes what the consent page showed the user: the
+// client's name, and the exact set of URIs it may receive a code at.
+//
+// A CIMD client controls its own metadata document and may change it at any
+// time. Binding a remembered approval to this hash means a rename or a new
+// redirect_uri re-prompts, so an approval can never be inherited by a client
+// the user would not recognise, or redirect somewhere they never saw.
+//
+// The URIs are sorted because array order in a client-controlled document
+// carries no meaning; re-prompting on a reordering would be noise. Fields are
+// NUL-separated so ("ab", "c") cannot hash the same as ("a", "bc").
+func consentFingerprint(meta *ClientMetadata) string {
+	uris := slices.Clone(meta.RedirectURIs)
+	slices.Sort(uris)
+
+	h := sha256.New()
+	h.Write([]byte(consentFingerprintDomain))
+	h.Write([]byte{0})
+	h.Write([]byte(meta.ClientName))
+
+	for _, uri := range uris {
+		h.Write([]byte{0})
+		h.Write([]byte(uri))
+	}
+
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}

--- a/internal/mcp/oauth/consent_store.go
+++ b/internal/mcp/oauth/consent_store.go
@@ -17,6 +17,10 @@ import (
 // records rather than silently reinterpret them.
 const consentFingerprintDomain = "cetacean-consent-v1"
 
+// consentKeyDomain separates this hash from every other use of SHA-256 in the
+// package, so a value from one can never be mistaken for the other.
+const consentKeyDomain = "cetacean-consent-key-v1"
+
 // hashField writes a length-prefixed field, so the hash is an unambiguous
 // encoding of its inputs. A separator byte is not enough: client_name comes
 // from a JSON document the client controls, and JSON can encode any byte
@@ -29,6 +33,21 @@ func hashField(h hash.Hash, field string) {
 	h.Write([]byte(field))
 }
 
+// hashFields folds a domain separator and its fields into one SHA-256. Every
+// hashed value in this package goes through here, so the two disciplines the
+// comments above defend — domain separation and length-prefixing — are
+// implemented once rather than restated at each new hash.
+func hashFields(domain string, fields ...string) string {
+	h := sha256.New()
+	hashField(h, domain)
+
+	for _, field := range fields {
+		hashField(h, field)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
 // consentFingerprint hashes what the consent page showed the user: the
 // client's name, and the exact set of URIs it may receive a code at.
 //
@@ -38,32 +57,55 @@ func hashField(h hash.Hash, field string) {
 // the user would not recognise, or redirect somewhere they never saw.
 //
 // The URIs are sorted because array order in a client-controlled document
-// carries no meaning; re-prompting on a reordering would be noise. Fields are
-// length-prefixed so no two distinct tuples can produce the same byte stream,
-// including when a field itself contains the delimiter.
+// carries no meaning; re-prompting on a reordering would be noise.
 func consentFingerprint(meta *ClientMetadata) string {
 	uris := slices.Clone(meta.RedirectURIs)
 	slices.Sort(uris)
 
-	h := sha256.New()
-	hashField(h, consentFingerprintDomain)
-	hashField(h, meta.ClientName)
+	return hashFields(consentFingerprintDomain, append([]string{meta.ClientName}, uris...)...)
+}
 
-	for _, uri := range uris {
-		hashField(h, uri)
-	}
+// ConsentKey identifies one approval: this user, this client, this MCP
+// endpoint. The three are all free-form strings, so they travel as a named
+// struct — passed positionally, a transposed pair compiles and silently keys a
+// different record.
+type ConsentKey struct {
+	Subject  string `json:"subject"`
+	ClientID string `json:"clientId"`
+	Resource string `json:"resource"`
+}
 
-	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+// hash identifies the approval, without the fingerprint: the fingerprint lives
+// in the value, so a client whose metadata changed replaces its stale record
+// rather than accumulating a second one alongside it.
+//
+// A subject can originate from an OIDC token claim, and JSON can encode any
+// byte including NUL, so a plain separator-joined string cannot rule out one
+// triple's bytes spelling another's — e.g. ("a\x00b", "c", "d") and
+// ("a", "b\x00c", "d") would join identically. hashFields length-prefixes each
+// field, so the composition is unambiguous whatever bytes a field contains.
+func (k ConsentKey) hash() string {
+	return hashFields(consentKeyDomain, k.Subject, k.ClientID, k.Resource)
+}
+
+// ConsentKey projects the identity a refresh token was issued to onto the
+// approval it was granted under, so the token-to-consent mapping is written
+// once rather than spelled out at each teardown site.
+func (d RefreshTokenData) ConsentKey() ConsentKey {
+	return ConsentKey{Subject: d.Subject, ClientID: d.ClientID, Resource: d.Resource}
 }
 
 // ConsentRecord is one remembered approval: this user approved this client,
 // as it looked at the time, for this MCP endpoint.
 type ConsentRecord struct {
-	Subject     string    `json:"subject"`
-	ClientID    string    `json:"clientId"`
-	Resource    string    `json:"resource"`
-	Fingerprint string    `json:"fingerprint"`
-	GrantedAt   time.Time `json:"grantedAt"`
+	ConsentKey
+
+	Fingerprint string `json:"fingerprint"`
+
+	// GrantedAt is not read by the server. It is recorded so an operator
+	// reading the state file can tell when an approval was given, and when a
+	// stale-looking one is safe to delete by hand.
+	GrantedAt time.Time `json:"grantedAt"`
 }
 
 // ConsentStore remembers approvals so an already-approved client does not
@@ -76,98 +118,103 @@ type ConsentRecord struct {
 // caveat is the usual one — an attacker with host access has already won —
 // but the property being protected is integrity, not secrecy.
 type ConsentStore struct {
+	changeNotifier
+
+	// ttl bounds how long a record keeps skipping the consent screen.
+	//
+	// The store needs a lifetime of its own because it cannot borrow the token
+	// store's. An approval is only reachable for revocation by presenting a
+	// token from its grant family, and a family is torn down once its token
+	// expires — so an unbounded record outlives the only handle anyone had on
+	// it and keeps authorizing silently with no way left to withdraw it. A
+	// max-age is what makes "remembered" a lease rather than a one-way door.
+	//
+	// Zero or negative disables remembering: nothing is recorded and nothing
+	// is honoured, so every authorization reaches a human.
+	ttl time.Duration
+
 	mu      sync.Mutex
 	records map[string]ConsentRecord
-
-	// onChange is called after every mutation that changed state, always with
-	// mu released. Nil when the store is memory-only.
-	onChange func()
 }
 
-// NewConsentStore returns a ready-to-use ConsentStore.
-func NewConsentStore() *ConsentStore {
+// NewConsentStore returns a ready-to-use ConsentStore whose approvals lapse
+// after ttl. A ttl of zero or less disables remembering altogether.
+func NewConsentStore(ttl time.Duration) *ConsentStore {
 	return &ConsentStore{
+		ttl:     ttl,
 		records: make(map[string]ConsentRecord),
 	}
 }
 
-// SetOnChange installs the callback fired after every mutation. Call it during
-// setup, before the store serves any request: it is not guarded by the mutex,
-// because a hook swapped mid-flight would race the mutations it records.
-func (s *ConsentStore) SetOnChange(fn func()) {
-	s.onChange = fn
+// Enabled reports whether approvals are remembered at all.
+func (s *ConsentStore) Enabled() bool {
+	return s.ttl > 0
 }
 
-// writeThrough notifies the owner of the durable state that it changed. It
-// must be called with mu released, since the owner takes a snapshot, which
-// acquires it.
-func (s *ConsentStore) writeThrough() {
-	if s.onChange == nil {
-		return
-	}
-
-	s.onChange()
+// TTL is how long a fresh approval will be honoured. The consent page reads it
+// from here rather than from config, so what the page promises and what the
+// store enforces cannot drift.
+func (s *ConsentStore) TTL() time.Duration {
+	return s.ttl
 }
 
-// consentKeyDomain separates this hash from every other use of SHA-256 in the
-// package, so a value from one can never be mistaken for the other.
-const consentKeyDomain = "cetacean-consent-key-v1"
-
-// consentKey identifies the approval, without the fingerprint: the fingerprint
-// lives in the value, so a client whose metadata changed replaces its stale
-// record rather than accumulating a second one alongside it.
-//
-// A subject can originate from an OIDC token claim, and JSON can encode any
-// byte including NUL, so a plain separator-joined string cannot rule out one
-// triple's bytes spelling another's — e.g. ("a\x00b", "c", "d") and
-// ("a", "b\x00c", "d") would join identically. Each field is instead
-// length-prefixed via hashField before being folded into a SHA-256, so the
-// composition is unambiguous regardless of what bytes a field contains.
-func consentKey(subject, clientID, resource string) string {
-	h := sha256.New()
-	hashField(h, consentKeyDomain)
-	hashField(h, subject)
-	hashField(h, clientID)
-	hashField(h, resource)
-
-	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+// expired reports whether a record granted at grantedAt has outlived the
+// store's lease. Evaluated against a caller-supplied now so a single sweep
+// judges every record against one instant.
+func (s *ConsentStore) expired(grantedAt time.Time, now time.Time) bool {
+	return now.Sub(grantedAt) >= s.ttl
 }
 
 // Allows reports whether this exact approval was remembered — same user, same
 // client, same MCP endpoint, and the same client metadata they were shown.
-func (s *ConsentStore) Allows(subject, clientID, resource, fingerprint string) bool {
+// A lapsed record is reported as not allowed but deliberately left in place:
+// this is the read path, and deleting here would turn every authorization into
+// a potential file write. Restore drops them at the next start.
+func (s *ConsentStore) Allows(key ConsentKey, fingerprint string) bool {
+	if !s.Enabled() {
+		return false
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, exists := s.records[consentKey(subject, clientID, resource)]
+	record, exists := s.records[key.hash()]
 
-	return exists && record.Fingerprint == fingerprint
+	return exists &&
+		record.Fingerprint == fingerprint &&
+		!s.expired(record.GrantedAt, time.Now())
 }
 
 // Remember records an approval, replacing any earlier one for the same user,
 // client and resource.
-func (s *ConsentStore) Remember(subject, clientID, resource, fingerprint string) {
-	key := consentKey(subject, clientID, resource)
-
-	s.mu.Lock()
-	existing, exists := s.records[key]
-	unchanged := exists && existing.Fingerprint == fingerprint
-	if !unchanged {
-		s.records[key] = ConsentRecord{
-			Subject:     subject,
-			ClientID:    clientID,
-			Resource:    resource,
-			Fingerprint: fingerprint,
-			GrantedAt:   time.Now(),
-		}
-	}
-	s.mu.Unlock()
-
-	// Re-approving an unchanged client changes nothing durable, and rewriting
-	// the whole file for it would be work for no reason.
-	if unchanged {
+func (s *ConsentStore) Remember(key ConsentKey, fingerprint string) {
+	// Recording an approval that Allows would never honour costs a file write
+	// and leaves a capability on disk for no benefit.
+	if !s.Enabled() {
 		return
 	}
+
+	hash := key.hash()
+
+	s.mu.Lock()
+
+	// Re-approving an unchanged client changes nothing durable, and rewriting
+	// the whole file for it would be work for no reason. A record close enough
+	// to lapsing is rewritten anyway, since re-approval is what renews the
+	// lease.
+	existing, exists := s.records[hash]
+	if exists && existing.Fingerprint == fingerprint && !s.expired(existing.GrantedAt, time.Now()) {
+		s.mu.Unlock()
+
+		return
+	}
+
+	s.records[hash] = ConsentRecord{
+		ConsentKey:  key,
+		Fingerprint: fingerprint,
+		GrantedAt:   time.Now(),
+	}
+	s.mu.Unlock()
 
 	s.writeThrough()
 }
@@ -175,12 +222,12 @@ func (s *ConsentStore) Remember(subject, clientID, resource, fingerprint string)
 // Forget drops an approval. Called when a grant is revoked or burned for
 // theft, so revocation cannot degrade into "grant one more silent
 // re-authorization".
-func (s *ConsentStore) Forget(subject, clientID, resource string) {
-	key := consentKey(subject, clientID, resource)
+func (s *ConsentStore) Forget(key ConsentKey) {
+	hash := key.hash()
 
 	s.mu.Lock()
-	_, existed := s.records[key]
-	delete(s.records, key)
+	_, existed := s.records[hash]
+	delete(s.records, hash)
 	s.mu.Unlock()
 
 	if !existed {
@@ -216,13 +263,26 @@ func (s *ConsentStore) Snapshot() []ConsentRecord {
 	return records
 }
 
-// Restore replaces the store's state from a snapshot.
+// Restore replaces the store's state from a snapshot, dropping approvals that
+// lapsed while the process was down. This is the store's only pruning point:
+// Allows refuses a lapsed record but leaves it alone, so without this the file
+// would accumulate records that can never authorize anything again.
 func (s *ConsentStore) Restore(records []ConsentRecord) {
+	now := time.Now()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.records = make(map[string]ConsentRecord, len(records))
+	if !s.Enabled() {
+		return
+	}
+
 	for _, record := range records {
-		s.records[consentKey(record.Subject, record.ClientID, record.Resource)] = record
+		if s.expired(record.GrantedAt, now) {
+			continue
+		}
+
+		s.records[record.hash()] = record
 	}
 }

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/radiergummi/cetacean/internal/auth"
 	"github.com/radiergummi/cetacean/internal/config"
 )
 
@@ -431,5 +432,134 @@ func TestVersion1FileLoadsWithoutConsent(t *testing.T) {
 	}
 	if len(state.Consent) != 0 {
 		t.Errorf("consent records = %d, want none", len(state.Consent))
+	}
+}
+
+// authorizeGET drives a GET /oauth/authorize for a CIMD client whose metadata
+// document is served by a local test server, and returns the response.
+func authorizeGET(
+	t *testing.T,
+	s *Server,
+	clientID, redirectURI string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "/oauth/authorize?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {computeS256Challenge("verifier-verifier-verifier-1234")},
+		"code_challenge_method": {"S256"},
+		"state":                 {"xyz"},
+		"resource":              {s.cfg.MCPResource},
+	}.Encode()
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), &auth.Identity{
+		Subject:  testSubject,
+		Provider: "none",
+	}))
+
+	w := httptest.NewRecorder()
+	s.HandleAuthorize(w, req)
+
+	return w
+}
+
+// cimdServer stands up a CIMD client whose metadata document is served over
+// TLS from loopback, and returns a Server wired to fetch it.
+func cimdServer(t *testing.T) (srv *Server, clientID, redirectURI string, meta *ClientMetadata) {
+	t.Helper()
+
+	published := ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"https://example.com/cb"},
+	}
+
+	var documentURL string
+	httpSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveMetadata(documentURL, published)(w, r)
+	}))
+	t.Cleanup(httpSrv.Close)
+	documentURL = httpSrv.URL + "/client.json"
+
+	srv = newTestServer(t)
+
+	// The document is served with a self-signed certificate, so the fetcher
+	// needs the test server's client to trust it. newTestServer already sets
+	// AllowLoopback.
+	srv.cimd.Client = httpSrv.Client()
+
+	// consentFingerprint reads only ClientName and RedirectURIs, so this local
+	// copy fingerprints identically to the fetched document.
+	return srv, documentURL, published.RedirectURIs[0], &published
+}
+
+func TestApprovedClientSkipsTheConsentPage(t *testing.T) {
+	s, clientID, redirectURI, meta := cimdServer(t)
+	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(meta))
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (redirect with a code)", w.Code, http.StatusFound)
+	}
+
+	location, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	if location.Query().Get("code") == "" {
+		t.Error("no authorization code in the redirect")
+	}
+	if strings.Contains(w.Body.String(), "Authorization Request") {
+		t.Error("the consent page was rendered despite a matching approval")
+	}
+}
+
+func TestChangedMetadataRePrompts(t *testing.T) {
+	s, clientID, redirectURI, _ := cimdServer(t)
+
+	// An approval granted against different metadata than the client now
+	// publishes must not carry over.
+	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, "fingerprint-from-before")
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (the consent page)", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), "Authorization Request") {
+		t.Error("expected the consent page to be rendered")
+	}
+}
+
+func TestDynamicallyRegisteredClientNeverSkipsTheConsentPage(t *testing.T) {
+	s := newTestServer(t)
+
+	const clientID = "dcr-generated-client-id"
+	const redirectURI = "http://127.0.0.1:1/cb"
+
+	s.clients.register(&ClientRegistration{
+		ClientID:     clientID,
+		ClientName:   "Self-Registered CLI",
+		RedirectURIs: []string{redirectURI},
+	})
+
+	// Seed a record that matches on every field. It must still be ignored:
+	// a DCR client's metadata is self-reported, so a fingerprint over it
+	// proves nothing about who the client is.
+	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(&ClientMetadata{
+		ClientName:   "Self-Registered CLI",
+		RedirectURIs: []string{redirectURI},
+	}))
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (the consent page)", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), "Authorization Request") {
+		t.Error("an unverified client skipped the consent page")
 	}
 }

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -72,12 +72,36 @@ func TestConsentFingerprintChangesWithTheDecision(t *testing.T) {
 }
 
 func TestConsentFingerprintSeparatesFields(t *testing.T) {
-	// Without a separator between the name and the URIs, ("ab", "c") and
-	// ("a", "bc") would hash alike and one client could impersonate another.
-	a := consentFingerprint(&ClientMetadata{ClientName: "ab", RedirectURIs: []string{"c"}})
-	b := consentFingerprint(&ClientMetadata{ClientName: "a", RedirectURIs: []string{"bc"}})
+	tests := []struct {
+		name string
+		a    *ClientMetadata
+		b    *ClientMetadata
+	}{
+		{
+			name: "concatenation collision",
+			// Without field separation, ("ab", "c") and ("a", "bc") would
+			// hash alike and one client could impersonate another.
+			a: &ClientMetadata{ClientName: "ab", RedirectURIs: []string{"c"}},
+			b: &ClientMetadata{ClientName: "a", RedirectURIs: []string{"bc"}},
+		},
+		{
+			name: "embedded NUL in ClientName",
+			// client_name comes from a JSON document the client controls.
+			// JSON can encode a literal NUL via \u0000. Without length
+			// prefixing, ClientName="A\x00B" with RedirectURIs=nil would
+			// collide with ClientName="A" with RedirectURIs=["B"].
+			a: &ClientMetadata{ClientName: "A\x00B", RedirectURIs: nil},
+			b: &ClientMetadata{ClientName: "A", RedirectURIs: []string{"B"}},
+		},
+	}
 
-	if a == b {
-		t.Error("concatenation collision: two different clients share a fingerprint")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fpA := consentFingerprint(tc.a)
+			fpB := consentFingerprint(tc.b)
+			if fpA == fpB {
+				t.Errorf("collision: two different clients share fingerprint %q", fpA)
+			}
+		})
 	}
 }

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"testing"
+	"time"
 )
 
 func TestConsentFingerprintIgnoresRedirectURIOrder(t *testing.T) {
@@ -101,6 +102,181 @@ func TestConsentFingerprintSeparatesFields(t *testing.T) {
 			fpB := consentFingerprint(tc.b)
 			if fpA == fpB {
 				t.Errorf("collision: two different clients share fingerprint %q", fpA)
+			}
+		})
+	}
+}
+
+const (
+	testSubject     = "user@example.com"
+	testClientID    = "https://example.com/client.json"
+	testResource    = "https://cetacean.example.com/mcp"
+	testFingerprint = "fingerprint-a"
+)
+
+func TestConsentStoreRemembersAnApproval(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	if !s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Error("a remembered approval should be allowed")
+	}
+}
+
+func TestConsentStoreRequiresAnExactMatch(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	tests := []struct {
+		name                                     string
+		subject, clientID, resource, fingerprint string
+	}{
+		{
+			name:    "another user",
+			subject: "someone@example.com", clientID: testClientID,
+			resource: testResource, fingerprint: testFingerprint,
+		},
+		{
+			name:    "another client",
+			subject: testSubject, clientID: "https://other.example/client.json",
+			resource: testResource, fingerprint: testFingerprint,
+		},
+		{
+			// RFC 8707: an approval for one MCP endpoint must not cover another.
+			name:    "another resource",
+			subject: testSubject, clientID: testClientID,
+			resource: "https://other.example.com/mcp", fingerprint: testFingerprint,
+		},
+		{
+			// The client changed its metadata after the approval.
+			name:    "changed metadata",
+			subject: testSubject, clientID: testClientID,
+			resource: testResource, fingerprint: "fingerprint-b",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if s.Allows(tc.subject, tc.clientID, tc.resource, tc.fingerprint) {
+				t.Error("a non-matching request should re-prompt")
+			}
+		})
+	}
+}
+
+func TestConsentStoreReplacesAStaleRecord(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, "fingerprint-a")
+	s.Remember(testSubject, testClientID, testResource, "fingerprint-b")
+
+	// A user must never hold two live approvals for one client, one of which
+	// they no longer remember granting.
+	if got := len(s.Snapshot()); got != 1 {
+		t.Errorf("records = %d, want the stale one replaced", got)
+	}
+	if s.Allows(testSubject, testClientID, testResource, "fingerprint-a") {
+		t.Error("the replaced approval should no longer be allowed")
+	}
+}
+
+func TestConsentStoreForgets(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+	s.Forget(testSubject, testClientID, testResource)
+
+	if s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Error("a forgotten approval should re-prompt")
+	}
+}
+
+func TestConsentStoreNotifiesOnlyOnRealChanges(t *testing.T) {
+	s := NewConsentStore()
+
+	var writes int
+	s.SetOnChange(func() { writes++ })
+
+	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+	s.Remember(testSubject, testClientID, testResource, testFingerprint) // identical
+	s.Forget(testSubject, "https://unknown.example/client.json", testResource)
+
+	// Re-approving an unchanged client and forgetting an unknown one change
+	// nothing, and a whole-file rewrite for each would be work for no reason.
+	if writes != 1 {
+		t.Errorf("writes = %d, want 1 (only the first Remember changed state)", writes)
+	}
+}
+
+func TestConsentStoreSnapshotIsDeterministic(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember("b@example.com", testClientID, testResource, testFingerprint)
+	s.Remember("a@example.com", testClientID, testResource, testFingerprint)
+
+	// Map iteration order is random; an unsorted snapshot would rewrite the
+	// file with reordered records on every unrelated change.
+	first := s.Snapshot()
+	for range 5 {
+		next := s.Snapshot()
+		for i := range first {
+			if first[i].Subject != next[i].Subject {
+				t.Fatal("snapshot order is not stable")
+			}
+		}
+	}
+	if first[0].Subject != "a@example.com" {
+		t.Errorf("first record = %q, want the sorted-first subject", first[0].Subject)
+	}
+}
+
+func TestConsentStoreRestoreReplacesState(t *testing.T) {
+	s := NewConsentStore()
+	s.Remember("stale@example.com", testClientID, testResource, testFingerprint)
+
+	s.Restore([]ConsentRecord{{
+		Subject:     testSubject,
+		ClientID:    testClientID,
+		Resource:    testResource,
+		Fingerprint: testFingerprint,
+		GrantedAt:   time.Now(),
+	}})
+
+	if s.Allows("stale@example.com", testClientID, testResource, testFingerprint) {
+		t.Error("Restore should replace state, not merge into it")
+	}
+	if !s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Error("the restored record should be allowed")
+	}
+}
+
+func TestConsentKeySeparatesFields(t *testing.T) {
+	// Naive NUL-joining would let these two triples collide: "a\x00b" as a
+	// subject joined with clientID "c" reads identically to subject "a"
+	// joined with clientID "b\x00c" once concatenated with the resource.
+	tests := []struct {
+		name                           string
+		subjectA, clientIDA, resourceA string
+		subjectB, clientIDB, resourceB string
+	}{
+		{
+			name:     "concatenation collision across fields",
+			subjectA: "a", clientIDA: "b", resourceA: "c",
+			subjectB: "ab", clientIDB: "", resourceB: "c",
+		},
+		{
+			name: "embedded NUL in subject",
+			// A subject can originate from an OIDC token claim, and JSON can
+			// encode any byte including NUL. Naive "\x00"-joining would let
+			// this subject spell a different (subject, clientID) pair.
+			subjectA: "a\x00b", clientIDA: "c", resourceA: "d",
+			subjectB: "a", clientIDB: "b\x00c", resourceB: "d",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keyA := consentKey(tc.subjectA, tc.clientIDA, tc.resourceA)
+			keyB := consentKey(tc.subjectB, tc.clientIDB, tc.resourceB)
+			if keyA == keyB {
+				t.Errorf("collision: two different triples share key %q", keyA)
 			}
 		})
 	}

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"fmt"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,10 +10,17 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/radiergummi/cetacean/internal/auth"
-	"github.com/radiergummi/cetacean/internal/config"
 )
+
+// testConsentTTL is long enough that no test crosses it by accident; the tests
+// that care about lapsing set their own.
+const testConsentTTL = 2160 * time.Hour
+
+// keyFor builds the approval identity the store is keyed on. Tests name the
+// triple positionally; production code passes a ConsentKey it built by field.
+func keyFor(subject, clientID, resource string) ConsentKey {
+	return ConsentKey{Subject: subject, ClientID: clientID, Resource: resource}
+}
 
 func TestConsentFingerprintIgnoresRedirectURIOrder(t *testing.T) {
 	// CIMD documents are client-controlled and array order carries no meaning,
@@ -126,17 +132,17 @@ const (
 )
 
 func TestConsentStoreRemembersAnApproval(t *testing.T) {
-	s := NewConsentStore()
-	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+	s := NewConsentStore(testConsentTTL)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
 
-	if !s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+	if !s.Allows(keyFor(testSubject, testClientID, testResource), testFingerprint) {
 		t.Error("a remembered approval should be allowed")
 	}
 }
 
 func TestConsentStoreRequiresAnExactMatch(t *testing.T) {
-	s := NewConsentStore()
-	s.Remember(testSubject, testClientID, testResource, testFingerprint)
+	s := NewConsentStore(testConsentTTL)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
 
 	tests := []struct {
 		name                                     string
@@ -168,7 +174,7 @@ func TestConsentStoreRequiresAnExactMatch(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if s.Allows(tc.subject, tc.clientID, tc.resource, tc.fingerprint) {
+			if s.Allows(keyFor(tc.subject, tc.clientID, tc.resource), tc.fingerprint) {
 				t.Error("a non-matching request should re-prompt")
 			}
 		})
@@ -176,39 +182,39 @@ func TestConsentStoreRequiresAnExactMatch(t *testing.T) {
 }
 
 func TestConsentStoreReplacesAStaleRecord(t *testing.T) {
-	s := NewConsentStore()
-	s.Remember(testSubject, testClientID, testResource, "fingerprint-a")
-	s.Remember(testSubject, testClientID, testResource, "fingerprint-b")
+	s := NewConsentStore(testConsentTTL)
+	s.Remember(keyFor(testSubject, testClientID, testResource), "fingerprint-a")
+	s.Remember(keyFor(testSubject, testClientID, testResource), "fingerprint-b")
 
 	// A user must never hold two live approvals for one client, one of which
 	// they no longer remember granting.
 	if got := len(s.Snapshot()); got != 1 {
 		t.Errorf("records = %d, want the stale one replaced", got)
 	}
-	if s.Allows(testSubject, testClientID, testResource, "fingerprint-a") {
+	if s.Allows(keyFor(testSubject, testClientID, testResource), "fingerprint-a") {
 		t.Error("the replaced approval should no longer be allowed")
 	}
 }
 
 func TestConsentStoreForgets(t *testing.T) {
-	s := NewConsentStore()
-	s.Remember(testSubject, testClientID, testResource, testFingerprint)
-	s.Forget(testSubject, testClientID, testResource)
+	s := NewConsentStore(testConsentTTL)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
+	s.Forget(keyFor(testSubject, testClientID, testResource))
 
-	if s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+	if s.Allows(keyFor(testSubject, testClientID, testResource), testFingerprint) {
 		t.Error("a forgotten approval should re-prompt")
 	}
 }
 
 func TestConsentStoreNotifiesOnlyOnRealChanges(t *testing.T) {
-	s := NewConsentStore()
+	s := NewConsentStore(testConsentTTL)
 
 	var writes int
 	s.SetOnChange(func() { writes++ })
 
-	s.Remember(testSubject, testClientID, testResource, testFingerprint)
-	s.Remember(testSubject, testClientID, testResource, testFingerprint) // identical
-	s.Forget(testSubject, "https://unknown.example/client.json", testResource)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint) // identical
+	s.Forget(keyFor(testSubject, "https://unknown.example/client.json", testResource))
 
 	// Re-approving an unchanged client and forgetting an unknown one change
 	// nothing, and a whole-file rewrite for each would be work for no reason.
@@ -218,9 +224,9 @@ func TestConsentStoreNotifiesOnlyOnRealChanges(t *testing.T) {
 }
 
 func TestConsentStoreSnapshotIsDeterministic(t *testing.T) {
-	s := NewConsentStore()
-	s.Remember("b@example.com", testClientID, testResource, testFingerprint)
-	s.Remember("a@example.com", testClientID, testResource, testFingerprint)
+	s := NewConsentStore(testConsentTTL)
+	s.Remember(keyFor("b@example.com", testClientID, testResource), testFingerprint)
+	s.Remember(keyFor("a@example.com", testClientID, testResource), testFingerprint)
 
 	// Map iteration order is random; an unsorted snapshot would rewrite the
 	// file with reordered records on every unrelated change.
@@ -239,21 +245,19 @@ func TestConsentStoreSnapshotIsDeterministic(t *testing.T) {
 }
 
 func TestConsentStoreRestoreReplacesState(t *testing.T) {
-	s := NewConsentStore()
-	s.Remember("stale@example.com", testClientID, testResource, testFingerprint)
+	s := NewConsentStore(testConsentTTL)
+	s.Remember(keyFor("stale@example.com", testClientID, testResource), testFingerprint)
 
 	s.Restore([]ConsentRecord{{
-		Subject:     testSubject,
-		ClientID:    testClientID,
-		Resource:    testResource,
+		ConsentKey:  keyFor(testSubject, testClientID, testResource),
 		Fingerprint: testFingerprint,
 		GrantedAt:   time.Now(),
 	}})
 
-	if s.Allows("stale@example.com", testClientID, testResource, testFingerprint) {
+	if s.Allows(keyFor("stale@example.com", testClientID, testResource), testFingerprint) {
 		t.Error("Restore should replace state, not merge into it")
 	}
-	if !s.Allows(testSubject, testClientID, testResource, testFingerprint) {
+	if !s.Allows(keyFor(testSubject, testClientID, testResource), testFingerprint) {
 		t.Error("the restored record should be allowed")
 	}
 }
@@ -284,8 +288,8 @@ func TestConsentKeySeparatesFields(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			keyA := consentKey(tc.subjectA, tc.clientIDA, tc.resourceA)
-			keyB := consentKey(tc.subjectB, tc.clientIDB, tc.resourceB)
+			keyA := keyFor(tc.subjectA, tc.clientIDA, tc.resourceA).hash()
+			keyB := keyFor(tc.subjectB, tc.clientIDB, tc.resourceB).hash()
 			if keyA == keyB {
 				t.Errorf("collision: two different triples share key %q", keyA)
 			}
@@ -296,24 +300,13 @@ func TestConsentKeySeparatesFields(t *testing.T) {
 func TestConsentSurvivesRestart(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
-	cfg := ServerConfig{
-		Issuer:      "https://cetacean.test",
-		MCPResource: testResource,
-		MCP: config.MCPConfig{
-			AccessTokenTTL:  time.Hour,
-			RefreshTokenTTL: 720 * time.Hour,
-		},
-		SigningKey:     []byte("test-signing-key-32bytes-padded!!"),
-		TokenStorePath: path,
-	}
-
-	before := NewServer(cfg)
-	before.consent.Remember(testSubject, testClientID, testResource, testFingerprint)
+	before := newPersistingServer(t, path, testResource)
+	before.consent.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
 
 	// A second Server over the same path stands in for the process restarting.
-	after := NewServer(cfg)
+	after := newPersistingServer(t, path, testResource)
 
-	if !after.consent.Allows(testSubject, testClientID, testResource, testFingerprint) {
+	if !after.consent.Allows(keyFor(testSubject, testClientID, testResource), testFingerprint) {
 		t.Fatal("an approval granted before the restart should still be allowed")
 	}
 }
@@ -321,12 +314,9 @@ func TestConsentSurvivesRestart(t *testing.T) {
 func TestConsentIsWrittenThrough(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
-	consent := NewConsentStore()
-	tokens := NewRefreshTokenStore()
-	file := &stateFile{path: path, tokens: tokens, consent: consent}
-	consent.SetOnChange(file.write)
+	consent := persisting(NewRefreshTokenStore(), path)
 
-	consent.Remember(testSubject, testClientID, testResource, testFingerprint)
+	consent.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
 
 	state, err := readState(path)
 	if err != nil {
@@ -349,7 +339,7 @@ func consentServer(t *testing.T) (*Server, string) {
 	t.Helper()
 
 	s := newTestServer(t)
-	s.consent.Remember(testSubject, testClientID, s.cfg.MCPResource, testFingerprint)
+	s.consent.Remember(keyFor(testSubject, testClientID, s.cfg.MCPResource), testFingerprint)
 
 	token := s.refreshTokens.Issue(RefreshTokenData{
 		Subject:  testSubject,
@@ -372,12 +362,12 @@ func TestRevocationClearsConsent(t *testing.T) {
 	// A record outliving revocation degrades revoke into "grant one more
 	// silent re-authorization", which is worse than not revoking, because it
 	// appears to have worked.
-	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+	if s.consent.Allows(keyFor(testSubject, testClientID, s.cfg.MCPResource), testFingerprint) {
 		t.Error("revocation should have cleared the approval")
 	}
 }
 
-func TestTheftClearsConsent(t *testing.T) {
+func TestTheftResultNamesTheBurnedFamily(t *testing.T) {
 	s, token := consentServer(t)
 
 	rotated := s.refreshTokens.Rotate(token, time.Hour)
@@ -389,19 +379,18 @@ func TestTheftClearsConsent(t *testing.T) {
 	if !replay.Theft {
 		t.Fatal("re-presenting a consumed token should be detected as theft")
 	}
-	if replay.Data.Subject != testSubject {
-		t.Fatalf("theft result should name the burned family, got subject %q", replay.Data.Subject)
-	}
-	s.consent.Forget(replay.Data.Subject, replay.Data.ClientID, replay.Data.Resource)
 
-	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
-		t.Error("a burned grant family should not leave a silent re-grant behind")
+	// Naming the burned family is what lets the caller clear its approval; the
+	// handler that does so is covered by TestTheftAtTheTokenEndpointClearsConsent.
+	want := keyFor(testSubject, testClientID, s.cfg.MCPResource)
+	if got := replay.Data.ConsentKey(); got != want {
+		t.Errorf("theft result should name the burned family, got %+v", got)
 	}
 }
 
 func TestExpiryDoesNotClearConsent(t *testing.T) {
 	s := newTestServer(t)
-	s.consent.Remember(testSubject, testClientID, s.cfg.MCPResource, testFingerprint)
+	s.consent.Remember(keyFor(testSubject, testClientID, s.cfg.MCPResource), testFingerprint)
 
 	expired := s.refreshTokens.Issue(RefreshTokenData{
 		Subject:  testSubject,
@@ -414,8 +403,169 @@ func TestExpiryDoesNotClearConsent(t *testing.T) {
 	}
 
 	// Consent outliving the refresh token is the entire point of the feature.
-	if !s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+	if !s.consent.Allows(keyFor(testSubject, testClientID, s.cfg.MCPResource), testFingerprint) {
 		t.Error("expiry must not clear consent")
+	}
+}
+
+// grantedAt rewinds a remembered approval's grant time, standing in for one
+// recorded that long ago. The store has no clock to inject and Remember always
+// stamps time.Now(), so the record is edited in place.
+//
+// Deliberately not a Snapshot/Restore round-trip: Restore prunes what has
+// lapsed, so aging a record that way would leave the store empty and the test
+// would pass on the record being *absent* rather than on Allows judging it
+// expired. Restore's pruning has its own test.
+func grantedAt(t *testing.T, s *ConsentStore, age time.Duration) {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.records) == 0 {
+		t.Fatal("nothing to age")
+	}
+
+	for hash, record := range s.records {
+		record.GrantedAt = time.Now().Add(-age)
+		s.records[hash] = record
+	}
+}
+
+func TestLapsedApprovalIsNotHonoured(t *testing.T) {
+	s := NewConsentStore(time.Hour)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
+
+	// An approval is only revocable by presenting a token from its grant
+	// family. That family is torn down when its refresh token expires, so
+	// without a lease of its own the record would outlive the only handle
+	// anyone had on it and keep authorizing silently, forever.
+	grantedAt(t, s, 2*time.Hour)
+
+	if s.Allows(keyFor(testSubject, testClientID, testResource), testFingerprint) {
+		t.Error("an approval past its lease must not skip the consent page")
+	}
+}
+
+func TestApprovalWithinItsLeaseIsHonoured(t *testing.T) {
+	s := NewConsentStore(24 * time.Hour)
+	s.Remember(keyFor(testSubject, testClientID, testResource), testFingerprint)
+
+	// The lease has to outlive the refresh token or the feature is pointless:
+	// not re-prompting once the token expires is the whole reason to remember.
+	grantedAt(t, s, 23*time.Hour)
+
+	if !s.Allows(keyFor(testSubject, testClientID, testResource), testFingerprint) {
+		t.Error("an approval inside its lease should still be honoured")
+	}
+}
+
+func TestRestorePrunesLapsedApprovals(t *testing.T) {
+	s := NewConsentStore(time.Hour)
+
+	fresh := keyFor("fresh@example.com", testClientID, testResource)
+	stale := keyFor("stale@example.com", testClientID, testResource)
+
+	s.Restore([]ConsentRecord{
+		{ConsentKey: fresh, Fingerprint: testFingerprint, GrantedAt: time.Now()},
+		{
+			ConsentKey:  stale,
+			Fingerprint: testFingerprint,
+			GrantedAt:   time.Now().Add(-2 * time.Hour),
+		},
+	})
+
+	// Allows refuses a lapsed record but leaves it in place, so Restore is the
+	// only thing that stops the file accumulating records that can never
+	// authorize anything again.
+	if got := len(s.Snapshot()); got != 1 {
+		t.Errorf("records after restore = %d, want only the unexpired one", got)
+	}
+	if !s.Allows(fresh, testFingerprint) {
+		t.Error("the unexpired record should have survived")
+	}
+	if s.Allows(stale, testFingerprint) {
+		t.Error("the lapsed record should have been pruned")
+	}
+}
+
+func TestReapprovalRenewsTheLease(t *testing.T) {
+	s := NewConsentStore(time.Hour)
+	key := keyFor(testSubject, testClientID, testResource)
+
+	s.Remember(key, testFingerprint)
+	grantedAt(t, s, 2*time.Hour)
+
+	// Re-approving skips the write when nothing changed. A lapsed record has
+	// changed in the one way that matters, so the short-circuit must not
+	// swallow the renewal.
+	s.Remember(key, testFingerprint)
+
+	if !s.Allows(key, testFingerprint) {
+		t.Error("re-approving a lapsed client should renew its lease")
+	}
+}
+
+func TestZeroTTLDisablesRemembering(t *testing.T) {
+	s := NewConsentStore(0)
+	key := keyFor(testSubject, testClientID, testResource)
+
+	var writes int
+	s.SetOnChange(func() { writes++ })
+
+	s.Remember(key, testFingerprint)
+
+	if s.Allows(key, testFingerprint) {
+		t.Error("a disabled store must never skip the consent page")
+	}
+	if got := len(s.Snapshot()); got != 0 {
+		t.Errorf("records = %d, want none recorded while disabled", got)
+	}
+	if writes != 0 {
+		t.Errorf("writes = %d, want none: nothing durable changed", writes)
+	}
+}
+
+func TestDisabledConsentAlwaysPromptsThroughTheServer(t *testing.T) {
+	s, clientID, redirectURI, meta := cimdServer(t)
+	s.consent = NewConsentStore(0)
+
+	// Even a record that matches on every field must not skip the page once an
+	// operator has turned remembering off.
+	s.consent.Restore([]ConsentRecord{{
+		ConsentKey:  keyFor(testSubject, clientID, s.cfg.MCPResource),
+		Fingerprint: consentFingerprint(meta),
+		GrantedAt:   time.Now(),
+	}})
+
+	w := authorizeGET(t, s, clientID, redirectURI)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (the consent page)", w.Code, http.StatusOK)
+	}
+}
+
+func TestConsentPageStatesTheLease(t *testing.T) {
+	s, clientID, redirectURI, _ := cimdServer(t)
+	s.consent = NewConsentStore(48 * time.Hour)
+
+	body := authorizeGET(t, s, clientID, redirectURI).Body.String()
+
+	// The page has to describe the lease it is actually offering, not an
+	// open-ended promise it no longer keeps.
+	if !strings.Contains(body, "2 days") {
+		t.Errorf("consent page should state how long the approval lasts, got:\n%s", body)
+	}
+}
+
+func TestConsentPageOmitsTheLeaseWhenDisabled(t *testing.T) {
+	s, clientID, redirectURI, _ := cimdServer(t)
+	s.consent = NewConsentStore(0)
+
+	body := authorizeGET(t, s, clientID, redirectURI).Body.String()
+
+	if strings.Contains(body, "will be remembered") {
+		t.Errorf("a disabled store must not promise to remember, got:\n%s", body)
 	}
 }
 
@@ -468,16 +618,7 @@ func TestVersion1FileLoadsWithoutConsent(t *testing.T) {
 	}
 
 	// Drive the load path an upgrading operator's restart actually takes.
-	s := NewServer(ServerConfig{
-		Issuer:      "https://cetacean.test",
-		MCPResource: testResource,
-		MCP: config.MCPConfig{
-			AccessTokenTTL:  time.Hour,
-			RefreshTokenTTL: 720 * time.Hour,
-		},
-		SigningKey:     []byte("test-signing-key-32bytes-padded!!"),
-		TokenStorePath: path,
-	})
+	s := newPersistingServer(t, path, testResource)
 
 	data, ok := s.refreshTokens.Validate(raw)
 	if !ok {
@@ -504,21 +645,15 @@ func authorizeGET(
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
-	target := "/oauth/authorize?" + url.Values{
-		"response_type":         {"code"},
-		"client_id":             {clientID},
-		"redirect_uri":          {redirectURI},
-		"code_challenge":        {computeS256Challenge(authorizeVerifier)},
-		"code_challenge_method": {"S256"},
-		"state":                 {"xyz"},
-		"resource":              {s.cfg.MCPResource},
-	}.Encode()
+	target := authorizeURL(
+		clientID,
+		redirectURI,
+		computeS256Challenge(authorizeVerifier),
+		"xyz",
+		s.cfg.MCPResource,
+	)
 
-	req := httptest.NewRequest(http.MethodGet, target, nil)
-	req = req.WithContext(auth.ContextWithIdentity(req.Context(), &auth.Identity{
-		Subject:  testSubject,
-		Provider: "none",
-	}))
+	req := withIdentity(httptest.NewRequest(http.MethodGet, target, nil), testSubject, "")
 
 	w := httptest.NewRecorder()
 	s.HandleAuthorize(w, req)
@@ -557,7 +692,7 @@ func cimdServer(t *testing.T) (srv *Server, clientID, redirectURI string, meta *
 
 func TestApprovedClientSkipsTheConsentPage(t *testing.T) {
 	s, clientID, redirectURI, meta := cimdServer(t)
-	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(meta))
+	s.consent.Remember(keyFor(testSubject, clientID, s.cfg.MCPResource), consentFingerprint(meta))
 
 	w := authorizeGET(t, s, clientID, redirectURI)
 
@@ -582,7 +717,7 @@ func TestChangedMetadataRePrompts(t *testing.T) {
 
 	// An approval granted against different metadata than the client now
 	// publishes must not carry over.
-	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, "fingerprint-from-before")
+	s.consent.Remember(keyFor(testSubject, clientID, s.cfg.MCPResource), "fingerprint-from-before")
 
 	w := authorizeGET(t, s, clientID, redirectURI)
 
@@ -609,10 +744,11 @@ func TestDynamicallyRegisteredClientNeverSkipsTheConsentPage(t *testing.T) {
 	// Seed a record that matches on every field. It must still be ignored:
 	// a DCR client's metadata is self-reported, so a fingerprint over it
 	// proves nothing about who the client is.
-	s.consent.Remember(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(&ClientMetadata{
+	fingerprint := consentFingerprint(&ClientMetadata{
 		ClientName:   "Self-Registered CLI",
 		RedirectURIs: []string{redirectURI},
-	}))
+	})
+	s.consent.Remember(keyFor(testSubject, clientID, s.cfg.MCPResource), fingerprint)
 
 	w := authorizeGET(t, s, clientID, redirectURI)
 
@@ -632,50 +768,11 @@ func approvePOST(
 	t *testing.T,
 	s *Server,
 	page *httptest.ResponseRecorder,
-	clientID, redirectURI string,
 	overrides url.Values,
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
-	body := page.Body.String()
-
-	form := url.Values{
-		"decision":              {"approve"},
-		"response_type":         {"code"},
-		"client_id":             {clientID},
-		"redirect_uri":          {redirectURI},
-		"code_challenge":        {computeS256Challenge(authorizeVerifier)},
-		"code_challenge_method": {"S256"},
-		"state":                 {"xyz"},
-		"resource":              {s.cfg.MCPResource},
-		"csrf_token":            {extractHiddenField(body, "csrf_token")},
-		consentFingerprintField: {extractHiddenField(body, consentFingerprintField)},
-	}
-
-	maps.Copy(form, overrides)
-
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/oauth/authorize",
-		strings.NewReader(form.Encode()),
-	)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	for _, cookie := range page.Result().Cookies() {
-		if cookie.Name == csrfCookieName {
-			req.AddCookie(cookie)
-		}
-	}
-
-	req = req.WithContext(auth.ContextWithIdentity(req.Context(), &auth.Identity{
-		Subject:  testSubject,
-		Provider: "none",
-	}))
-
-	w := httptest.NewRecorder()
-	s.HandleAuthorize(w, req)
-
-	return w
+	return submitConsent(t, s, page, "approve", testSubject, "", overrides)
 }
 
 // redirectedCode returns the authorization code from a recorded redirect.
@@ -698,7 +795,7 @@ func TestApprovingThroughTheConsentPageIsRemembered(t *testing.T) {
 		t.Fatalf("GET status = %d, want the consent page: %s", page.Code, page.Body.String())
 	}
 
-	approved := approvePOST(t, s, page, clientID, redirectURI, nil)
+	approved := approvePOST(t, s, page, nil)
 	if approved.Code != http.StatusFound {
 		t.Fatalf("POST status = %d, want %d: %s",
 			approved.Code, http.StatusFound, approved.Body.String())
@@ -710,7 +807,8 @@ func TestApprovingThroughTheConsentPageIsRemembered(t *testing.T) {
 	// The wiring under test: the approve handler must write the record, not
 	// merely issue a code. Seeding the store directly would prove nothing
 	// about whether the endpoint ever calls Remember.
-	if !s.consent.Allows(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(meta)) {
+	approval := keyFor(testSubject, clientID, s.cfg.MCPResource)
+	if !s.consent.Allows(approval, consentFingerprint(meta)) {
 		t.Fatal("approving through the consent page recorded no approval")
 	}
 
@@ -769,7 +867,7 @@ func TestTheftAtTheTokenEndpointClearsConsent(t *testing.T) {
 
 	// A replayed token burned the family. Silently re-granting on the next
 	// authorize is exactly wrong.
-	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+	if s.consent.Allows(keyFor(testSubject, testClientID, s.cfg.MCPResource), testFingerprint) {
 		t.Error("a replayed refresh token should have cleared the approval")
 	}
 }
@@ -819,7 +917,7 @@ func TestMetadataChangedMidFlowRePrompts(t *testing.T) {
 	s.cimd.cache = nil
 	s.cimd.mu.Unlock()
 
-	stale := approvePOST(t, s, page, documentURL, redirectURI, nil)
+	stale := approvePOST(t, s, page, nil)
 
 	if stale.Code != http.StatusOK {
 		t.Fatalf("POST status = %d, want the consent page again: %s",
@@ -834,7 +932,7 @@ func TestMetadataChangedMidFlowRePrompts(t *testing.T) {
 
 	// The re-prompt must be usable: a fresh nonce bound to the new
 	// fingerprint, so approving it goes through.
-	confirmed := approvePOST(t, s, stale, documentURL, redirectURI, nil)
+	confirmed := approvePOST(t, s, stale, nil)
 	if confirmed.Code != http.StatusFound {
 		t.Fatalf("re-approval status = %d, want %d: %s",
 			confirmed.Code, http.StatusFound, confirmed.Body.String())
@@ -844,12 +942,8 @@ func TestMetadataChangedMidFlowRePrompts(t *testing.T) {
 	current := published
 	mu.Unlock()
 
-	if !s.consent.Allows(
-		testSubject,
-		documentURL,
-		s.cfg.MCPResource,
-		consentFingerprint(&current),
-	) {
+	approval := keyFor(testSubject, documentURL, s.cfg.MCPResource)
+	if !s.consent.Allows(approval, consentFingerprint(&current)) {
 		t.Error("approving the second prompt should record the metadata it displayed")
 	}
 }
@@ -865,7 +959,7 @@ func TestTamperedFingerprintFailsCSRF(t *testing.T) {
 	// The fingerprint is not a secret and rides in a hidden field; the CSRF
 	// HMAC is what makes it unforgeable. Swapping it must not merely
 	// re-prompt — it must fail the token check outright.
-	tampered := approvePOST(t, s, page, clientID, redirectURI, url.Values{
+	tampered := approvePOST(t, s, page, url.Values{
 		consentFingerprintField: {"a-fingerprint-the-user-never-saw"},
 	})
 

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -1,0 +1,83 @@
+package oauth
+
+import (
+	"testing"
+)
+
+func TestConsentFingerprintIgnoresRedirectURIOrder(t *testing.T) {
+	// CIMD documents are client-controlled and array order carries no meaning,
+	// so re-prompting on a reordering would be noise.
+	a := consentFingerprint(&ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"http://localhost:1/cb", "http://localhost:2/cb"},
+	})
+	b := consentFingerprint(&ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"http://localhost:2/cb", "http://localhost:1/cb"},
+	})
+
+	if a != b {
+		t.Errorf("reordering redirect_uris changed the fingerprint: %q vs %q", a, b)
+	}
+}
+
+func TestConsentFingerprintChangesWithTheDecision(t *testing.T) {
+	base := &ClientMetadata{
+		ClientName:   "Acme CLI",
+		RedirectURIs: []string{"http://localhost:1/cb"},
+	}
+	baseline := consentFingerprint(base)
+
+	tests := []struct {
+		name string
+		meta *ClientMetadata
+	}{
+		{
+			name: "renamed",
+			meta: &ClientMetadata{
+				ClientName:   "Totally Different",
+				RedirectURIs: []string{"http://localhost:1/cb"},
+			},
+		},
+		{
+			name: "redirect uri added",
+			meta: &ClientMetadata{
+				ClientName:   "Acme CLI",
+				RedirectURIs: []string{"http://localhost:1/cb", "http://evil.example/cb"},
+			},
+		},
+		{
+			name: "redirect uri removed",
+			meta: &ClientMetadata{
+				ClientName:   "Acme CLI",
+				RedirectURIs: nil,
+			},
+		},
+		{
+			name: "redirect uri edited",
+			meta: &ClientMetadata{
+				ClientName:   "Acme CLI",
+				RedirectURIs: []string{"http://localhost:1/cb2"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := consentFingerprint(tc.meta); got == baseline {
+				t.Error("fingerprint did not change, so a stale approval would carry over")
+			}
+		})
+	}
+}
+
+func TestConsentFingerprintSeparatesFields(t *testing.T) {
+	// Without a separator between the name and the URIs, ("ab", "c") and
+	// ("a", "bc") would hash alike and one client could impersonate another.
+	a := consentFingerprint(&ClientMetadata{ClientName: "ab", RedirectURIs: []string{"c"}})
+	b := consentFingerprint(&ClientMetadata{ClientName: "a", RedirectURIs: []string{"bc"}})
+
+	if a == b {
+		t.Error("concatenation collision: two different clients share a fingerprint")
+	}
+}

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -1,7 +1,11 @@
 package oauth
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -332,6 +336,82 @@ func TestConsentIsWrittenThrough(t *testing.T) {
 	}
 	if state.Consent[0].Fingerprint != testFingerprint {
 		t.Errorf("fingerprint = %q", state.Consent[0].Fingerprint)
+	}
+}
+
+// consentServer builds a Server with a memory-only state file and one
+// remembered approval for the token it returns.
+func consentServer(t *testing.T) (*Server, string) {
+	t.Helper()
+
+	s := newTestServer(t)
+	s.consent.Remember(testSubject, testClientID, s.cfg.MCPResource, testFingerprint)
+
+	token := s.refreshTokens.Issue(RefreshTokenData{
+		Subject:  testSubject,
+		ClientID: testClientID,
+		Resource: s.cfg.MCPResource,
+	}, time.Hour)
+
+	return s, token
+}
+
+func TestRevocationClearsConsent(t *testing.T) {
+	s, token := consentServer(t)
+
+	form := url.Values{"token": {token}}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/revoke", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.HandleRevoke(rec, req)
+
+	// A record outliving revocation degrades revoke into "grant one more
+	// silent re-authorization", which is worse than not revoking, because it
+	// appears to have worked.
+	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("revocation should have cleared the approval")
+	}
+}
+
+func TestTheftClearsConsent(t *testing.T) {
+	s, token := consentServer(t)
+
+	rotated := s.refreshTokens.Rotate(token, time.Hour)
+	if !rotated.OK {
+		t.Fatal("the first rotation should succeed")
+	}
+
+	replay := s.refreshTokens.Rotate(token, time.Hour)
+	if !replay.Theft {
+		t.Fatal("re-presenting a consumed token should be detected as theft")
+	}
+	if replay.Data.Subject != testSubject {
+		t.Fatalf("theft result should name the burned family, got subject %q", replay.Data.Subject)
+	}
+	s.consent.Forget(replay.Data.Subject, replay.Data.ClientID, replay.Data.Resource)
+
+	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("a burned grant family should not leave a silent re-grant behind")
+	}
+}
+
+func TestExpiryDoesNotClearConsent(t *testing.T) {
+	s := newTestServer(t)
+	s.consent.Remember(testSubject, testClientID, s.cfg.MCPResource, testFingerprint)
+
+	expired := s.refreshTokens.Issue(RefreshTokenData{
+		Subject:  testSubject,
+		ClientID: testClientID,
+		Resource: s.cfg.MCPResource,
+	}, -time.Second)
+
+	if s.refreshTokens.Rotate(expired, time.Hour).OK {
+		t.Fatal("an expired token should not rotate")
+	}
+
+	// Consent outliving the refresh token is the entire point of the feature.
+	if !s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("expiry must not clear consent")
 	}
 }
 

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -1,8 +1,11 @@
 package oauth
 
 import (
+	"os"
 	"testing"
 	"time"
+
+	"github.com/radiergummi/cetacean/internal/config"
 )
 
 func TestConsentFingerprintIgnoresRedirectURIOrder(t *testing.T) {
@@ -279,5 +282,74 @@ func TestConsentKeySeparatesFields(t *testing.T) {
 				t.Errorf("collision: two different triples share key %q", keyA)
 			}
 		})
+	}
+}
+
+func TestConsentSurvivesRestart(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	cfg := ServerConfig{
+		Issuer:      "https://cetacean.test",
+		MCPResource: testResource,
+		MCP: config.MCPConfig{
+			AccessTokenTTL:  time.Hour,
+			RefreshTokenTTL: 720 * time.Hour,
+		},
+		SigningKey:     []byte("test-signing-key-32bytes-padded!!"),
+		TokenStorePath: path,
+	}
+
+	before := NewServer(cfg)
+	before.consent.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	// A second Server over the same path stands in for the process restarting.
+	after := NewServer(cfg)
+
+	if !after.consent.Allows(testSubject, testClientID, testResource, testFingerprint) {
+		t.Fatal("an approval granted before the restart should still be allowed")
+	}
+}
+
+func TestConsentIsWrittenThrough(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	consent := NewConsentStore()
+	tokens := NewRefreshTokenStore()
+	file := &stateFile{path: path, tokens: tokens, consent: consent}
+	consent.SetOnChange(file.write)
+
+	consent.Remember(testSubject, testClientID, testResource, testFingerprint)
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if state.Version != oauthStateVersion {
+		t.Errorf("version = %d, want %d", state.Version, oauthStateVersion)
+	}
+	if len(state.Consent) != 1 {
+		t.Fatalf("consent records on disk = %d, want 1", len(state.Consent))
+	}
+	if state.Consent[0].Fingerprint != testFingerprint {
+		t.Errorf("fingerprint = %q", state.Consent[0].Fingerprint)
+	}
+}
+
+func TestVersion1FileLoadsWithoutConsent(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	// A file written before consent records existed. It must load, not error:
+	// an operator upgrading should keep their refresh tokens.
+	v1 := []byte(`{"version":1,"tokens":{},"consumed":{},"grants":{}}`)
+	if err := os.WriteFile(path, v1, 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("a v1 file should still load: %v", err)
+	}
+	if len(state.Consent) != 0 {
+		t.Errorf("consent records = %d, want none", len(state.Consent))
 	}
 }

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -1010,3 +1010,34 @@ func TestConsentPageDisclosesRemembering(t *testing.T) {
 		t.Error("a DCR client's approval is never remembered, so the page must not say it is")
 	}
 }
+
+func TestIssueCodeRefusesAnUnregisteredRedirect(t *testing.T) {
+	s := newTestServer(t)
+	meta := &ClientMetadata{RedirectURIs: []string{"https://example.com/cb"}}
+
+	// Both handlers check this before calling, so reaching the helper with an
+	// unregistered target means a caller lost the guard. The helper is the
+	// sink for an open redirect on an authorization endpoint, so it must
+	// refuse rather than trust that someone upstream checked.
+	w := httptest.NewRecorder()
+	s.issueCodeAndRedirect(
+		w,
+		httptest.NewRequest(http.MethodGet, "/oauth/authorize", nil),
+		meta,
+		AuthCodeData{
+			ClientID:    testClientID,
+			RedirectURI: "https://attacker.example/cb",
+		},
+		"xyz",
+	)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if location := w.Header().Get("Location"); location != "" {
+		t.Errorf("redirected to an unregistered URI: %s", location)
+	}
+	if strings.Contains(w.Body.String(), "code=") {
+		t.Error("an authorization code was minted for an unregistered redirect")
+	}
+}

--- a/internal/mcp/oauth/consent_store_test.go
+++ b/internal/mcp/oauth/consent_store_test.go
@@ -1,11 +1,14 @@
 package oauth
 
 import (
+	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -419,10 +422,40 @@ func TestExpiryDoesNotClearConsent(t *testing.T) {
 func TestVersion1FileLoadsWithoutConsent(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
-	// A file written before consent records existed. It must load, not error:
-	// an operator upgrading should keep their refresh tokens.
-	v1 := []byte(`{"version":1,"tokens":{},"consumed":{},"grants":{}}`)
-	if err := os.WriteFile(path, v1, 0600); err != nil {
+	// A file written before consent records existed, holding a live refresh
+	// token. The token is what makes this fixture worth having: v2 moved
+	// tokens, consumed and grants into an embedded RefreshTokenSnapshot, and
+	// an embedding that nested them under a key instead of flattening would
+	// drop every operator's refresh tokens on upgrade. An empty token map
+	// cannot see that, because the round-trip helpers are symmetric and would
+	// round-trip a nested shape just as happily.
+	const raw = "v1-fixture-refresh-token"
+
+	now := time.Now().UTC()
+	expiry := now.Add(time.Hour).Format(time.RFC3339Nano)
+
+	v1 := fmt.Sprintf(`{
+  "version": 1,
+  "timestamp": %q,
+  "tokens": {
+    %q: {
+      "subject": %q,
+      "clientId": %q,
+      "resource": %q,
+      "grantId": "v1-grant",
+      "expiresAt": %q,
+      "grantExpiresAt": %q
+    }
+  },
+  "consumed": {},
+  "grants": {"v1-grant": [%q]}
+}`,
+		now.Format(time.RFC3339Nano),
+		hashToken(raw), testSubject, testClientID, testResource, expiry, expiry,
+		hashToken(raw),
+	)
+
+	if err := os.WriteFile(path, []byte(v1), 0600); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
 
@@ -433,7 +466,34 @@ func TestVersion1FileLoadsWithoutConsent(t *testing.T) {
 	if len(state.Consent) != 0 {
 		t.Errorf("consent records = %d, want none", len(state.Consent))
 	}
+
+	// Drive the load path an upgrading operator's restart actually takes.
+	s := NewServer(ServerConfig{
+		Issuer:      "https://cetacean.test",
+		MCPResource: testResource,
+		MCP: config.MCPConfig{
+			AccessTokenTTL:  time.Hour,
+			RefreshTokenTTL: 720 * time.Hour,
+		},
+		SigningKey:     []byte("test-signing-key-32bytes-padded!!"),
+		TokenStorePath: path,
+	})
+
+	data, ok := s.refreshTokens.Validate(raw)
+	if !ok {
+		t.Fatal("a v1 refresh token must still validate after the upgrade")
+	}
+	if data.Subject != testSubject {
+		t.Errorf("subject = %q, want %q", data.Subject, testSubject)
+	}
+	if data.ClientID != testClientID {
+		t.Errorf("clientId = %q, want %q", data.ClientID, testClientID)
+	}
 }
+
+// authorizeVerifier is the PKCE verifier every authorize helper below derives
+// its code_challenge from, so a GET and the POST that follows it agree.
+const authorizeVerifier = "verifier-verifier-verifier-1234"
 
 // authorizeGET drives a GET /oauth/authorize for a CIMD client whose metadata
 // document is served by a local test server, and returns the response.
@@ -448,7 +508,7 @@ func authorizeGET(
 		"response_type":         {"code"},
 		"client_id":             {clientID},
 		"redirect_uri":          {redirectURI},
-		"code_challenge":        {computeS256Challenge("verifier-verifier-verifier-1234")},
+		"code_challenge":        {computeS256Challenge(authorizeVerifier)},
 		"code_challenge_method": {"S256"},
 		"state":                 {"xyz"},
 		"resource":              {s.cfg.MCPResource},
@@ -561,5 +621,298 @@ func TestDynamicallyRegisteredClientNeverSkipsTheConsentPage(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Authorization Request") {
 		t.Error("an unverified client skipped the consent page")
+	}
+}
+
+// approvePOST posts the consent form back the way a browser would: every
+// hidden field the page rendered, plus the CSRF nonce cookie it set. Passing
+// the recorded GET response rather than rebuilding the form by hand is the
+// point — a field the page stopped rendering shows up as a failure here.
+func approvePOST(
+	t *testing.T,
+	s *Server,
+	page *httptest.ResponseRecorder,
+	clientID, redirectURI string,
+	overrides url.Values,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body := page.Body.String()
+
+	form := url.Values{
+		"decision":              {"approve"},
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {computeS256Challenge(authorizeVerifier)},
+		"code_challenge_method": {"S256"},
+		"state":                 {"xyz"},
+		"resource":              {s.cfg.MCPResource},
+		"csrf_token":            {extractHiddenField(body, "csrf_token")},
+		consentFingerprintField: {extractHiddenField(body, consentFingerprintField)},
+	}
+
+	maps.Copy(form, overrides)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/oauth/authorize",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	for _, cookie := range page.Result().Cookies() {
+		if cookie.Name == csrfCookieName {
+			req.AddCookie(cookie)
+		}
+	}
+
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), &auth.Identity{
+		Subject:  testSubject,
+		Provider: "none",
+	}))
+
+	w := httptest.NewRecorder()
+	s.HandleAuthorize(w, req)
+
+	return w
+}
+
+// redirectedCode returns the authorization code from a recorded redirect.
+func redirectedCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+
+	location, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+
+	return location.Query().Get("code")
+}
+
+func TestApprovingThroughTheConsentPageIsRemembered(t *testing.T) {
+	s, clientID, redirectURI, meta := cimdServer(t)
+
+	page := authorizeGET(t, s, clientID, redirectURI)
+	if page.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want the consent page: %s", page.Code, page.Body.String())
+	}
+
+	approved := approvePOST(t, s, page, clientID, redirectURI, nil)
+	if approved.Code != http.StatusFound {
+		t.Fatalf("POST status = %d, want %d: %s",
+			approved.Code, http.StatusFound, approved.Body.String())
+	}
+	if redirectedCode(t, approved) == "" {
+		t.Fatal("no authorization code in the approval redirect")
+	}
+
+	// The wiring under test: the approve handler must write the record, not
+	// merely issue a code. Seeding the store directly would prove nothing
+	// about whether the endpoint ever calls Remember.
+	if !s.consent.Allows(testSubject, clientID, s.cfg.MCPResource, consentFingerprint(meta)) {
+		t.Fatal("approving through the consent page recorded no approval")
+	}
+
+	// And the record it wrote must be the one the skip path reads.
+	again := authorizeGET(t, s, clientID, redirectURI)
+	if again.Code != http.StatusFound {
+		t.Fatalf("second GET status = %d, want a redirect with a code", again.Code)
+	}
+	if redirectedCode(t, again) == "" {
+		t.Error("the second authorization did not carry a code")
+	}
+}
+
+// postRefreshGrant drives a refresh_token grant through the real token
+// endpoint.
+//
+// No resource parameter: when one is supplied the handler validates it against
+// the live token before rotating, so a replayed token is rejected as unknown
+// and never reaches the theft branch. RequireResourceIndicator is off in
+// newTestServer, so omitting it is a legitimate request.
+func postRefreshGrant(t *testing.T, s *Server, token string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {token},
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/oauth/token",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	s.HandleToken(w, req)
+
+	return w
+}
+
+func TestTheftAtTheTokenEndpointClearsConsent(t *testing.T) {
+	s, token := consentServer(t)
+
+	// A legitimate refresh, then a replay of the token it consumed. Both go
+	// through HandleToken on purpose: calling Rotate directly proves only that
+	// the store detects theft, not that the endpoint reacts to it.
+	if first := postRefreshGrant(t, s, token); first.Code != http.StatusOK {
+		t.Fatalf("first refresh: status = %d, want 200: %s", first.Code, first.Body.String())
+	}
+
+	replay := postRefreshGrant(t, s, token)
+	if replay.Code != http.StatusBadRequest {
+		t.Fatalf("replay: status = %d, want 400: %s", replay.Code, replay.Body.String())
+	}
+
+	// A replayed token burned the family. Silently re-granting on the next
+	// authorize is exactly wrong.
+	if s.consent.Allows(testSubject, testClientID, s.cfg.MCPResource, testFingerprint) {
+		t.Error("a replayed refresh token should have cleared the approval")
+	}
+}
+
+func TestMetadataChangedMidFlowRePrompts(t *testing.T) {
+	// The document is mutated between the GET and the POST, so the handler
+	// goroutine and the test goroutine both touch it.
+	var (
+		mu        sync.Mutex
+		published = ClientMetadata{
+			ClientName:   "Acme CLI",
+			RedirectURIs: []string{"https://example.com/cb"},
+		}
+		documentURL string
+	)
+
+	httpSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		current := published
+		mu.Unlock()
+
+		serveMetadata(documentURL, current)(w, r)
+	}))
+	t.Cleanup(httpSrv.Close)
+	documentURL = httpSrv.URL + "/client.json"
+
+	s := newTestServer(t)
+	s.cimd.Client = httpSrv.Client()
+
+	const redirectURI = "https://example.com/cb"
+
+	page := authorizeGET(t, s, documentURL, redirectURI)
+	if page.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want the consent page: %s", page.Code, page.Body.String())
+	}
+
+	// The client edits its document while the user is deciding, and the
+	// fetcher's cached copy lapses — a consent tab left open longer than an
+	// hour, a restart, an eviction. Without the fingerprint travelling from
+	// the GET, the POST would fingerprint this new document and record an
+	// approval for a client the user never saw.
+	mu.Lock()
+	published.ClientName = "Totally Different"
+	mu.Unlock()
+
+	s.cimd.mu.Lock()
+	s.cimd.cache = nil
+	s.cimd.mu.Unlock()
+
+	stale := approvePOST(t, s, page, documentURL, redirectURI, nil)
+
+	if stale.Code != http.StatusOK {
+		t.Fatalf("POST status = %d, want the consent page again: %s",
+			stale.Code, stale.Body.String())
+	}
+	if !strings.Contains(stale.Body.String(), "Totally Different") {
+		t.Error("the second prompt should describe the client as it is now")
+	}
+	if got := len(s.consent.Snapshot()); got != 0 {
+		t.Errorf("records = %d, want nothing recorded for metadata the user never saw", got)
+	}
+
+	// The re-prompt must be usable: a fresh nonce bound to the new
+	// fingerprint, so approving it goes through.
+	confirmed := approvePOST(t, s, stale, documentURL, redirectURI, nil)
+	if confirmed.Code != http.StatusFound {
+		t.Fatalf("re-approval status = %d, want %d: %s",
+			confirmed.Code, http.StatusFound, confirmed.Body.String())
+	}
+
+	mu.Lock()
+	current := published
+	mu.Unlock()
+
+	if !s.consent.Allows(
+		testSubject,
+		documentURL,
+		s.cfg.MCPResource,
+		consentFingerprint(&current),
+	) {
+		t.Error("approving the second prompt should record the metadata it displayed")
+	}
+}
+
+func TestTamperedFingerprintFailsCSRF(t *testing.T) {
+	s, clientID, redirectURI, _ := cimdServer(t)
+
+	page := authorizeGET(t, s, clientID, redirectURI)
+	if page.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want the consent page: %s", page.Code, page.Body.String())
+	}
+
+	// The fingerprint is not a secret and rides in a hidden field; the CSRF
+	// HMAC is what makes it unforgeable. Swapping it must not merely
+	// re-prompt — it must fail the token check outright.
+	tampered := approvePOST(t, s, page, clientID, redirectURI, url.Values{
+		consentFingerprintField: {"a-fingerprint-the-user-never-saw"},
+	})
+
+	if tampered.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s",
+			tampered.Code, http.StatusBadRequest, tampered.Body.String())
+	}
+	if !strings.Contains(tampered.Body.String(), "CSRF") {
+		t.Errorf("expected a CSRF failure, got: %s", tampered.Body.String())
+	}
+	if got := len(s.consent.Snapshot()); got != 0 {
+		t.Errorf("records = %d, want none", got)
+	}
+}
+
+func TestConsentPageDisclosesRemembering(t *testing.T) {
+	const disclosure = "will be remembered"
+
+	verified, clientID, redirectURI, _ := cimdServer(t)
+
+	page := authorizeGET(t, verified, clientID, redirectURI)
+	if page.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want the consent page: %s", page.Code, page.Body.String())
+	}
+
+	// Turning "approve once" into "approve until revoked" without telling the
+	// person is not consent.
+	if !strings.Contains(page.Body.String(), disclosure) {
+		t.Error("the consent page for a verified client should say the approval is remembered")
+	}
+
+	// And it must not claim so where nothing is remembered.
+	unverified := newTestServer(t)
+
+	const dcrRedirectURI = "http://127.0.0.1:1/cb"
+
+	unverified.clients.register(&ClientRegistration{
+		ClientID:     "dcr-disclosure-client",
+		ClientName:   "Self-Registered CLI",
+		RedirectURIs: []string{dcrRedirectURI},
+	})
+
+	dcrPage := authorizeGET(t, unverified, "dcr-disclosure-client", dcrRedirectURI)
+	if dcrPage.Code != http.StatusOK {
+		t.Fatalf("DCR GET status = %d, want the consent page", dcrPage.Code)
+	}
+	if strings.Contains(dcrPage.Body.String(), disclosure) {
+		t.Error("a DCR client's approval is never remembered, so the page must not say it is")
 	}
 }

--- a/internal/mcp/oauth/consent_test.go
+++ b/internal/mcp/oauth/consent_test.go
@@ -166,6 +166,13 @@ func TestConsentApproveProducesCode(t *testing.T) {
 		t.Fatal("CSRF token not found in consent page")
 	}
 
+	// The CSRF token is bound to the fingerprint of the metadata the page was
+	// rendered from, so a browser resubmitting the form must carry it back.
+	fingerprint := extractHiddenField(body, consentFingerprintField)
+	if fingerprint == "" {
+		t.Fatal("metadata fingerprint not found in consent page")
+	}
+
 	// Extract the nonce cookie set by the GET.
 	var nonceCookie *http.Cookie
 	for _, c := range getRec.Result().Cookies() {
@@ -189,6 +196,7 @@ func TestConsentApproveProducesCode(t *testing.T) {
 		"state":                 {"stateXYZ"},
 		"resource":              {s.cfg.MCPResource},
 		"csrf_token":            {csrfToken},
+		consentFingerprintField: {fingerprint},
 	}
 	postReq := httptest.NewRequest(
 		http.MethodPost,

--- a/internal/mcp/oauth/consent_test.go
+++ b/internal/mcp/oauth/consent_test.go
@@ -1,9 +1,12 @@
 package oauth
 
 import (
+	"html"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -159,55 +162,8 @@ func TestConsentApproveProducesCode(t *testing.T) {
 		t.Fatalf("GET consent: expected 200, got %d: %s", getRec.Code, getRec.Body.String())
 	}
 
-	// Extract CSRF token from the rendered form.
-	body := getRec.Body.String()
-	csrfToken := extractHiddenField(body, "csrf_token")
-	if csrfToken == "" {
-		t.Fatal("CSRF token not found in consent page")
-	}
-
-	// The CSRF token is bound to the fingerprint of the metadata the page was
-	// rendered from, so a browser resubmitting the form must carry it back.
-	fingerprint := extractHiddenField(body, consentFingerprintField)
-	if fingerprint == "" {
-		t.Fatal("metadata fingerprint not found in consent page")
-	}
-
-	// Extract the nonce cookie set by the GET.
-	var nonceCookie *http.Cookie
-	for _, c := range getRec.Result().Cookies() {
-		if c.Name == csrfCookieName {
-			nonceCookie = c
-			break
-		}
-	}
-	if nonceCookie == nil {
-		t.Fatal("CSRF nonce cookie not set")
-	}
-
-	// Step 2: POST the approval.
-	form := url.Values{
-		"decision":              {"approve"},
-		"response_type":         {"code"},
-		"client_id":             {clientID},
-		"redirect_uri":          {"http://localhost:7777/cb"},
-		"code_challenge":        {challenge},
-		"code_challenge_method": {"S256"},
-		"state":                 {"stateXYZ"},
-		"resource":              {s.cfg.MCPResource},
-		"csrf_token":            {csrfToken},
-		consentFingerprintField: {fingerprint},
-	}
-	postReq := httptest.NewRequest(
-		http.MethodPost,
-		"/oauth/authorize",
-		strings.NewReader(form.Encode()),
-	)
-	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	postReq.AddCookie(nonceCookie)
-	postReq = withIdentity(postReq, "bob", "bob@example.com")
-	postRec := httptest.NewRecorder()
-	s.HandleAuthorize(postRec, postReq)
+	// Step 2: POST the approval, resubmitting the form the page rendered.
+	postRec := submitConsent(t, s, getRec, "approve", "bob", "bob@example.com", nil)
 
 	if postRec.Code != http.StatusFound {
 		t.Fatalf("expected redirect (302), got %d: %s", postRec.Code, postRec.Body.String())
@@ -237,32 +193,65 @@ func TestConsentApproveProducesCode(t *testing.T) {
 	}
 }
 
-// extractHiddenField parses a simple hidden input value from HTML without
-// importing an HTML parser — good enough for test templates we control.
-func extractHiddenField(html, name string) string {
-	marker := `name="` + name + `" value="`
-	idx := strings.Index(html, marker)
-	if idx == -1 {
-		// Try alternate attribute order.
-		marker = `name="` + name + `"`
-		idx = strings.Index(html, marker)
-		if idx == -1 {
-			return ""
-		}
-		// Look for value=" after the name attr.
-		_, after, ok := strings.Cut(html[idx:], `value="`)
-		if !ok {
-			return ""
-		}
-		val, _, ok := strings.Cut(after, `"`)
-		if !ok {
-			return ""
-		}
-		return val
+// hiddenInputPattern matches the hidden inputs the consent template emits.
+var hiddenInputPattern = regexp.MustCompile(`<input type="hidden" name="([^"]*)" value="([^"]*)">`)
+
+// hiddenFields reads every hidden input out of a rendered form, undoing the
+// HTML escaping the template applied.
+func hiddenFields(page string) url.Values {
+	fields := url.Values{}
+	for _, match := range hiddenInputPattern.FindAllStringSubmatch(page, -1) {
+		fields.Set(match[1], html.UnescapeString(match[2]))
 	}
-	val, _, ok := strings.Cut(html[idx+len(marker):], `"`)
-	if !ok {
-		return ""
+
+	return fields
+}
+
+// consentForm rebuilds the form a browser would resubmit from a rendered
+// consent page: every hidden input the template emitted, plus the decision.
+//
+// Reading the fields back off the page rather than restating them is what keeps
+// these tests in step with the template. A field added to the form is carried
+// automatically — which is exactly what the consent fingerprint was not, having
+// cost an edit in all three places that submit this form.
+func consentForm(page, decision string, overrides url.Values) url.Values {
+	form := hiddenFields(page)
+	form.Set("decision", decision)
+	maps.Copy(form, overrides)
+
+	return form
+}
+
+// submitConsent POSTs a decision back to the authorize endpoint the way a
+// browser would: the form the page rendered, carrying the nonce cookie it set.
+func submitConsent(
+	t *testing.T,
+	s *Server,
+	page *httptest.ResponseRecorder,
+	decision, subject, email string,
+	overrides url.Values,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := consentForm(page.Body.String(), decision, overrides)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/oauth/authorize",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	for _, cookie := range page.Result().Cookies() {
+		if cookie.Name == csrfCookieName {
+			req.AddCookie(cookie)
+		}
 	}
-	return val
+
+	req = withIdentity(req, subject, email)
+
+	w := httptest.NewRecorder()
+	s.HandleAuthorize(w, req)
+
+	return w
 }

--- a/internal/mcp/oauth/issuer_test.go
+++ b/internal/mcp/oauth/issuer_test.go
@@ -39,6 +39,13 @@ func runConsent(t *testing.T, s *Server, decision string, overrides url.Values) 
 		t.Fatal("CSRF token not found in consent page")
 	}
 
+	// The CSRF token is bound to the fingerprint of the metadata the page was
+	// rendered from, so a browser resubmitting the form must carry it back.
+	fingerprint := extractHiddenField(getRec.Body.String(), consentFingerprintField)
+	if fingerprint == "" {
+		t.Fatal("metadata fingerprint not found in consent page")
+	}
+
 	var nonceCookie *http.Cookie
 	for _, cookie := range getRec.Result().Cookies() {
 		if cookie.Name == csrfCookieName {
@@ -62,6 +69,7 @@ func runConsent(t *testing.T, s *Server, decision string, overrides url.Values) 
 		"state":                 {"stateISS"},
 		"resource":              {s.cfg.MCPResource},
 		"csrf_token":            {csrfToken},
+		consentFingerprintField: {fingerprint},
 	}
 
 	maps.Copy(form, overrides)

--- a/internal/mcp/oauth/issuer_test.go
+++ b/internal/mcp/oauth/issuer_test.go
@@ -1,11 +1,9 @@
 package oauth
 
 import (
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 )
 
@@ -34,57 +32,7 @@ func runConsent(t *testing.T, s *Server, decision string, overrides url.Values) 
 		t.Fatalf("GET consent: status %d: %s", getRec.Code, getRec.Body.String())
 	}
 
-	csrfToken := extractHiddenField(getRec.Body.String(), "csrf_token")
-	if csrfToken == "" {
-		t.Fatal("CSRF token not found in consent page")
-	}
-
-	// The CSRF token is bound to the fingerprint of the metadata the page was
-	// rendered from, so a browser resubmitting the form must carry it back.
-	fingerprint := extractHiddenField(getRec.Body.String(), consentFingerprintField)
-	if fingerprint == "" {
-		t.Fatal("metadata fingerprint not found in consent page")
-	}
-
-	var nonceCookie *http.Cookie
-	for _, cookie := range getRec.Result().Cookies() {
-		if cookie.Name == csrfCookieName {
-			nonceCookie = cookie
-
-			break
-		}
-	}
-
-	if nonceCookie == nil {
-		t.Fatal("CSRF nonce cookie not set")
-	}
-
-	form := url.Values{
-		"decision":              {decision},
-		"response_type":         {"code"},
-		"client_id":             {clientID},
-		"redirect_uri":          {redirectURI},
-		"code_challenge":        {challenge},
-		"code_challenge_method": {"S256"},
-		"state":                 {"stateISS"},
-		"resource":              {s.cfg.MCPResource},
-		"csrf_token":            {csrfToken},
-		consentFingerprintField: {fingerprint},
-	}
-
-	maps.Copy(form, overrides)
-
-	postReq := httptest.NewRequest(
-		http.MethodPost,
-		"/oauth/authorize",
-		strings.NewReader(form.Encode()),
-	)
-	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	postReq.AddCookie(nonceCookie)
-	postReq = withIdentity(postReq, "bob", "bob@example.com")
-
-	postRec := httptest.NewRecorder()
-	s.HandleAuthorize(postRec, postReq)
+	postRec := submitConsent(t, s, getRec, decision, "bob", "bob@example.com", overrides)
 
 	if postRec.Code != http.StatusFound {
 		t.Fatalf("expected a redirect, got %d: %s", postRec.Code, postRec.Body.String())

--- a/internal/mcp/oauth/persist.go
+++ b/internal/mcp/oauth/persist.go
@@ -11,11 +11,11 @@ import (
 	json "github.com/goccy/go-json"
 )
 
-// refreshTokenStoreVersion is the on-disk format version. Bump it whenever the
-// shape below changes incompatibly; readRefreshTokens refuses anything newer.
-const refreshTokenStoreVersion = 1
+// oauthStateVersion is the on-disk format version. Bump it whenever the shape
+// below changes incompatibly; readState refuses anything newer.
+const oauthStateVersion = 1
 
-// RefreshTokenSnapshot is the on-disk representation of a RefreshTokenStore.
+// RefreshTokenSnapshot is the serializable state of a RefreshTokenStore.
 //
 // The store's own types are unexported, and deliberately stay that way: this
 // is a separate, explicit shape so the file format is not hostage to a field
@@ -25,11 +25,18 @@ const refreshTokenStoreVersion = 1
 // hash exactly as they are in memory, so the file holds an identity mapping —
 // who a hash belongs to — and never anything a client could present.
 type RefreshTokenSnapshot struct {
-	Version   int                              `json:"version"`
-	Timestamp time.Time                        `json:"timestamp"`
-	Tokens    map[string]RefreshTokenSnapEntry `json:"tokens"`
-	Consumed  map[string]string                `json:"consumed"`
-	Grants    map[string][]string              `json:"grants"`
+	Tokens   map[string]RefreshTokenSnapEntry `json:"tokens"`
+	Consumed map[string]string                `json:"consumed"`
+	Grants   map[string][]string              `json:"grants"`
+}
+
+// oauthState is the file itself: everything the OAuth server keeps across a
+// restart, under one version and one timestamp. The store snapshots are
+// embedded so the wire format stays flat.
+type oauthState struct {
+	Version              int       `json:"version"`
+	Timestamp            time.Time `json:"timestamp"`
+	RefreshTokenSnapshot           // tokens, consumed, grants
 }
 
 // RefreshTokenSnapEntry is one live token: the claims bound to it plus both
@@ -71,11 +78,9 @@ func (s *RefreshTokenStore) Snapshot() RefreshTokenSnapshot {
 	}
 
 	return RefreshTokenSnapshot{
-		Version:   refreshTokenStoreVersion,
-		Timestamp: time.Now(),
-		Tokens:    tokens,
-		Consumed:  consumed,
-		Grants:    grants,
+		Tokens:   tokens,
+		Consumed: consumed,
+		Grants:   grants,
 	}
 }
 
@@ -135,23 +140,23 @@ func (s *RefreshTokenStore) Restore(snap RefreshTokenSnapshot) {
 	}
 }
 
-// writeRefreshTokens serializes a snapshot to path using a temporary file and
-// an atomic rename, so a crash mid-write leaves the previous file intact.
-func writeRefreshTokens(path string, snap RefreshTokenSnapshot) error {
-	data, err := json.Marshal(snap)
+// writeState serializes the OAuth state to path using a temporary file and an
+// atomic rename, so a crash mid-write leaves the previous file intact.
+func writeState(path string, state oauthState) error {
+	data, err := json.Marshal(state)
 	if err != nil {
-		return fmt.Errorf("marshal refresh tokens: %w", err)
+		return fmt.Errorf("marshal oauth state: %w", err)
 	}
 
 	tmpPath := path + ".tmp"
 	if err := writeFileSynced(tmpPath, data); err != nil {
 		os.Remove(tmpPath) //nolint:errcheck
-		return fmt.Errorf("write refresh tokens tmp: %w", err)
+		return fmt.Errorf("write oauth state tmp: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, path); err != nil {
 		os.Remove(tmpPath) //nolint:errcheck
-		return fmt.Errorf("rename refresh tokens: %w", err)
+		return fmt.Errorf("rename oauth state: %w", err)
 	}
 
 	// The rename is only durable once the directory entry reaches the disk.
@@ -159,7 +164,7 @@ func writeRefreshTokens(path string, snap RefreshTokenSnapshot) error {
 	// though every write above succeeded, which is exactly the case this
 	// store exists to survive.
 	if err := syncDir(filepath.Dir(path)); err != nil {
-		return fmt.Errorf("sync refresh token dir: %w", err)
+		return fmt.Errorf("sync oauth state dir: %w", err)
 	}
 
 	return nil
@@ -198,43 +203,56 @@ func syncDir(dir string) error {
 	return d.Sync()
 }
 
-// readRefreshTokens reads a snapshot written by writeRefreshTokens.
-func readRefreshTokens(path string) (RefreshTokenSnapshot, error) {
+// readState reads a file written by writeState.
+func readState(path string) (oauthState, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path is operator-configured
 	if err != nil {
-		return RefreshTokenSnapshot{}, fmt.Errorf("read refresh tokens: %w", err)
+		return oauthState{}, fmt.Errorf("read oauth state: %w", err)
 	}
 
-	var snap RefreshTokenSnapshot
-	if err := json.Unmarshal(data, &snap); err != nil {
-		return RefreshTokenSnapshot{}, fmt.Errorf("unmarshal refresh tokens: %w", err)
+	var state oauthState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return oauthState{}, fmt.Errorf("unmarshal oauth state: %w", err)
 	}
 
-	if snap.Version < 1 || snap.Version > refreshTokenStoreVersion {
-		return RefreshTokenSnapshot{}, fmt.Errorf(
-			"unsupported refresh token store version: got %d, supported 1..%d",
-			snap.Version,
-			refreshTokenStoreVersion,
+	if state.Version < 1 || state.Version > oauthStateVersion {
+		return oauthState{}, fmt.Errorf(
+			"unsupported oauth state version: got %d, supported 1..%d",
+			state.Version,
+			oauthStateVersion,
 		)
 	}
 
-	return snap, nil
+	return state, nil
 }
 
-// persistRefreshTokens returns a writer that saves every mutation to path.
+// stateFile owns the OAuth server's durable state on disk.
 //
-// A failed write is logged and swallowed: the token is already valid in
-// memory, so refusing to issue it would turn a durability problem into an
-// outage. The operator learns that a restart will cost a re-authorization,
-// which is the behaviour they had before this file existed.
-func persistRefreshTokens(path string) func(RefreshTokenSnapshot) {
-	return func(snap RefreshTokenSnapshot) {
-		if err := writeRefreshTokens(path, snap); err != nil {
-			slog.Warn(
-				"MCP refresh token store write failed; tokens will not survive a restart",
-				"error", err,
-				"path", path,
-			)
-		}
+// The stores cannot each hold their own writer: they share one file, so each
+// would serialize the whole thing from its own view and drop the other's. The
+// file is the single writer, and every store points its change hook here.
+type stateFile struct {
+	path   string
+	tokens *RefreshTokenStore
+}
+
+// write serializes every store's current state. A failed write is logged and
+// swallowed: the state is already live in memory, so refusing to serve would
+// turn a durability problem into an outage. The operator learns that a restart
+// will cost a re-authorization, which is the behaviour they had before this
+// file existed.
+func (f *stateFile) write() {
+	state := oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: f.tokens.Snapshot(),
+	}
+
+	if err := writeState(f.path, state); err != nil {
+		slog.Warn(
+			"MCP OAuth state write failed; tokens will not survive a restart",
+			"error", err,
+			"path", f.path,
+		)
 	}
 }

--- a/internal/mcp/oauth/persist.go
+++ b/internal/mcp/oauth/persist.go
@@ -166,7 +166,7 @@ func writeState(path string, state oauthState) error {
 	// client a re-authorization. A lost update between two processes is
 	// survivable; unparseable bytes are not. The cost is that an unclean kill
 	// mid-write leaves an orphan file behind instead of reusing one slot.
-	tmpPath, err := writeTempSynced(filepath.Dir(path), filepath.Base(path)+".*.tmp", data)
+	tmpPath, err := writeTempSynced(path, data)
 	if err != nil {
 		return fmt.Errorf("write oauth state tmp: %w", err)
 	}
@@ -187,38 +187,40 @@ func writeState(path string, state oauthState) error {
 	return nil
 }
 
-// writeTempSynced creates a uniquely named file in dir, writes data to it and
-// flushes it to the disk before returning, so the caller can treat a nil error
-// as "this survives a crash". It returns the path it created, which the caller
-// owns: on error it is removed here, on success the caller renames it.
+// writeTempSynced creates a uniquely named sibling of path, writes data to it
+// and flushes it to the disk before returning, so the caller can treat a nil
+// error as "this survives a crash". It returns the path it created, which the
+// caller owns: on error it is removed here, on success the caller renames it.
 //
 // os.CreateTemp already creates with mode 0600, which is what this file needs.
-func writeTempSynced(dir, pattern string, data []byte) (string, error) {
-	f, err := os.CreateTemp(dir, pattern)
+// The name it picks matches tempFileSuffix, so sweepTempFiles can recognise an
+// orphan left behind by an unclean kill.
+func writeTempSynced(path string, data []byte) (string, error) {
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+tempFileSuffix)
 	if err != nil {
 		return "", err
 	}
 
-	path := f.Name()
+	tmpPath := f.Name()
 
 	if _, err := f.Write(data); err != nil {
-		f.Close()       //nolint:errcheck // the write error is the one worth reporting
-		os.Remove(path) //nolint:errcheck
+		f.Close()          //nolint:errcheck // the write error is the one worth reporting
+		os.Remove(tmpPath) //nolint:errcheck
 		return "", err
 	}
 
 	if err := f.Sync(); err != nil {
-		f.Close()       //nolint:errcheck // the sync error is the one worth reporting
-		os.Remove(path) //nolint:errcheck
+		f.Close()          //nolint:errcheck // the sync error is the one worth reporting
+		os.Remove(tmpPath) //nolint:errcheck
 		return "", err
 	}
 
 	if err := f.Close(); err != nil {
-		os.Remove(path) //nolint:errcheck
+		os.Remove(tmpPath) //nolint:errcheck
 		return "", err
 	}
 
-	return path, nil
+	return tmpPath, nil
 }
 
 // syncDir flushes a directory's own entries, which is what makes a rename
@@ -254,6 +256,59 @@ func readState(path string) (oauthState, error) {
 	}
 
 	return state, nil
+}
+
+// tempFileSuffix is appended to the state file's name to form the pattern
+// os.CreateTemp expands. It is shared by the writer and the sweeper so the
+// names one creates are exactly the ones the other reclaims.
+const tempFileSuffix = ".*.tmp"
+
+// changeNotifier is the write-through hook the stores share. Both hold state
+// that belongs to one file, and neither knows what owns it, so both report a
+// mutation the same way.
+type changeNotifier struct {
+	// onChange is called after every mutation that changed state, always with
+	// the store's mutex released. Nil when the store is memory-only.
+	onChange func()
+}
+
+// SetOnChange installs the callback fired after every mutation. Call it during
+// setup, before the store serves any request: it is not guarded by a mutex,
+// because a hook swapped mid-flight would race the mutations it records.
+func (n *changeNotifier) SetOnChange(fn func()) {
+	n.onChange = fn
+}
+
+// writeThrough notifies the owner of the durable state that it changed. It
+// must be called with the store's mutex released, since the owner takes a
+// snapshot, which acquires it.
+func (n *changeNotifier) writeThrough() {
+	if n.onChange == nil {
+		return
+	}
+
+	n.onChange()
+}
+
+// sweepTempFiles removes temp files orphaned by an unclean kill mid-write.
+// Each holds a full copy of the state, so leaving them to accumulate would
+// both fill the data directory and scatter extra copies of it around. Called
+// once at startup, where a stray readdir costs nothing and no writer is racing
+// it: a temp file that a live writer still owns cannot exist yet.
+func sweepTempFiles(path string) {
+	orphans, err := filepath.Glob(path + tempFileSuffix)
+	if err != nil {
+		return // the pattern is a constant, so this cannot fire
+	}
+
+	for _, orphan := range orphans {
+		if err := os.Remove(orphan); err != nil {
+			slog.Warn("could not remove orphaned MCP OAuth state temp file",
+				"error", err,
+				"path", orphan,
+			)
+		}
+	}
 }
 
 // stateFile owns the OAuth server's durable state on disk.

--- a/internal/mcp/oauth/persist.go
+++ b/internal/mcp/oauth/persist.go
@@ -13,7 +13,11 @@ import (
 
 // oauthStateVersion is the on-disk format version. Bump it whenever the shape
 // below changes incompatibly; readState refuses anything newer.
-const oauthStateVersion = 1
+//
+// v2 added consent records. A v1 file loads and yields none, which is exactly
+// the pre-upgrade behaviour: every client is prompted once more, then
+// remembered.
+const oauthStateVersion = 2
 
 // RefreshTokenSnapshot is the serializable state of a RefreshTokenStore.
 //
@@ -37,6 +41,11 @@ type oauthState struct {
 	Version              int       `json:"version"`
 	Timestamp            time.Time `json:"timestamp"`
 	RefreshTokenSnapshot           // tokens, consumed, grants
+
+	// Consent is a slice rather than a map: it is readable in the file, and it
+	// avoids inventing an encoding for a composite key built from three
+	// free-form strings.
+	Consent []ConsentRecord `json:"consent,omitempty"`
 }
 
 // RefreshTokenSnapEntry is one live token: the claims bound to it plus both
@@ -232,8 +241,9 @@ func readState(path string) (oauthState, error) {
 // would serialize the whole thing from its own view and drop the other's. The
 // file is the single writer, and every store points its change hook here.
 type stateFile struct {
-	path   string
-	tokens *RefreshTokenStore
+	path    string
+	tokens  *RefreshTokenStore
+	consent *ConsentStore
 }
 
 // write serializes every store's current state. A failed write is logged and
@@ -246,11 +256,12 @@ func (f *stateFile) write() {
 		Version:              oauthStateVersion,
 		Timestamp:            time.Now(),
 		RefreshTokenSnapshot: f.tokens.Snapshot(),
+		Consent:              f.consent.Snapshot(),
 	}
 
 	if err := writeState(f.path, state); err != nil {
 		slog.Warn(
-			"MCP OAuth state write failed; tokens will not survive a restart",
+			"MCP OAuth state write failed; tokens and approvals will not survive a restart",
 			"error", err,
 			"path", f.path,
 		)

--- a/internal/mcp/oauth/persist.go
+++ b/internal/mcp/oauth/persist.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	json "github.com/goccy/go-json"
@@ -157,9 +158,16 @@ func writeState(path string, state oauthState) error {
 		return fmt.Errorf("marshal oauth state: %w", err)
 	}
 
-	tmpPath := path + ".tmp"
-	if err := writeFileSynced(tmpPath, data); err != nil {
-		os.Remove(tmpPath) //nolint:errcheck
+	// The temp file gets a unique name rather than a fixed path + ".tmp".
+	// stateFile's mutex already serializes writers inside this process, but
+	// two processes pointed at one data directory would otherwise open and
+	// truncate the same temp file and interleave their bytes into it, and the
+	// rename would publish something that fails to parse — costing every
+	// client a re-authorization. A lost update between two processes is
+	// survivable; unparseable bytes are not. The cost is that an unclean kill
+	// mid-write leaves an orphan file behind instead of reusing one slot.
+	tmpPath, err := writeTempSynced(filepath.Dir(path), filepath.Base(path)+".*.tmp", data)
+	if err != nil {
 		return fmt.Errorf("write oauth state tmp: %w", err)
 	}
 
@@ -179,25 +187,38 @@ func writeState(path string, state oauthState) error {
 	return nil
 }
 
-// writeFileSynced writes data to path and flushes it to the disk before
-// returning, so the caller can treat a nil error as "this survives a crash".
-func writeFileSynced(path string, data []byte) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+// writeTempSynced creates a uniquely named file in dir, writes data to it and
+// flushes it to the disk before returning, so the caller can treat a nil error
+// as "this survives a crash". It returns the path it created, which the caller
+// owns: on error it is removed here, on success the caller renames it.
+//
+// os.CreateTemp already creates with mode 0600, which is what this file needs.
+func writeTempSynced(dir, pattern string, data []byte) (string, error) {
+	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
-		return err
+		return "", err
 	}
 
+	path := f.Name()
+
 	if _, err := f.Write(data); err != nil {
-		f.Close() //nolint:errcheck // the write error is the one worth reporting
-		return err
+		f.Close()       //nolint:errcheck // the write error is the one worth reporting
+		os.Remove(path) //nolint:errcheck
+		return "", err
 	}
 
 	if err := f.Sync(); err != nil {
-		f.Close() //nolint:errcheck // the sync error is the one worth reporting
-		return err
+		f.Close()       //nolint:errcheck // the sync error is the one worth reporting
+		os.Remove(path) //nolint:errcheck
+		return "", err
 	}
 
-	return f.Close()
+	if err := f.Close(); err != nil {
+		os.Remove(path) //nolint:errcheck
+		return "", err
+	}
+
+	return path, nil
 }
 
 // syncDir flushes a directory's own entries, which is what makes a rename
@@ -241,6 +262,17 @@ func readState(path string) (oauthState, error) {
 // would serialize the whole thing from its own view and drop the other's. The
 // file is the single writer, and every store points its change hook here.
 type stateFile struct {
+	// mu makes "the single writer" true rather than aspirational. Two stores
+	// mutating concurrently each call write, and unserialized they would
+	// snapshot at different moments and rename in either order — publishing a
+	// snapshot taken before the other's mutation and silently dropping a token
+	// or an approval that is still live in memory. Held across the whole of
+	// write so the snapshot and the rename that publishes it stay one step.
+	//
+	// Neither store's mutex is held while its hook runs, so taking this one
+	// here cannot deadlock against them.
+	mu sync.Mutex
+
 	path    string
 	tokens  *RefreshTokenStore
 	consent *ConsentStore
@@ -252,6 +284,9 @@ type stateFile struct {
 // will cost a re-authorization, which is the behaviour they had before this
 // file existed.
 func (f *stateFile) write() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	state := oauthState{
 		Version:              oauthStateVersion,
 		Timestamp:            time.Now(),

--- a/internal/mcp/oauth/persist_test.go
+++ b/internal/mcp/oauth/persist_test.go
@@ -14,19 +14,42 @@ import (
 func restart(t *testing.T, s *RefreshTokenStore, path string) *RefreshTokenStore {
 	t.Helper()
 
-	if err := writeRefreshTokens(path, s.Snapshot()); err != nil {
+	if err := writeState(path, oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: s.Snapshot(),
+	}); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
-	snap, err := readRefreshTokens(path)
+	state, err := readState(path)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
 
 	restored := NewRefreshTokenStore()
-	restored.Restore(snap)
+	restored.Restore(state.RefreshTokenSnapshot)
 
 	return restored
+}
+
+// onDisk reads back what the store has written without going through it, so
+// these tests assert on the file rather than on the store's own memory.
+func onDisk(t *testing.T, path string) oauthState {
+	t.Helper()
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	return state
+}
+
+// persisting wires a store to a file the way NewServer does.
+func persisting(s *RefreshTokenStore, path string) {
+	file := &stateFile{path: path, tokens: s}
+	s.SetOnChange(file.write)
 }
 
 func TestRefreshTokenSurvivesRestart(t *testing.T) {
@@ -116,12 +139,16 @@ func TestExpiredGrantFamilyIsDroppedOnLoad(t *testing.T) {
 		snap.Tokens[hash] = entry
 	}
 
-	if err := writeRefreshTokens(path, snap); err != nil {
+	if err := writeState(path, oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: snap,
+	}); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
 	restored := NewRefreshTokenStore()
-	restored.Restore(onDisk(t, path))
+	restored.Restore(onDisk(t, path).RefreshTokenSnapshot)
 
 	if _, ok := restored.Validate(live); !ok {
 		t.Fatal("the unexpired token should still validate")
@@ -148,7 +175,11 @@ func TestRefreshTokenFileIsPrivateAndAtomic(t *testing.T) {
 	s := NewRefreshTokenStore()
 	s.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
 
-	if err := writeRefreshTokens(path, s.Snapshot()); err != nil {
+	if err := writeState(path, oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: s.Snapshot(),
+	}); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -194,31 +225,18 @@ func TestReadRefreshTokensRejectsUnreadableFiles(t *testing.T) {
 				}
 			}
 
-			if _, err := readRefreshTokens(tc.path); err == nil {
+			if _, err := readState(tc.path); err == nil {
 				t.Fatal("expected an error the caller can log and carry on from")
 			}
 		})
 	}
 }
 
-// onDisk reads back what the store has written without going through it, so
-// these tests assert on the file rather than on the store's own memory.
-func onDisk(t *testing.T, path string) RefreshTokenSnapshot {
-	t.Helper()
-
-	snap, err := readRefreshTokens(path)
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-
-	return snap
-}
-
 func TestIssueIsWrittenThrough(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
 	s := NewRefreshTokenStore()
-	s.SetPersistFunc(persistRefreshTokens(path))
+	persisting(s, path)
 
 	// Nothing calls save: a token the client already holds must be durable by
 	// the time the token endpoint answers, or a crash loses exactly the token
@@ -234,7 +252,7 @@ func TestRotateIsWrittenThrough(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
 	s := NewRefreshTokenStore()
-	s.SetPersistFunc(persistRefreshTokens(path))
+	persisting(s, path)
 
 	token := s.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
 	if !s.Rotate(token, time.Hour).OK {
@@ -254,7 +272,7 @@ func TestRevokeIsWrittenThrough(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
 	s := NewRefreshTokenStore()
-	s.SetPersistFunc(persistRefreshTokens(path))
+	persisting(s, path)
 
 	token := s.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
 	s.RevokeGrant(token)
@@ -306,8 +324,8 @@ func TestServerWithoutTokenStorePathKeepsTokensInMemory(t *testing.T) {
 	// With no path configured there is nowhere a write could be observed, so
 	// the assertion is on the wiring itself: no persister was installed, which
 	// is what keeps a read-only deployment from warning on every mutation.
-	if s.refreshTokens.persist != nil {
-		t.Error("a server with no token store path should install no persister")
+	if s.refreshTokens.onChange != nil {
+		t.Error("a server with no token store path should install no change hook")
 	}
 }
 
@@ -315,7 +333,7 @@ func TestUnknownTokenRotationDoesNotWrite(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
 	s := NewRefreshTokenStore()
-	s.SetPersistFunc(persistRefreshTokens(path))
+	persisting(s, path)
 	s.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
 
 	// Removing the file makes a subsequent write observable: anyone can post a
@@ -336,7 +354,7 @@ func TestUnknownTokenRevocationDoesNotWrite(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
 	s := NewRefreshTokenStore()
-	s.SetPersistFunc(persistRefreshTokens(path))
+	persisting(s, path)
 	s.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
 
 	if err := os.Remove(path); err != nil {

--- a/internal/mcp/oauth/persist_test.go
+++ b/internal/mcp/oauth/persist_test.go
@@ -46,9 +46,11 @@ func onDisk(t *testing.T, path string) oauthState {
 	return state
 }
 
-// persisting wires a store to a file the way NewServer does.
+// persisting wires a store to a file the way NewServer does. A ConsentStore is
+// constructed alongside it, unused by the caller, so these tests exercise the
+// same stateFile wiring NewServer builds rather than a partial stand-in.
 func persisting(s *RefreshTokenStore, path string) {
-	file := &stateFile{path: path, tokens: s}
+	file := &stateFile{path: path, tokens: s, consent: NewConsentStore()}
 	s.SetOnChange(file.write)
 }
 

--- a/internal/mcp/oauth/persist_test.go
+++ b/internal/mcp/oauth/persist_test.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/radiergummi/cetacean/internal/config"
 )
 
 // restart round-trips a store through the on-disk format the way a process
@@ -16,11 +14,7 @@ import (
 func restart(t *testing.T, s *RefreshTokenStore, path string) *RefreshTokenStore {
 	t.Helper()
 
-	if err := writeState(path, oauthState{
-		Version:              oauthStateVersion,
-		Timestamp:            time.Now(),
-		RefreshTokenSnapshot: s.Snapshot(),
-	}); err != nil {
+	if err := writeState(path, tokenState(s.Snapshot())); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -33,6 +27,16 @@ func restart(t *testing.T, s *RefreshTokenStore, path string) *RefreshTokenStore
 	restored.Restore(state.RefreshTokenSnapshot)
 
 	return restored
+}
+
+// tokenState wraps a refresh-token snapshot in the file envelope, so a new
+// envelope field is reconsidered in one place rather than at each writer.
+func tokenState(snap RefreshTokenSnapshot) oauthState {
+	return oauthState{
+		Version:              oauthStateVersion,
+		Timestamp:            time.Now(),
+		RefreshTokenSnapshot: snap,
+	}
 }
 
 // onDisk reads back what the store has written without going through it, so
@@ -48,12 +52,18 @@ func onDisk(t *testing.T, path string) oauthState {
 	return state
 }
 
-// persisting wires a store to a file the way NewServer does. A ConsentStore is
-// constructed alongside it, unused by the caller, so these tests exercise the
-// same stateFile wiring NewServer builds rather than a partial stand-in.
-func persisting(s *RefreshTokenStore, path string) {
-	file := &stateFile{path: path, tokens: s, consent: NewConsentStore()}
+// persisting wires a store to a file the way NewServer does, and returns the
+// ConsentStore sharing that file so a caller can drive the other half of it.
+// Both hooks are installed, so these tests exercise the same stateFile wiring
+// NewServer builds rather than a partial stand-in.
+func persisting(s *RefreshTokenStore, path string) *ConsentStore {
+	consent := NewConsentStore(testConsentTTL)
+
+	file := &stateFile{path: path, tokens: s, consent: consent}
 	s.SetOnChange(file.write)
+	consent.SetOnChange(file.write)
+
+	return consent
 }
 
 func TestRefreshTokenSurvivesRestart(t *testing.T) {
@@ -143,11 +153,7 @@ func TestExpiredGrantFamilyIsDroppedOnLoad(t *testing.T) {
 		snap.Tokens[hash] = entry
 	}
 
-	if err := writeState(path, oauthState{
-		Version:              oauthStateVersion,
-		Timestamp:            time.Now(),
-		RefreshTokenSnapshot: snap,
-	}); err != nil {
+	if err := writeState(path, tokenState(snap)); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -179,11 +185,7 @@ func TestRefreshTokenFileIsPrivateAndAtomic(t *testing.T) {
 	s := NewRefreshTokenStore()
 	s.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
 
-	if err := writeState(path, oauthState{
-		Version:              oauthStateVersion,
-		Timestamp:            time.Now(),
-		RefreshTokenSnapshot: s.Snapshot(),
-	}); err != nil {
+	if err := writeState(path, tokenState(s.Snapshot())); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -291,18 +293,7 @@ func TestRevokeIsWrittenThrough(t *testing.T) {
 func TestServerCarriesRefreshTokensAcrossRestart(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
-	cfg := ServerConfig{
-		Issuer:      "https://cetacean.test",
-		MCPResource: "https://cetacean.test/mcp",
-		MCP: config.MCPConfig{
-			AccessTokenTTL:  time.Hour,
-			RefreshTokenTTL: 720 * time.Hour,
-		},
-		SigningKey:     []byte("test-signing-key-32bytes-padded!!"),
-		TokenStorePath: path,
-	}
-
-	before := NewServer(cfg)
+	before := newPersistingServer(t, path, "https://cetacean.test/mcp")
 	token := before.refreshTokens.Issue(RefreshTokenData{
 		Subject:  "user@example.com",
 		ClientID: "https://example.com/client",
@@ -310,14 +301,14 @@ func TestServerCarriesRefreshTokensAcrossRestart(t *testing.T) {
 	}, 720*time.Hour)
 
 	// A second Server over the same path stands in for the process restarting.
-	after := NewServer(cfg)
+	after := newPersistingServer(t, path, "https://cetacean.test/mcp")
 
 	if _, ok := after.refreshTokens.Validate(token); !ok {
 		t.Fatal("a refresh token issued before the restart should still validate")
 	}
 }
 
-func TestServerWithoutTokenStorePathKeepsTokensInMemory(t *testing.T) {
+func TestServerWithoutStatePathKeepsTokensInMemory(t *testing.T) {
 	s := newTestServer(t)
 
 	token := s.refreshTokens.Issue(RefreshTokenData{Subject: "user@example.com"}, time.Hour)
@@ -376,11 +367,7 @@ func TestStateFileSerializesConcurrentWriters(t *testing.T) {
 	path := t.TempDir() + "/mcp-tokens.json"
 
 	tokens := NewRefreshTokenStore()
-	consent := NewConsentStore()
-
-	file := &stateFile{path: path, tokens: tokens, consent: consent}
-	tokens.SetOnChange(file.write)
-	consent.SetOnChange(file.write)
+	consent := persisting(tokens, path)
 
 	// Two independent stores now write the same file from their own hooks.
 	// Unserialized, each snapshots at its own moment and opens the same temp
@@ -415,12 +402,8 @@ func TestStateFileSerializesConcurrentWriters(t *testing.T) {
 		defer wg.Done()
 
 		for i := range rounds {
-			consent.Remember(
-				fmt.Sprintf("consent-%d@example.com", i),
-				testClientID,
-				testResource,
-				testFingerprint,
-			)
+			subject := fmt.Sprintf("consent-%d@example.com", i)
+			consent.Remember(keyFor(subject, testClientID, testResource), testFingerprint)
 		}
 	}()
 

--- a/internal/mcp/oauth/persist_test.go
+++ b/internal/mcp/oauth/persist_test.go
@@ -1,7 +1,9 @@
 package oauth
 
 import (
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -367,5 +369,75 @@ func TestUnknownTokenRevocationDoesNotWrite(t *testing.T) {
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("revoking an unknown token wrote to disk; it changes no state")
+	}
+}
+
+func TestStateFileSerializesConcurrentWriters(t *testing.T) {
+	path := t.TempDir() + "/mcp-tokens.json"
+
+	tokens := NewRefreshTokenStore()
+	consent := NewConsentStore()
+
+	file := &stateFile{path: path, tokens: tokens, consent: consent}
+	tokens.SetOnChange(file.write)
+	consent.SetOnChange(file.write)
+
+	// Two independent stores now write the same file from their own hooks.
+	// Unserialized, each snapshots at its own moment and opens the same temp
+	// path, so the rename publishes either a stale snapshot — silently losing
+	// a token or an approval still live in memory — or structurally mixed
+	// bytes that fail to parse at the next start, costing every client a
+	// re-authorization.
+	//
+	// This exercises that path rather than proving it: the corruption is in
+	// the file, not in memory, so the race detector cannot see it and the
+	// interleaving does not reproduce on demand. It is a regression guard on
+	// the invariant — a published file always parses and always holds both
+	// stores — not a reproduction of the unserialized failure.
+	const rounds = 25
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := range rounds {
+			tokens.Issue(RefreshTokenData{
+				Subject:  fmt.Sprintf("token-%d@example.com", i),
+				ClientID: testClientID,
+				Resource: testResource,
+			}, time.Hour)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := range rounds {
+			consent.Remember(
+				fmt.Sprintf("consent-%d@example.com", i),
+				testClientID,
+				testResource,
+				testFingerprint,
+			)
+		}
+	}()
+
+	wg.Wait()
+
+	state, err := readState(path)
+	if err != nil {
+		t.Fatalf("the published file must always parse: %v", err)
+	}
+
+	// Every mutation completed before the write it triggered, so whichever
+	// write held the lock last saw both stores complete — and the file it
+	// published must hold everything.
+	if got := len(state.Tokens); got != rounds {
+		t.Errorf("tokens on disk = %d, want %d", got, rounds)
+	}
+	if got := len(state.Consent); got != rounds {
+		t.Errorf("consent records on disk = %d, want %d", got, rounds)
 	}
 }

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -593,6 +593,61 @@ func (s *Server) issueCodeAndRedirect(
 	http.Redirect(w, r, redirectURI.String(), http.StatusFound)
 }
 
+// consentPrompt carries everything needed to render the consent page. Both the
+// initial GET and the POST that finds the client changed mid-decision go
+// through it, so the second prompt is built exactly like the first.
+type consentPrompt struct {
+	meta     *ClientMetadata
+	verified bool
+	identity *auth.Identity
+
+	// fingerprint hashes meta. It is passed rather than recomputed so the
+	// value bound into the CSRF token is provably the one the caller compared
+	// against, not a second resolution of the same document.
+	fingerprint string
+
+	responseType        string
+	clientID            string
+	redirectURI         string
+	codeChallenge       string
+	codeChallengeMethod string
+	state               string
+
+	// resource is the raw request parameter, echoed back unchanged: the form
+	// must resubmit what the client sent, not the resolved default.
+	resource string
+}
+
+// renderConsentPage issues a fresh CSRF nonce bound to this prompt and renders
+// the form.
+func (s *Server) renderConsentPage(w http.ResponseWriter, p consentPrompt) {
+	csrfToken, _ := issueCSRFNonce(
+		w,
+		s.cfg.SigningKey,
+		p.state,
+		p.fingerprint,
+		strings.HasPrefix(s.cfg.Issuer, "https://"),
+	)
+
+	renderConsent(w, consentData{
+		ClientName:          p.meta.ClientName,
+		Verified:            p.verified,
+		Remembered:          p.verified,
+		RedirectURI:         p.redirectURI,
+		Subject:             p.identity.Subject,
+		Email:               p.identity.Email,
+		ActionURL:           s.cfg.BasePath + "/oauth/authorize",
+		ResponseType:        p.responseType,
+		ClientID:            p.clientID,
+		CodeChallenge:       p.codeChallenge,
+		CodeChallengeMethod: p.codeChallengeMethod,
+		State:               p.state,
+		Resource:            p.resource,
+		Fingerprint:         p.fingerprint,
+		CSRFToken:           csrfToken,
+	})
+}
+
 func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	responseType := q.Get("response_type")
@@ -652,6 +707,21 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fingerprint the metadata exactly once, here, from the document the page
+	// is about to be rendered from. It travels to the POST in a hidden field
+	// covered by the CSRF HMAC, because a record must be bound to what the
+	// user was *shown*: resolving the client again on POST and fingerprinting
+	// that would record a document the user may never have seen, whenever the
+	// CIMD cache entry lapsed in between.
+	//
+	// Computed for unverified clients too. Nothing is remembered for them, but
+	// the fingerprint costs a hash, and covering it uniformly means the POST
+	// re-prompts whenever the name or redirect URI on screen went stale — for
+	// DCR that is an LRU eviction and re-registration rather than a document
+	// edit, but the user is equally owed a page describing the client that is
+	// about to receive the code.
+	fingerprint := consentFingerprint(meta)
+
 	// A remembered approval skips the page. Only for verified clients, and only
 	// when the metadata still hashes to what the user was shown — a CIMD client
 	// controls its own document and could otherwise redirect an inherited
@@ -661,7 +731,7 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	// redirect_uri was exact-matched against the client's registered set above,
 	// so a silently issued code still lands only where the client registered.
 	if verified &&
-		s.consent.Allows(identity.Subject, clientID, effectiveResource, consentFingerprint(meta)) {
+		s.consent.Allows(identity.Subject, clientID, effectiveResource, fingerprint) {
 		s.issueCodeAndRedirect(w, r, authorizedRequest{
 			clientID:      clientID,
 			redirectURI:   redirectURIRaw,
@@ -675,30 +745,18 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	csrfToken, _ := issueCSRFNonce(
-		w,
-		s.cfg.SigningKey,
-		state,
-		strings.HasPrefix(s.cfg.Issuer, "https://"),
-	)
-
-	actionURL := s.cfg.BasePath + "/oauth/authorize"
-
-	renderConsent(w, consentData{
-		ClientName:          meta.ClientName,
-		Verified:            verified,
-		Remembered:          verified,
-		RedirectURI:         redirectURIRaw,
-		Subject:             identity.Subject,
-		Email:               identity.Email,
-		ActionURL:           actionURL,
-		ResponseType:        responseType,
-		ClientID:            clientID,
-		CodeChallenge:       codeChallenge,
-		CodeChallengeMethod: codeChallengeMethod,
-		State:               state,
-		Resource:            resourceParam,
-		CSRFToken:           csrfToken,
+	s.renderConsentPage(w, consentPrompt{
+		meta:                meta,
+		verified:            verified,
+		identity:            identity,
+		fingerprint:         fingerprint,
+		responseType:        responseType,
+		clientID:            clientID,
+		redirectURI:         redirectURIRaw,
+		codeChallenge:       codeChallenge,
+		codeChallengeMethod: codeChallengeMethod,
+		state:               state,
+		resource:            resourceParam,
 	})
 }
 
@@ -716,6 +774,12 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 	codeChallengeMethod := r.FormValue("code_challenge_method")
 	resourceParam := r.FormValue("resource")
 	decision := r.FormValue("decision")
+	responseType := r.FormValue("response_type")
+
+	// Only trustworthy once verifyCSRFToken passes: the CSRF HMAC covers this
+	// field, so a token that verifies proves this is the fingerprint the
+	// consent page was rendered with.
+	shownFingerprint := r.FormValue(consentFingerprintField)
 
 	// Re-validate client and redirect_uri before any redirect.
 	meta, verified, errMsg := s.resolveClientMeta(r, clientID)
@@ -770,14 +834,45 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The client's metadata changed between rendering the page and this
+	// submission — a CIMD document edited, or its cache entry lapsed and the
+	// re-fetch returned something else. The user approved a name and a set of
+	// redirect URIs that no longer describe this client, so their approval
+	// does not cover this request: prompt again from the fresh metadata rather
+	// than issue a code or record anything against a document they never saw.
+	//
+	// The cookie is deliberately not cleared here; renderConsentPage replaces
+	// it with a nonce bound to the new fingerprint.
+	if fingerprint := consentFingerprint(meta); fingerprint != shownFingerprint {
+		s.renderConsentPage(w, consentPrompt{
+			meta:                meta,
+			verified:            verified,
+			identity:            identity,
+			fingerprint:         fingerprint,
+			responseType:        responseType,
+			clientID:            clientID,
+			redirectURI:         redirectURIRaw,
+			codeChallenge:       codeChallenge,
+			codeChallengeMethod: codeChallengeMethod,
+			state:               state,
+			resource:            resourceParam,
+		})
+
+		return
+	}
+
 	// Clear the CSRF cookie — the flow is complete.
 	clearCSRFCookie(w, secure)
 
 	// Remembering is limited to verified clients. A DCR client's metadata is
 	// self-reported and its client_id does not survive a restart, so a record
 	// keyed on one would be worthless at best.
+	//
+	// The recorded fingerprint is the one the page displayed, proven current
+	// by the comparison above — not a fresh resolution, which could differ
+	// from what the user actually approved.
 	if verified {
-		s.consent.Remember(identity.Subject, clientID, effectiveResource, consentFingerprint(meta))
+		s.consent.Remember(identity.Subject, clientID, effectiveResource, shownFingerprint)
 	}
 
 	s.issueCodeAndRedirect(w, r, authorizedRequest{

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -408,6 +408,10 @@ func (s *Server) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request)
 	// Now consume (rotate) the token. Theft detection runs inside Rotate.
 	result := s.refreshTokens.Rotate(refreshTokenRaw, s.cfg.MCP.RefreshTokenTTL)
 	if result.Theft {
+		// A replayed token means someone else holds a copy. Re-prompting is
+		// the point: the next authorization must reach a human.
+		s.consent.Forget(result.Data.Subject, result.Data.ClientID, result.Data.Resource)
+
 		// Per RFC 6749 §5.2: don't leak that it was theft.
 		writeTokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token is invalid")
 		return
@@ -516,7 +520,11 @@ func (s *Server) HandleRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 	token := r.FormValue("token") // #nosec G120 -- bounded above
 	if token != "" {
-		s.refreshTokens.RevokeGrant(token)
+		// Revoking must also drop the approval, or the next authorization
+		// request is granted silently and revocation only appeared to work.
+		if data, revoked := s.refreshTokens.RevokeGrant(token); revoked {
+			s.consent.Forget(data.Subject, data.ClientID, data.Resource)
+		}
 	}
 	// RFC 7009 §2.2: always 200 regardless of whether the token was valid.
 	w.WriteHeader(http.StatusOK)

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -546,6 +546,53 @@ func (s *Server) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// authorizedRequest carries the validated parameters of an authorization
+// request that is ready to receive a code.
+type authorizedRequest struct {
+	clientID      string
+	redirectURI   string
+	codeChallenge string
+	resource      string
+	state         string
+	subject       string
+	groups        []string
+}
+
+// issueCodeAndRedirect mints an authorization code and redirects the browser
+// back to the client with it. Both the consent-page POST and the skipped-consent
+// GET path end here, so they cannot drift apart.
+func (s *Server) issueCodeAndRedirect(
+	w http.ResponseWriter,
+	r *http.Request,
+	p authorizedRequest,
+) {
+	rawCode := s.authCodes.Issue(AuthCodeData{
+		ClientID:      p.clientID,
+		RedirectURI:   p.redirectURI,
+		CodeChallenge: p.codeChallenge,
+		Resource:      p.resource,
+		Subject:       p.subject,
+		Groups:        p.groups,
+	}, authCodeTTL)
+
+	redirectURI, _ := url.Parse(p.redirectURI)
+	q := redirectURI.Query()
+	q.Set("code", rawCode)
+
+	if p.state != "" {
+		q.Set("state", p.state)
+	}
+
+	// RFC 9207: name the issuer in the authorization response so a client
+	// configured with several authorization servers cannot be tricked into
+	// redeeming this code at the wrong one (mix-up attack).
+	q.Set("iss", s.cfg.issuerID())
+	redirectURI.RawQuery = q.Encode()
+
+	//nolint:gosec // G710: p.redirectURI was exact-matched against the client's registered redirect_uris (HasRedirectURI) by both callers before reaching here; this is a pre-validated URI, not open redirect.
+	http.Redirect(w, r, redirectURI.String(), http.StatusFound)
+}
+
 func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	responseType := q.Get("response_type")
@@ -588,11 +635,12 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := ValidateResourceIndicator(
+	effectiveResource, err := ValidateResourceIndicator(
 		resourceParam,
 		s.cfg.MCPResource,
 		s.cfg.MCP.RequireResourceIndicator,
-	); err != nil {
+	)
+	if err != nil {
 		s.redirectWithError(w, r, redirectURIRaw, state, "invalid_target", err.Error())
 		return
 	}
@@ -601,6 +649,29 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	identity := auth.IdentityFromContext(r.Context())
 	if identity == nil {
 		renderErrorPage(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	// A remembered approval skips the page. Only for verified clients, and only
+	// when the metadata still hashes to what the user was shown — a CIMD client
+	// controls its own document and could otherwise redirect an inherited
+	// approval somewhere the user never saw.
+	//
+	// Issuing a code from a GET is ordinary for an authorization endpoint, and
+	// redirect_uri was exact-matched against the client's registered set above,
+	// so a silently issued code still lands only where the client registered.
+	if verified &&
+		s.consent.Allows(identity.Subject, clientID, effectiveResource, consentFingerprint(meta)) {
+		s.issueCodeAndRedirect(w, r, authorizedRequest{
+			clientID:      clientID,
+			redirectURI:   redirectURIRaw,
+			codeChallenge: codeChallenge,
+			resource:      effectiveResource,
+			state:         state,
+			subject:       identity.Subject,
+			groups:        identity.Groups,
+		})
+
 		return
 	}
 
@@ -616,6 +687,7 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	renderConsent(w, consentData{
 		ClientName:          meta.ClientName,
 		Verified:            verified,
+		Remembered:          verified,
 		RedirectURI:         redirectURIRaw,
 		Subject:             identity.Subject,
 		Email:               identity.Email,
@@ -646,7 +718,7 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 	decision := r.FormValue("decision")
 
 	// Re-validate client and redirect_uri before any redirect.
-	meta, _, errMsg := s.resolveClientMeta(r, clientID)
+	meta, verified, errMsg := s.resolveClientMeta(r, clientID)
 	if errMsg != "" {
 		renderErrorPage(w, http.StatusBadRequest, errMsg)
 		return
@@ -698,33 +770,25 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Issue authorization code.
-	rawCode := s.authCodes.Issue(AuthCodeData{
-		ClientID:      clientID,
-		RedirectURI:   redirectURIRaw,
-		CodeChallenge: codeChallenge,
-		Resource:      effectiveResource,
-		Subject:       identity.Subject,
-		Groups:        identity.Groups,
-	}, authCodeTTL)
-
 	// Clear the CSRF cookie — the flow is complete.
 	clearCSRFCookie(w, secure)
 
-	// Redirect with code.
-	redirectURI, _ := url.Parse(redirectURIRaw)
-	q := redirectURI.Query()
-	q.Set("code", rawCode)
-	if state != "" {
-		q.Set("state", state)
+	// Remembering is limited to verified clients. A DCR client's metadata is
+	// self-reported and its client_id does not survive a restart, so a record
+	// keyed on one would be worthless at best.
+	if verified {
+		s.consent.Remember(identity.Subject, clientID, effectiveResource, consentFingerprint(meta))
 	}
-	// RFC 9207: name the issuer in the authorization response so a client
-	// configured with several authorization servers cannot be tricked into
-	// redeeming this code at the wrong one (mix-up attack).
-	q.Set("iss", s.cfg.issuerID())
-	redirectURI.RawQuery = q.Encode()
-	//nolint:gosec // G710: redirectURIRaw was exact-matched against the client's registered redirect_uris (HasRedirectURI) earlier in handleAuthorizePOST; this is a pre-validated URI, not open redirect.
-	http.Redirect(w, r, redirectURI.String(), http.StatusFound)
+
+	s.issueCodeAndRedirect(w, r, authorizedRequest{
+		clientID:      clientID,
+		redirectURI:   redirectURIRaw,
+		codeChallenge: codeChallenge,
+		resource:      effectiveResource,
+		state:         state,
+		subject:       identity.Subject,
+		groups:        identity.Groups,
+	})
 }
 
 // cimdDisabledMessage is shown when a client presents an https:// client_id

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -45,10 +45,11 @@ type ServerConfig struct {
 	// HTTPClient is an optional HTTP client for CIMD fetches.
 	HTTPClient *http.Client
 
-	// TokenStorePath is where refresh tokens are persisted, so a restart does
-	// not force every client to re-authorize. Empty keeps the store in memory
-	// only, which is what happens when the data directory is not writable.
-	TokenStorePath string
+	// StatePath is where the OAuth server's durable state — refresh tokens and
+	// remembered approvals — is persisted, so a restart does not force every
+	// client to re-authorize. Empty keeps both stores in memory only, which is
+	// what happens when the data directory is not writable.
+	StatePath string
 }
 
 // Server is the OAuth 2.1 authorization server. Use NewServer to construct.
@@ -91,22 +92,24 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	refreshTokens := NewRefreshTokenStore()
-	consent := NewConsentStore()
+	consent := NewConsentStore(cfg.MCP.ConsentTTL)
 
-	if cfg.TokenStorePath != "" {
+	if cfg.StatePath != "" {
+		sweepTempFiles(cfg.StatePath)
+
 		// A missing file is the normal first start. Anything else — corrupt
 		// JSON, bad permissions, a version from a newer build — costs every
 		// client a re-authorization, so it is worth an operator's attention.
 		// Neither is fatal: the server comes up empty and clients re-authorize,
 		// exactly as they did before the store existed.
-		if state, err := readState(cfg.TokenStorePath); err != nil {
+		if state, err := readState(cfg.StatePath); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				slog.Info("no MCP OAuth state yet", "path", cfg.TokenStorePath)
+				slog.Info("no MCP OAuth state yet", "path", cfg.StatePath)
 			} else {
 				slog.Warn(
 					"could not read MCP OAuth state; clients must re-authorize",
 					"error", err,
-					"path", cfg.TokenStorePath,
+					"path", cfg.StatePath,
 				)
 			}
 		} else {
@@ -118,7 +121,7 @@ func NewServer(cfg ServerConfig) *Server {
 			)
 		}
 
-		file := &stateFile{path: cfg.TokenStorePath, tokens: refreshTokens, consent: consent}
+		file := &stateFile{path: cfg.StatePath, tokens: refreshTokens, consent: consent}
 		refreshTokens.SetOnChange(file.write)
 		consent.SetOnChange(file.write)
 	}
@@ -410,7 +413,7 @@ func (s *Server) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request)
 	if result.Theft {
 		// A replayed token means someone else holds a copy. Re-prompting is
 		// the point: the next authorization must reach a human.
-		s.consent.Forget(result.Data.Subject, result.Data.ClientID, result.Data.Resource)
+		s.consent.Forget(result.Data.ConsentKey())
 
 		// Per RFC 6749 §5.2: don't leak that it was theft.
 		writeTokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token is invalid")
@@ -523,7 +526,7 @@ func (s *Server) HandleRevoke(w http.ResponseWriter, r *http.Request) {
 		// Revoking must also drop the approval, or the next authorization
 		// request is granted silently and revocation only appeared to work.
 		if data, revoked := s.refreshTokens.RevokeGrant(token); revoked {
-			s.consent.Forget(data.Subject, data.ClientID, data.Resource)
+			s.consent.Forget(data.ConsentKey())
 		}
 	}
 	// RFC 7009 §2.2: always 200 regardless of whether the token was valid.
@@ -546,41 +549,26 @@ func (s *Server) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// authorizedRequest carries the validated parameters of an authorization
-// request that is ready to receive a code.
-type authorizedRequest struct {
-	clientID      string
-	redirectURI   string
-	codeChallenge string
-	resource      string
-	state         string
-	subject       string
-	groups        []string
-}
-
 // issueCodeAndRedirect mints an authorization code and redirects the browser
 // back to the client with it. Both the consent-page POST and the skipped-consent
 // GET path end here, so they cannot drift apart.
+//
+// state is separate from code because it is echoed back to the client rather
+// than bound into the code.
 func (s *Server) issueCodeAndRedirect(
 	w http.ResponseWriter,
 	r *http.Request,
-	p authorizedRequest,
+	code AuthCodeData,
+	state string,
 ) {
-	rawCode := s.authCodes.Issue(AuthCodeData{
-		ClientID:      p.clientID,
-		RedirectURI:   p.redirectURI,
-		CodeChallenge: p.codeChallenge,
-		Resource:      p.resource,
-		Subject:       p.subject,
-		Groups:        p.groups,
-	}, authCodeTTL)
+	rawCode := s.authCodes.Issue(code, authCodeTTL)
 
-	redirectURI, _ := url.Parse(p.redirectURI)
+	redirectURI, _ := url.Parse(code.RedirectURI)
 	q := redirectURI.Query()
 	q.Set("code", rawCode)
 
-	if p.state != "" {
-		q.Set("state", p.state)
+	if state != "" {
+		q.Set("state", state)
 	}
 
 	// RFC 9207: name the issuer in the authorization response so a client
@@ -589,63 +577,38 @@ func (s *Server) issueCodeAndRedirect(
 	q.Set("iss", s.cfg.issuerID())
 	redirectURI.RawQuery = q.Encode()
 
-	//nolint:gosec // G710: p.redirectURI was exact-matched against the client's registered redirect_uris (HasRedirectURI) by both callers before reaching here; this is a pre-validated URI, not open redirect.
+	//nolint:gosec // G710: code.RedirectURI was exact-matched against the client's registered redirect_uris (HasRedirectURI) by both callers before reaching here; this is a pre-validated URI, not open redirect.
 	http.Redirect(w, r, redirectURI.String(), http.StatusFound)
 }
 
-// consentPrompt carries everything needed to render the consent page. Both the
-// initial GET and the POST that finds the client changed mid-decision go
-// through it, so the second prompt is built exactly like the first.
-type consentPrompt struct {
-	meta     *ClientMetadata
-	verified bool
-	identity *auth.Identity
+// renderConsentPage completes a partly-built consentData with the fields only
+// the server can supply — the action URL and a fresh CSRF nonce bound to this
+// page's state and fingerprint — and renders the form. Both the initial GET and
+// the POST that finds the client changed mid-decision go through it, so the
+// second prompt is built exactly like the first.
+//
+// The caller sets Fingerprint to the hash of the metadata it just rendered
+// from, rather than this recomputing it, so the value bound into the CSRF
+// token is provably the one the caller compared against.
+func (s *Server) renderConsentPage(w http.ResponseWriter, data consentData) {
+	data.ActionURL = s.cfg.BasePath + "/oauth/authorize"
 
-	// fingerprint hashes meta. It is passed rather than recomputed so the
-	// value bound into the CSRF token is provably the one the caller compared
-	// against, not a second resolution of the same document.
-	fingerprint string
+	// Empty unless this approval will actually be remembered, which is what
+	// the template gates the disclosure on: promising to remember a client the
+	// server will prompt for again is worse than saying nothing.
+	if data.Verified && s.consent.Enabled() {
+		data.RememberedFor = humanizeDuration(s.consent.TTL())
+	}
 
-	responseType        string
-	clientID            string
-	redirectURI         string
-	codeChallenge       string
-	codeChallengeMethod string
-	state               string
-
-	// resource is the raw request parameter, echoed back unchanged: the form
-	// must resubmit what the client sent, not the resolved default.
-	resource string
-}
-
-// renderConsentPage issues a fresh CSRF nonce bound to this prompt and renders
-// the form.
-func (s *Server) renderConsentPage(w http.ResponseWriter, p consentPrompt) {
-	csrfToken, _ := issueCSRFNonce(
+	data.CSRFToken, _ = issueCSRFNonce(
 		w,
 		s.cfg.SigningKey,
-		p.state,
-		p.fingerprint,
+		data.State,
+		data.Fingerprint,
 		strings.HasPrefix(s.cfg.Issuer, "https://"),
 	)
 
-	renderConsent(w, consentData{
-		ClientName:          p.meta.ClientName,
-		Verified:            p.verified,
-		Remembered:          p.verified,
-		RedirectURI:         p.redirectURI,
-		Subject:             p.identity.Subject,
-		Email:               p.identity.Email,
-		ActionURL:           s.cfg.BasePath + "/oauth/authorize",
-		ResponseType:        p.responseType,
-		ClientID:            p.clientID,
-		CodeChallenge:       p.codeChallenge,
-		CodeChallengeMethod: p.codeChallengeMethod,
-		State:               p.state,
-		Resource:            p.resource,
-		Fingerprint:         p.fingerprint,
-		CSRFToken:           csrfToken,
-	})
+	renderConsent(w, data)
 }
 
 func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
@@ -730,33 +693,42 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	// Issuing a code from a GET is ordinary for an authorization endpoint, and
 	// redirect_uri was exact-matched against the client's registered set above,
 	// so a silently issued code still lands only where the client registered.
-	if verified &&
-		s.consent.Allows(identity.Subject, clientID, effectiveResource, fingerprint) {
-		s.issueCodeAndRedirect(w, r, authorizedRequest{
-			clientID:      clientID,
-			redirectURI:   redirectURIRaw,
-			codeChallenge: codeChallenge,
-			resource:      effectiveResource,
-			state:         state,
-			subject:       identity.Subject,
-			groups:        identity.Groups,
-		})
+	consentKey := ConsentKey{
+		Subject:  identity.Subject,
+		ClientID: clientID,
+		Resource: effectiveResource,
+	}
+
+	if verified && s.consent.Allows(consentKey, fingerprint) {
+		s.issueCodeAndRedirect(w, r, AuthCodeData{
+			ClientID:      clientID,
+			RedirectURI:   redirectURIRaw,
+			CodeChallenge: codeChallenge,
+			Resource:      effectiveResource,
+			Subject:       identity.Subject,
+			Groups:        identity.Groups,
+		}, state)
 
 		return
 	}
 
-	s.renderConsentPage(w, consentPrompt{
-		meta:                meta,
-		verified:            verified,
-		identity:            identity,
-		fingerprint:         fingerprint,
-		responseType:        responseType,
-		clientID:            clientID,
-		redirectURI:         redirectURIRaw,
-		codeChallenge:       codeChallenge,
-		codeChallengeMethod: codeChallengeMethod,
-		state:               state,
-		resource:            resourceParam,
+	s.renderConsentPage(w, consentData{
+		ClientName:          meta.ClientName,
+		Verified:            verified,
+		RedirectURI:         redirectURIRaw,
+		Subject:             identity.Subject,
+		Email:               identity.Email,
+		ResponseType:        responseType,
+		ClientID:            clientID,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		State:               state,
+
+		// resourceParam is the raw request parameter, echoed back unchanged:
+		// the form must resubmit what the client sent, not the resolved
+		// default.
+		Resource:    resourceParam,
+		Fingerprint: fingerprint,
 	})
 }
 
@@ -844,18 +816,19 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 	// The cookie is deliberately not cleared here; renderConsentPage replaces
 	// it with a nonce bound to the new fingerprint.
 	if fingerprint := consentFingerprint(meta); fingerprint != shownFingerprint {
-		s.renderConsentPage(w, consentPrompt{
-			meta:                meta,
-			verified:            verified,
-			identity:            identity,
-			fingerprint:         fingerprint,
-			responseType:        responseType,
-			clientID:            clientID,
-			redirectURI:         redirectURIRaw,
-			codeChallenge:       codeChallenge,
-			codeChallengeMethod: codeChallengeMethod,
-			state:               state,
-			resource:            resourceParam,
+		s.renderConsentPage(w, consentData{
+			ClientName:          meta.ClientName,
+			Verified:            verified,
+			RedirectURI:         redirectURIRaw,
+			Subject:             identity.Subject,
+			Email:               identity.Email,
+			ResponseType:        responseType,
+			ClientID:            clientID,
+			CodeChallenge:       codeChallenge,
+			CodeChallengeMethod: codeChallengeMethod,
+			State:               state,
+			Resource:            resourceParam,
+			Fingerprint:         fingerprint,
 		})
 
 		return
@@ -872,18 +845,21 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 	// by the comparison above — not a fresh resolution, which could differ
 	// from what the user actually approved.
 	if verified {
-		s.consent.Remember(identity.Subject, clientID, effectiveResource, shownFingerprint)
+		s.consent.Remember(ConsentKey{
+			Subject:  identity.Subject,
+			ClientID: clientID,
+			Resource: effectiveResource,
+		}, shownFingerprint)
 	}
 
-	s.issueCodeAndRedirect(w, r, authorizedRequest{
-		clientID:      clientID,
-		redirectURI:   redirectURIRaw,
-		codeChallenge: codeChallenge,
-		resource:      effectiveResource,
-		state:         state,
-		subject:       identity.Subject,
-		groups:        identity.Groups,
-	})
+	s.issueCodeAndRedirect(w, r, AuthCodeData{
+		ClientID:      clientID,
+		RedirectURI:   redirectURIRaw,
+		CodeChallenge: codeChallenge,
+		Resource:      effectiveResource,
+		Subject:       identity.Subject,
+		Groups:        identity.Groups,
+	}, state)
 }
 
 // cimdDisabledMessage is shown when a client presents an https:// client_id

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -96,22 +96,23 @@ func NewServer(cfg ServerConfig) *Server {
 		// client a re-authorization, so it is worth an operator's attention.
 		// Neither is fatal: the server comes up empty and clients re-authorize,
 		// exactly as they did before the store existed.
-		if snap, err := readRefreshTokens(cfg.TokenStorePath); err != nil {
+		if state, err := readState(cfg.TokenStorePath); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				slog.Info("no MCP refresh token store yet", "path", cfg.TokenStorePath)
+				slog.Info("no MCP OAuth state yet", "path", cfg.TokenStorePath)
 			} else {
 				slog.Warn(
-					"could not read MCP refresh tokens; clients must re-authorize",
+					"could not read MCP OAuth state; clients must re-authorize",
 					"error", err,
 					"path", cfg.TokenStorePath,
 				)
 			}
 		} else {
-			refreshTokens.Restore(snap)
-			slog.Info("loaded MCP refresh tokens", "grants", len(snap.Grants))
+			refreshTokens.Restore(state.RefreshTokenSnapshot)
+			slog.Info("loaded MCP OAuth state", "grants", len(state.Grants))
 		}
 
-		refreshTokens.SetPersistFunc(persistRefreshTokens(cfg.TokenStorePath))
+		file := &stateFile{path: cfg.TokenStorePath, tokens: refreshTokens}
+		refreshTokens.SetOnChange(file.write)
 	}
 
 	return &Server{

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -58,6 +58,7 @@ type Server struct {
 	cimd          *CIMDFetcher
 	authCodes     *AuthCodeStore
 	refreshTokens *RefreshTokenStore
+	consent       *ConsentStore
 	clients       *ClientRegistry // nil when DCREnabled is false
 }
 
@@ -90,6 +91,8 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	refreshTokens := NewRefreshTokenStore()
+	consent := NewConsentStore()
+
 	if cfg.TokenStorePath != "" {
 		// A missing file is the normal first start. Anything else — corrupt
 		// JSON, bad permissions, a version from a newer build — costs every
@@ -108,11 +111,16 @@ func NewServer(cfg ServerConfig) *Server {
 			}
 		} else {
 			refreshTokens.Restore(state.RefreshTokenSnapshot)
-			slog.Info("loaded MCP OAuth state", "grants", len(state.Grants))
+			consent.Restore(state.Consent)
+			slog.Info("loaded MCP OAuth state",
+				"grants", len(state.Grants),
+				"approvals", len(state.Consent),
+			)
 		}
 
-		file := &stateFile{path: cfg.TokenStorePath, tokens: refreshTokens}
+		file := &stateFile{path: cfg.TokenStorePath, tokens: refreshTokens, consent: consent}
 		refreshTokens.SetOnChange(file.write)
+		consent.SetOnChange(file.write)
 	}
 
 	return &Server{
@@ -121,6 +129,7 @@ func NewServer(cfg ServerConfig) *Server {
 		cimd:          cimd,
 		authCodes:     NewAuthCodeStore(),
 		refreshTokens: refreshTokens,
+		consent:       consent,
 		clients:       clients,
 	}
 }

--- a/internal/mcp/oauth/server.go
+++ b/internal/mcp/oauth/server.go
@@ -558,9 +558,23 @@ func (s *Server) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 func (s *Server) issueCodeAndRedirect(
 	w http.ResponseWriter,
 	r *http.Request,
+	meta *ClientMetadata,
 	code AuthCodeData,
 	state string,
 ) {
+	// Re-check the target against the client's registered set, even though
+	// both callers already did. This is the sink for an open redirect on an
+	// authorization endpoint, and hoisting the redirect into a shared helper
+	// moved it away from the guard that made it safe — leaving the invariant
+	// resting on a comment, and on every future caller remembering to check.
+	// Keeping the guard adjacent to the redirect makes it local again.
+	if !meta.HasRedirectURI(code.RedirectURI) {
+		renderErrorPage(w, http.StatusBadRequest,
+			"redirect_uri is not registered for this client")
+
+		return
+	}
+
 	rawCode := s.authCodes.Issue(code, authCodeTTL)
 
 	redirectURI, _ := url.Parse(code.RedirectURI)
@@ -577,7 +591,7 @@ func (s *Server) issueCodeAndRedirect(
 	q.Set("iss", s.cfg.issuerID())
 	redirectURI.RawQuery = q.Encode()
 
-	//nolint:gosec // G710: code.RedirectURI was exact-matched against the client's registered redirect_uris (HasRedirectURI) by both callers before reaching here; this is a pre-validated URI, not open redirect.
+	//nolint:gosec // G710: code.RedirectURI is exact-matched against the client's registered redirect_uris (HasRedirectURI) immediately above; this is a pre-validated URI, not open redirect.
 	http.Redirect(w, r, redirectURI.String(), http.StatusFound)
 }
 
@@ -700,7 +714,7 @@ func (s *Server) handleAuthorizeGET(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if verified && s.consent.Allows(consentKey, fingerprint) {
-		s.issueCodeAndRedirect(w, r, AuthCodeData{
+		s.issueCodeAndRedirect(w, r, meta, AuthCodeData{
 			ClientID:      clientID,
 			RedirectURI:   redirectURIRaw,
 			CodeChallenge: codeChallenge,
@@ -852,7 +866,7 @@ func (s *Server) handleAuthorizePOST(w http.ResponseWriter, r *http.Request) {
 		}, shownFingerprint)
 	}
 
-	s.issueCodeAndRedirect(w, r, AuthCodeData{
+	s.issueCodeAndRedirect(w, r, meta, AuthCodeData{
 		ClientID:      clientID,
 		RedirectURI:   redirectURIRaw,
 		CodeChallenge: codeChallenge,

--- a/internal/mcp/oauth/server_test.go
+++ b/internal/mcp/oauth/server_test.go
@@ -25,6 +25,7 @@ func newTestServer(t *testing.T) *Server {
 		MCP: config.MCPConfig{
 			AccessTokenTTL:           time.Hour,
 			RefreshTokenTTL:          720 * time.Hour,
+			ConsentTTL:               testConsentTTL,
 			RequireResourceIndicator: false,
 			DCREnabled:               true,
 			DCRRateLimit:             10,
@@ -35,6 +36,28 @@ func newTestServer(t *testing.T) *Server {
 	}
 	s := NewServer(cfg)
 	s.cimd.AllowLoopback = true
+	return s
+}
+
+// newPersistingServer is newTestServer wired to a state file at path, for tests
+// that restart a server over the same durable state. resource stays explicit:
+// these tests pin it to the audience their fixture tokens were written for.
+func newPersistingServer(t *testing.T, path, resource string) *Server {
+	t.Helper()
+
+	s := NewServer(ServerConfig{
+		Issuer:      "https://cetacean.test",
+		MCPResource: resource,
+		MCP: config.MCPConfig{
+			AccessTokenTTL:  time.Hour,
+			RefreshTokenTTL: 720 * time.Hour,
+			ConsentTTL:      testConsentTTL,
+		},
+		SigningKey: []byte("test-signing-key-32bytes-padded!!"),
+		StatePath:  path,
+	})
+	s.cimd.AllowLoopback = true
+
 	return s
 }
 

--- a/internal/mcp/oauth/store.go
+++ b/internal/mcp/oauth/store.go
@@ -150,32 +150,12 @@ const maxGrantHistorySize = 32
 // and grant-family theft detection. Raw tokens are never persisted; only
 // their SHA-256 hashes are held in memory.
 type RefreshTokenStore struct {
+	changeNotifier
+
 	mu       sync.Mutex
 	tokens   map[string]refreshTokenEntry // hash → live entry
 	consumed map[string]string            // hash → grantID (rotated-away tokens)
 	grants   map[string][]string          // grantID → ordered slice of recent hashes (capped at maxGrantHistorySize)
-
-	// onChange is called after every mutation, always with mu released. Nil
-	// when the store is memory-only.
-	onChange func()
-}
-
-// SetOnChange installs the callback fired after every mutation. Call it during
-// setup, before the store serves any request: it is not guarded by the mutex,
-// because a hook swapped mid-flight would race the mutations it records.
-func (s *RefreshTokenStore) SetOnChange(fn func()) {
-	s.onChange = fn
-}
-
-// writeThrough notifies the owner of the durable state that it changed. It
-// must be called with mu released, since the owner takes a snapshot, which
-// acquires it.
-func (s *RefreshTokenStore) writeThrough() {
-	if s.onChange == nil {
-		return
-	}
-
-	s.onChange()
 }
 
 // NewRefreshTokenStore returns a ready-to-use RefreshTokenStore.
@@ -282,9 +262,7 @@ func (s *RefreshTokenStore) rotate(oldToken string, ttl time.Duration) (RotateRe
 		// Naming the burned family lets the caller clear the user's consent
 		// record and log who was affected, neither of which was possible when
 		// this returned a zero result.
-		owner, _ := s.revokeGrantLocked(grantID)
-
-		return RotateResult{Theft: true, Data: owner}, true
+		return RotateResult{Theft: true, Data: s.revokeGrantLocked(grantID)}, true
 	}
 
 	// Step 3: live token lookup.
@@ -369,33 +347,24 @@ func (s *RefreshTokenStore) revokeGrant(token string) (RefreshTokenData, bool) {
 		return RefreshTokenData{}, false
 	}
 
-	owner, _ := s.revokeGrantLocked(grantID)
-
-	return owner, true
+	return s.revokeGrantLocked(grantID), true
 }
 
 // revokeGrantLocked removes every hash ever associated with grantID from both
 // tokens and consumed, then drops the grant record. It returns the identity
 // the family belonged to, read from its live token — a family has exactly one,
-// unless it has already expired.
+// unless it has already expired, in which case the zero value comes back.
 //
 // Whether revoking a family should also drop the user's consent record is the
 // caller's decision, not this function's: an explicit revocation and a theft
 // must clear it, and an expiry must not, because consent outliving the refresh
 // token is the point of remembering it. Must be called with s.mu held.
-func (s *RefreshTokenStore) revokeGrantLocked(grantID string) (RefreshTokenData, bool) {
-	hashes := s.grants[grantID]
+func (s *RefreshTokenStore) revokeGrantLocked(grantID string) RefreshTokenData {
+	var owner RefreshTokenData
 
-	var (
-		owner RefreshTokenData
-		found bool
-	)
-
-	for _, h := range hashes {
-		if entry, live := s.tokens[h]; live && !found {
+	for _, h := range s.grants[grantID] {
+		if entry, live := s.tokens[h]; live {
 			owner = entry.data
-			owner.Groups = append([]string(nil), entry.data.Groups...)
-			found = true
 		}
 
 		delete(s.tokens, h)
@@ -404,5 +373,5 @@ func (s *RefreshTokenStore) revokeGrantLocked(grantID string) (RefreshTokenData,
 
 	delete(s.grants, grantID)
 
-	return owner, found
+	return owner
 }

--- a/internal/mcp/oauth/store.go
+++ b/internal/mcp/oauth/store.go
@@ -118,7 +118,9 @@ type RefreshTokenData struct {
 	grantID  string // assigned and tracked by the store; unexported
 }
 
-// RotateResult is returned by RefreshTokenStore.Rotate.
+// RotateResult is returned by RefreshTokenStore.Rotate. On the theft path Data
+// names the family that was burned, so the caller can clear its consent record
+// and log the affected subject.
 type RotateResult struct {
 	NewToken string // empty when OK is false
 	Data     RefreshTokenData
@@ -275,12 +277,14 @@ func (s *RefreshTokenStore) rotate(oldToken string, ttl time.Duration) (RotateRe
 	defer s.mu.Unlock()
 
 	// Step 2: replay / theft check runs before anything else. On theft, the
-	// grant family is burned and Data is intentionally zero — the data is no
-	// longer in the store. Callers that need to log the affected subject
-	// must record it at issue time.
+	// grant family is burned.
 	if grantID, isConsumed := s.consumed[oldHash]; isConsumed {
-		s.revokeGrantLocked(grantID)
-		return RotateResult{Theft: true}, true
+		// Naming the burned family lets the caller clear the user's consent
+		// record and log who was affected, neither of which was possible when
+		// this returned a zero result.
+		owner, _ := s.revokeGrantLocked(grantID)
+
+		return RotateResult{Theft: true, Data: owner}, true
 	}
 
 	// Step 3: live token lookup.
@@ -292,7 +296,10 @@ func (s *RefreshTokenStore) rotate(oldToken string, ttl time.Duration) (RotateRe
 	// Step 4: expiry check. Tear down the whole family so consumed and grants
 	// don't accumulate orphaned entries past the token's natural lifetime.
 	if time.Now().After(entry.expiresAt) {
+		// The identity is deliberately dropped: an expired grant must not
+		// clear the user's consent.
 		s.revokeGrantLocked(entry.data.grantID)
+
 		return RotateResult{}, true
 	}
 
@@ -329,17 +336,22 @@ func (s *RefreshTokenStore) rotate(oldToken string, ttl time.Duration) (RotateRe
 	}, true
 }
 
-// RevokeGrant revokes every token in the grant family that contains the
-// given token, whether that token is currently live or already consumed.
-func (s *RefreshTokenStore) RevokeGrant(token string) {
-	if s.revokeGrant(token) {
+// RevokeGrant revokes every token in the grant family that contains the given
+// token, whether that token is currently live or already consumed. It returns
+// the identity the family belonged to, so the caller can clear the matching
+// consent record, and false when the token belongs to no known family.
+func (s *RefreshTokenStore) RevokeGrant(token string) (RefreshTokenData, bool) {
+	owner, revoked := s.revokeGrant(token)
+	if revoked {
 		s.writeThrough()
 	}
+
+	return owner, revoked
 }
 
 // revokeGrant revokes the family and reports whether one was found. A token
 // belonging to no known family is a no-op, and must not write.
-func (s *RefreshTokenStore) revokeGrant(token string) bool {
+func (s *RefreshTokenStore) revokeGrant(token string) (RefreshTokenData, bool) {
 	h := hashToken(token)
 
 	s.mu.Lock()
@@ -354,21 +366,43 @@ func (s *RefreshTokenStore) revokeGrant(token string) bool {
 	}
 
 	if grantID == "" {
-		return false
+		return RefreshTokenData{}, false
 	}
 
-	s.revokeGrantLocked(grantID)
+	owner, _ := s.revokeGrantLocked(grantID)
 
-	return true
+	return owner, true
 }
 
 // revokeGrantLocked removes every hash ever associated with grantID from both
-// tokens and consumed, then drops the grant record. Must be called with s.mu held.
-func (s *RefreshTokenStore) revokeGrantLocked(grantID string) {
+// tokens and consumed, then drops the grant record. It returns the identity
+// the family belonged to, read from its live token — a family has exactly one,
+// unless it has already expired.
+//
+// Whether revoking a family should also drop the user's consent record is the
+// caller's decision, not this function's: an explicit revocation and a theft
+// must clear it, and an expiry must not, because consent outliving the refresh
+// token is the point of remembering it. Must be called with s.mu held.
+func (s *RefreshTokenStore) revokeGrantLocked(grantID string) (RefreshTokenData, bool) {
 	hashes := s.grants[grantID]
+
+	var (
+		owner RefreshTokenData
+		found bool
+	)
+
 	for _, h := range hashes {
+		if entry, live := s.tokens[h]; live && !found {
+			owner = entry.data
+			owner.Groups = append([]string(nil), entry.data.Groups...)
+			found = true
+		}
+
 		delete(s.tokens, h)
 		delete(s.consumed, h)
 	}
+
 	delete(s.grants, grantID)
+
+	return owner, found
 }

--- a/internal/mcp/oauth/store.go
+++ b/internal/mcp/oauth/store.go
@@ -153,27 +153,27 @@ type RefreshTokenStore struct {
 	consumed map[string]string            // hash → grantID (rotated-away tokens)
 	grants   map[string][]string          // grantID → ordered slice of recent hashes (capped at maxGrantHistorySize)
 
-	// persist is called with a fresh snapshot after every mutation, always
-	// with mu released. Nil when the store is memory-only.
-	persist func(RefreshTokenSnapshot)
+	// onChange is called after every mutation, always with mu released. Nil
+	// when the store is memory-only.
+	onChange func()
 }
 
-// SetPersistFunc installs the writer that receives a snapshot after every
-// mutation. Call it during setup, before the store serves any request: it is
-// not guarded by the mutex, because a persister swapped mid-flight would race
-// the mutations it is meant to record.
-func (s *RefreshTokenStore) SetPersistFunc(fn func(RefreshTokenSnapshot)) {
-	s.persist = fn
+// SetOnChange installs the callback fired after every mutation. Call it during
+// setup, before the store serves any request: it is not guarded by the mutex,
+// because a hook swapped mid-flight would race the mutations it records.
+func (s *RefreshTokenStore) SetOnChange(fn func()) {
+	s.onChange = fn
 }
 
-// writeThrough hands the current state to the configured writer. It must be
-// called with mu released, since taking a snapshot acquires it.
+// writeThrough notifies the owner of the durable state that it changed. It
+// must be called with mu released, since the owner takes a snapshot, which
+// acquires it.
 func (s *RefreshTokenStore) writeThrough() {
-	if s.persist == nil {
+	if s.onChange == nil {
 		return
 	}
 
-	s.persist(s.Snapshot())
+	s.onChange()
 }
 
 // NewRefreshTokenStore returns a ready-to-use RefreshTokenStore.

--- a/main.go
+++ b/main.go
@@ -711,24 +711,24 @@ func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string
 		// path, since token durability is not tied to storage.snapshot: an
 		// operator who turns cache snapshots off still gets clients that stay
 		// authorized across a restart.
-		tokenStorePath := filepath.Join(d.cfg.DataDir, "mcp-tokens.json")
+		statePath := filepath.Join(d.cfg.DataDir, "mcp-tokens.json")
 		//nolint:gosec // DataDir is operator-configured, not user input
 		if err := os.MkdirAll(d.cfg.DataDir, 0700); err != nil {
 			slog.Warn(
-				"could not create data dir; MCP refresh tokens will not survive a restart",
+				"could not create data dir; MCP tokens and approvals will not survive a restart",
 				"error", err,
 				"path", d.cfg.DataDir,
 			)
-			tokenStorePath = ""
+			statePath = ""
 		}
 
 		oauthSrv = oauth.NewServer(oauth.ServerConfig{
-			Issuer:         issuer,
-			BasePath:       d.cfg.BasePath,
-			MCPResource:    mcpResource,
-			MCP:            d.cfg.MCP,
-			SigningKey:     signingKey,
-			TokenStorePath: tokenStorePath,
+			Issuer:      issuer,
+			BasePath:    d.cfg.BasePath,
+			MCPResource: mcpResource,
+			MCP:         d.cfg.MCP,
+			SigningKey:  signingKey,
+			StatePath:   statePath,
 		})
 		slog.Info("MCP OAuth 2.1 authorization server enabled",
 			"issuer", issuer, "resource", mcpResource)


### PR DESCRIPTION
Closes #160.

Records a user's consent decision so an already-approved client does not re-prompt on every authorization request. Built on #74's file and its versioning, as the issue anticipated: `mcp-tokens.json` goes to v2 with a `consent` section, and a v1 file loads and yields no approvals — which is exactly the pre-upgrade behaviour.

## The issue's four requirements

**1. Bind the record to the metadata it was granted against.** A `ConsentRecord` carries a SHA-256 fingerprint of the client's name and its sorted `redirect_uris`. It is computed **once**, on the GET that renders the consent page, and travels to the POST in a hidden field folded into the CSRF HMAC that is already verified on every submission. Resolving the client again on POST and fingerprinting *that* would record a document the user may never have seen, whenever the CIMD cache entry lapsed in between. On POST the fresh metadata is compared against what was shown, and a mismatch re-prompts from the new document rather than issuing a code or recording anything.

**2. Revocation must clear consent.** `RevokeGrant` now returns the identity the burned family belonged to, so `/oauth/revoke` clears the matching record. Theft detection at the token endpoint does the same — a replayed token means someone else holds a copy, and the next authorization must reach a human. Natural expiry deliberately does **not** clear it: consent outliving the refresh token is the point.

**3. Limited to verified clients.** Only CIMD clients are remembered. A DCR client's metadata is self-reported and its `client_id` does not survive a restart, so a record keyed on one would be worthless at best.

**4. Exact scope matching.** Records are keyed on subject + `client_id` + resource, as a `ConsentKey` struct rather than three positional strings — a transposed pair would compile and silently key a different record. Fields are length-prefixed into the hash, since a subject can come from an OIDC claim and JSON can encode any byte, so separator-joining could let one field's content spell another's.

## Beyond the issue: approvals are a lease

The issue's requirement 2 turns out not to be reachable in the steady state the feature creates. An approval is only revocable by presenting a token from its grant family — and that family is torn down once its refresh token expires. After that the record outlives the only handle anyone had on it: it keeps authorizing silently, with no in-product way to withdraw it.

So `ConsentStore` owns a lifetime of its own instead of borrowing the token store's. `CETACEAN_MCP_CONSENT_TTL` (default `2160h`/90d) bounds it; approving again renews it. The default has to outlive the 30-day refresh token or remembering buys nothing, so the config test asserts *that relationship* rather than the literal value. `0` disables remembering entirely. The consent page states the lease it is actually offering, read from the store rather than from config so the promise and the enforcement cannot drift.

## Threat model

Treated as the issue asks — integrity, not confidentiality. Unlike the refresh tokens beside them, an approval is a capability: anyone able to *write* the file can pre-approve a client and complete an authorization with no human in the loop. Same `0600` and the same "attacker with host access has already won" caveat, but the file is now also written through a unique temp name, so two processes sharing a data directory cannot interleave bytes into one temp file and publish something that will not parse. Startup sweeps temp files orphaned by an unclean kill, each of which held a full copy of the state.

## Testing

`go test ./...`, `-race`, and `golangci-lint` are clean.

Tests drive the real handlers for the wirings that make the feature work rather than seeding the store: approving records, an approved client skips the page, changed metadata re-prompts, a DCR client never skips, a replay at the token endpoint forgets, and a tampered fingerprint fails CSRF outright rather than merely re-prompting. The v1 fixture carries a live refresh token, so a nested rather than flattened snapshot embedding would be caught. The consent form is rebuilt by reading the hidden inputs back off the rendered page, the way a browser would, so a field added to the template is carried automatically.

Both new lease branches were mutation-tested — removing the expiry check in `Allows`, and the renewal check in `Remember`, each fails a test.
