### PR TITLE
test(logs): pin the cursor rule shared by the paginated and follow paths

### DIFF
--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -438,10 +438,11 @@ func TestFilterSinceAndBacklogFilterAgree(t *testing.T) {
 
 		// A duration is resolved against time.Now() separately by each side,
 		// so the two cursors differ by the microseconds between the calls.
-		// That only matters for a line sitting inside that window: this one
-		// resolves to roughly 1911, putting every fixture line a century clear
-		// of the boundary. Kept because a duration is one of the three
-		// accepted cursor forms and belongs in a parity check.
+		// That only matters for a line sitting inside that window, and this
+		// one resolves to well over a century before now, leaving every
+		// fixture line clear of the boundary by an enormous margin. Kept
+		// because a duration is one of the three accepted cursor forms and
+		// belongs in a parity check.
 		{"duration", "1000000h"},
 
 		{"unparseable", "not-a-cursor"},

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"bytes"
 	"encoding/binary"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -403,19 +404,28 @@ func TestBacklogFilter(t *testing.T) {
 func TestFilterSinceAndBacklogFilterAgree(t *testing.T) {
 	const task = "task-1"
 
+	// Each line owns its Attrs map. Sharing one instance across the fixture
+	// would couple the lines if anything under test ever wrote to it, and a
+	// failure would then point at the wrong line.
+	line := func(timestamp, message string) LogLine {
+		return LogLine{
+			Timestamp: timestamp,
+			Message:   message,
+			Attrs:     map[string]string{"taskId": task},
+		}
+	}
+
 	// Chronological, but deliberately not all in Docker's canonical form. A
 	// fixture of canonical timestamps cannot tell the two rules apart: the
 	// cursor is canonicalized on the way in, so against canonical lines a raw
 	// string compare agrees with Newer by accident. The offset and
 	// reduced-precision lines are the ones that separate them.
-	attrs := map[string]string{"taskId": task}
-
 	lines := []LogLine{
-		{Timestamp: "2026-08-28T09:59:59.000000000Z", Message: "a", Attrs: attrs},
-		{Timestamp: "2026-08-28T12:00:00.000000000+02:00", Message: "b", Attrs: attrs},
-		{Timestamp: "2026-08-28T10:00:00.5Z", Message: "c", Attrs: attrs},
-		{Timestamp: "2026-08-28T10:00:01.000000000Z", Message: "d", Attrs: attrs},
-		{Timestamp: "2026-08-28T11:00:00.000000000Z", Message: "e", Attrs: attrs},
+		line("2026-08-28T09:59:59.000000000Z", "a"),
+		line("2026-08-28T12:00:00.000000000+02:00", "b"),
+		line("2026-08-28T10:00:00.5Z", "c"),
+		line("2026-08-28T10:00:01.000000000Z", "d"),
+		line("2026-08-28T11:00:00.000000000Z", "e"),
 	}
 
 	cursors := []struct {
@@ -425,32 +435,35 @@ func TestFilterSinceAndBacklogFilterAgree(t *testing.T) {
 		{"second precision UTC", "2026-08-28T10:00:00Z"},
 		{"non-UTC offset", "2026-08-28T12:00:00+02:00"},
 		{"nanosecond precision", "2026-08-28T10:00:00.999999999Z"},
+
+		// A duration is resolved against time.Now() separately by each side,
+		// so the two cursors differ by the microseconds between the calls.
+		// That only matters for a line sitting inside that window: this one
+		// resolves to roughly 1911, putting every fixture line a century clear
+		// of the boundary. Kept because a duration is one of the three
+		// accepted cursor forms and belongs in a parity check.
 		{"duration", "1000000h"},
+
 		{"unparseable", "not-a-cursor"},
 	}
 
 	for _, tc := range cursors {
 		t.Run(tc.name, func(t *testing.T) {
 			paginated := []string{}
-			for _, line := range FilterSince(append([]LogLine(nil), lines...), tc.cursor) {
-				paginated = append(paginated, line.Message)
+			for _, kept := range FilterSince(append([]LogLine(nil), lines...), tc.cursor) {
+				paginated = append(paginated, kept.Message)
 			}
 
 			follow := []string{}
 			backlog := NewBacklogFilter(tc.cursor)
-			for _, line := range lines {
-				if backlog.Keep(line) {
-					follow = append(follow, line.Message)
+			for _, candidate := range lines {
+				if backlog.Keep(candidate) {
+					follow = append(follow, candidate.Message)
 				}
 			}
 
-			if len(paginated) != len(follow) {
-				t.Fatalf("paginated %v, follow %v", paginated, follow)
-			}
-			for i := range paginated {
-				if paginated[i] != follow[i] {
-					t.Fatalf("paginated %v, follow %v", paginated, follow)
-				}
+			if !slices.Equal(paginated, follow) {
+				t.Fatalf("paginated kept %v, follow kept %v", paginated, follow)
 			}
 		})
 	}

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -385,3 +385,73 @@ func TestBacklogFilter(t *testing.T) {
 		}
 	})
 }
+
+// TestFilterSinceAndBacklogFilterAgree pins the two entry points to one
+// comparison rule.
+//
+// The paginated path filters with FilterSince and the follow path with
+// BacklogFilter, and they are deliberately not interchangeable: BacklogFilter
+// only screens the replayed backlog, since live output may carry a clock the
+// cursor never saw. But they must agree on *whether a given line is past a
+// given cursor*, because that is the rule the cursors themselves are built on
+// — and the two comparisons living in separate functions is exactly how they
+// drifted apart before (#150).
+//
+// The fixture is one task's backlog in chronological order, which is what
+// BacklogFilter is specified against, so any disagreement is a difference in
+// the rule rather than in the latch.
+func TestFilterSinceAndBacklogFilterAgree(t *testing.T) {
+	const task = "task-1"
+
+	// Chronological, but deliberately not all in Docker's canonical form. A
+	// fixture of canonical timestamps cannot tell the two rules apart: the
+	// cursor is canonicalized on the way in, so against canonical lines a raw
+	// string compare agrees with Newer by accident. The offset and
+	// reduced-precision lines are the ones that separate them.
+	attrs := map[string]string{"taskId": task}
+
+	lines := []LogLine{
+		{Timestamp: "2026-08-28T09:59:59.000000000Z", Message: "a", Attrs: attrs},
+		{Timestamp: "2026-08-28T12:00:00.000000000+02:00", Message: "b", Attrs: attrs},
+		{Timestamp: "2026-08-28T10:00:00.5Z", Message: "c", Attrs: attrs},
+		{Timestamp: "2026-08-28T10:00:01.000000000Z", Message: "d", Attrs: attrs},
+		{Timestamp: "2026-08-28T11:00:00.000000000Z", Message: "e", Attrs: attrs},
+	}
+
+	cursors := []struct {
+		name   string
+		cursor string
+	}{
+		{"second precision UTC", "2026-08-28T10:00:00Z"},
+		{"non-UTC offset", "2026-08-28T12:00:00+02:00"},
+		{"nanosecond precision", "2026-08-28T10:00:00.999999999Z"},
+		{"duration", "1000000h"},
+		{"unparseable", "not-a-cursor"},
+	}
+
+	for _, tc := range cursors {
+		t.Run(tc.name, func(t *testing.T) {
+			paginated := []string{}
+			for _, line := range FilterSince(append([]LogLine(nil), lines...), tc.cursor) {
+				paginated = append(paginated, line.Message)
+			}
+
+			follow := []string{}
+			backlog := NewBacklogFilter(tc.cursor)
+			for _, line := range lines {
+				if backlog.Keep(line) {
+					follow = append(follow, line.Message)
+				}
+			}
+
+			if len(paginated) != len(follow) {
+				t.Fatalf("paginated %v, follow %v", paginated, follow)
+			}
+			for i := range paginated {
+				if paginated[i] != follow[i] {
+					t.Fatalf("paginated %v, follow %v", paginated, follow)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #150.

**The bug described in #150 is already fixed.** I verified each acceptance criterion empirically against `main` before writing anything:

| Criterion | Result |
|---|---|
| Non-UTC offset returns the same lines as the equivalent UTC instant | passes |
| `?after=2026-08-28T12:00:00Z` keeps sub-second lines in that second | passes |
| A Go duration works rather than being silently ignored | passes |
| A cursor from `nextCursor` round-trips without skipping | passes |

`ParseCursor` resolves RFC 3339 at any precision or offset, and Go durations, into Docker's fixed-width UTC layout; `Newer`/`Older` canonicalize the line timestamp before comparing. `dockerTimeFormat` is used rather than `RFC3339Nano` precisely because the latter trims trailing zeros — the round-trip trap the issue calls out. This landed with the shared `internal/logs` package in #148, despite the issue's "Why it wasn't fixed in #148" note.

**What was missing is the fifth criterion:** *"The SSE and paginated paths agree, with a test pinning that they do."* The two paths carry the rule in separate functions — `FilterSince` for pagination, `BacklogFilter.Keep` for follow — which is how they drifted apart in the first place. This adds that guard.

The two are deliberately *not* interchangeable: `BacklogFilter` only screens the replayed backlog, since live output can carry a clock the cursor never saw. What they must agree on is whether a given line is past a given cursor, so that is what the test pins, over a single task's chronologically ordered backlog.

### On the fixture

The first version of this test was vacuous and I caught it by mutation-testing. With a fixture of canonical Docker timestamps, regressing `BacklogFilter` to the exact `line.Timestamp <= f.cursor` comparison from the issue **still passed** — because the cursor is canonicalized on the way in, so against canonical lines a raw compare agrees with `Newer` by accident.

The fixture therefore includes a `+02:00` line and a reduced-precision line, which are what separate the two rules. With those, the same regression fails three of the five cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RSfskr3a6feoEiSRVSKtM
