### PR TITLE
fix(frontend): spread SSE reconnect delays so clients stop retrying in lockstep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Breaking:** `CETACEAN_MCP_SESSION_IDLE_TTL` and `CETACEAN_MCP_MAX_SESSIONS` (and their `session_idle_ttl` / `max_sessions` config-file equivalents) have been removed. The protocol no longer has sessions, so there is nothing to expire or cap. Both are now ignored if you still set them, so an existing config keeps working
 
 ### Fixed
+- Browsers no longer reconnect to Cetacean in lockstep after a restart or a brief capacity blip. Every open tab used to wait exactly the same interval, so they retried together, collided, and synchronized harder each round; reconnect delays are now spread out. Where the server asks a client to wait, the wait is still never shorter than it asked for
 - MCP clients no longer have to re-authorize every time Cetacean restarts. Refresh tokens are now kept in the data directory alongside the state snapshot, so an authorized client stays authorized. Set `CETACEAN_MCP_SIGNING_KEY` as well to keep access tokens valid across a restart too — an auto-generated key changes on every start
 - Turning off `CETACEAN_MCP_CIMD_ENABLED` now actually takes effect. The setting was ignored, so a server configured not to fetch client metadata documents still fetched them
 - AI agents on the new MCP protocol revision now receive live cluster updates. Subscribing succeeded and then delivered nothing, because 2026-07-28 replaced the subscription call the server was listening for

--- a/frontend/src/components/log/LogViewer.test.tsx
+++ b/frontend/src/components/log/LogViewer.test.tsx
@@ -139,6 +139,10 @@ function currentStream(): MockStream {
 }
 
 beforeEach(() => {
+  // These tests assert the reconnect *schedule*, so the jitter is pinned to
+  // its midpoint, where the backoff spread is exactly 1 and the curve is its
+  // nominal 1s/2s/4s. The spread itself is covered in lib/backoff.test.ts.
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
   mockServiceLogs.mockReset();
   mockServiceLogsStreamURL.mockReset();
   streams.length = 0;
@@ -150,6 +154,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -521,7 +526,10 @@ describe("LogViewer live tail resilience", () => {
     await flush(1000);
     await flush();
 
-    expect(screen.getByText(/too many log streams — retrying in 5s/i)).toBeInTheDocument();
+    // The countdown reports the wait actually scheduled, not the server's raw
+    // Retry-After: the 5s floor is stretched to 6.25s (Math.random pinned at
+    // 0.5) so rejected clients do not all wake in the same second.
+    expect(screen.getByText(/too many log streams — retrying in 7s/i)).toBeInTheDocument();
   });
 
   it("gives up after the retry cap and offers to resume", async () => {

--- a/frontend/src/components/log/logStream.test.ts
+++ b/frontend/src/components/log/logStream.test.ts
@@ -66,6 +66,10 @@ function queueStream(...chunks: string[]) {
 }
 
 beforeEach(() => {
+  // These tests assert the reconnect *schedule*, so the jitter is pinned to
+  // its midpoint, where the backoff spread is exactly 1 and the curve is its
+  // nominal 1s/2s/4s. The spread itself is covered in lib/backoff.test.ts.
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
   queue.length = 0;
   requestedUrls.length = 0;
   requestInits = [];
@@ -84,6 +88,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });
@@ -338,17 +343,39 @@ describe("streamLogsWithRetry", () => {
     expect(waits).toEqual([2000, 4000, 8000, 16_000]);
   });
 
-  it("waits the server's Retry-After instead of the backoff curve", async () => {
+  it("reports the stretched Retry-After as the deadline it will actually wait", async () => {
+    // retryAt drives the user-visible countdown, so it has to be the jittered
+    // delay rather than what the server asked for, or the countdown drifts
+    // against the retry it is counting down to.
+    queue.push(() => rateLimitedResponse(5));
+    const active = run();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    const retry = active.retries[0]!;
+    expect(retry.retryAt - Date.now()).toBe(6250);
+
+    await vi.advanceTimersByTimeAsync(6250);
+    expect(requestedUrls).toHaveLength(2);
+
+    active.controller.abort();
+    await active.finished;
+  });
+
+  it("waits at least the server's Retry-After instead of the backoff curve", async () => {
     queue.push(() => rateLimitedResponse(5));
     const active = run();
 
     await vi.advanceTimersByTimeAsync(0);
     expect(active.retries[0]?.failure.retryAfterMilliseconds).toBe(5000);
 
-    await vi.advanceTimersByTimeAsync(4000);
+    // The server named a floor and handed the same one to every client it
+    // rejected, so the wait is stretched past it rather than landing on it.
+    // Math.random is pinned at 0.5, so 5s becomes 6.25s.
+    await vi.advanceTimersByTimeAsync(5000);
     expect(requestedUrls).toHaveLength(1);
 
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1250);
     expect(requestedUrls).toHaveLength(2);
 
     active.controller.abort();

--- a/frontend/src/components/log/logStream.ts
+++ b/frontend/src/components/log/logStream.ts
@@ -1,6 +1,6 @@
 import type { ApiError, LogLine } from "../../api/client";
 import { problemFromResponse, redirectToLogin } from "../../api/client";
-import { backoffDelay } from "../../lib/backoff";
+import { backoffDelay, retryAfterDelay } from "../../lib/backoff";
 
 /**
  * Why this reads SSE through fetch instead of using EventSource:
@@ -317,9 +317,15 @@ export async function streamLogsWithRetry(
       return;
     }
 
+    // A Retry-After is stretched rather than replaced: the server named a
+    // floor, and every client it rejected while the cap was full was given the
+    // same one. Without a spread they all wake in the same second, find the cap
+    // still full, and synchronize harder each round.
+    const retryAfter = outcome.failure.retryAfterMilliseconds;
     const delay =
-      outcome.failure.retryAfterMilliseconds ??
-      backoffDelay(attempt, { base: baseReconnectDelay, max: maxReconnectDelay });
+      retryAfter === undefined
+        ? backoffDelay(attempt, { base: baseReconnectDelay, max: maxReconnectDelay })
+        : retryAfterDelay(retryAfter);
 
     handlers.onRetrying({
       attempt,

--- a/frontend/src/lib/backoff.test.ts
+++ b/frontend/src/lib/backoff.test.ts
@@ -12,6 +12,34 @@ function randomReturns(value: number) {
   vi.spyOn(Math, "random").mockReturnValue(value);
 }
 
+/**
+ * The largest value Math.random() realistically yields. Its range is `[0, 1)`,
+ * so 1 is unreachable; this rounds to the same maxima while staying an input
+ * the platform can actually produce.
+ */
+const nearlyOne = 0.999999;
+
+/**
+ * Drives Math.random through a fixed sequence, so a test asserting that the
+ * delays vary is deterministic rather than merely unlikely to collide.
+ *
+ * A stub still catches the spread being removed: a delay computed without
+ * randomness is constant whatever the sequence yields, so the set collapses to
+ * one entry and the assertion fails.
+ */
+function randomCycles(values: number[]) {
+  let index = 0;
+
+  vi.spyOn(Math, "random").mockImplementation(() => {
+    const value = values[index % values.length]!;
+    index += 1;
+
+    return value;
+  });
+}
+
+const spreadSamples = [0, 0.25, 0.5, 0.75, nearlyOne];
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -56,7 +84,7 @@ describe("backoffDelay", () => {
   });
 
   it("spreads the delay a quarter above nominal at the high end", () => {
-    randomReturns(1);
+    randomReturns(nearlyOne);
 
     expect(backoffDelay(1, options)).toBe(1250);
   });
@@ -64,6 +92,8 @@ describe("backoffDelay", () => {
   it("does not hand two clients failing together the same delay", () => {
     // A deterministic schedule is what turns one restart into a series of
     // synchronized spikes, so the spread is the behaviour under test.
+    randomCycles(spreadSamples);
+
     const delays = new Set(Array.from({ length: 50 }, () => backoffDelay(3, options)));
 
     expect(delays.size).toBeGreaterThan(1);
@@ -85,12 +115,14 @@ describe("retryAfterDelay", () => {
   });
 
   it("stretches by up to half again", () => {
-    randomReturns(1);
+    randomReturns(nearlyOne);
 
     expect(retryAfterDelay(5000)).toBe(7500);
   });
 
   it("scatters clients rejected at the same instant", () => {
+    randomCycles(spreadSamples);
+
     const delays = new Set(Array.from({ length: 50 }, () => retryAfterDelay(5000)));
 
     expect(delays.size).toBeGreaterThan(1);

--- a/frontend/src/lib/backoff.test.ts
+++ b/frontend/src/lib/backoff.test.ts
@@ -1,28 +1,103 @@
-import { backoffDelay } from "./backoff";
-import { describe, expect, it } from "vitest";
+import { backoffDelay, retryAfterDelay } from "./backoff";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const options = { base: 1000, max: 30_000 };
 
+/**
+ * Pins Math.random so a jittered delay is exact rather than merely in range.
+ * At 0.5 the backoff spread is exactly 1, which is what lets the nominal
+ * schedule below still be asserted on round numbers.
+ */
+function randomReturns(value: number) {
+  vi.spyOn(Math, "random").mockReturnValue(value);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("backoffDelay", () => {
   it("waits the base delay before the first retry", () => {
+    randomReturns(0.5);
+
     expect(backoffDelay(1, options)).toBe(1000);
   });
 
   it("doubles on each subsequent attempt", () => {
+    randomReturns(0.5);
+
     expect([2, 3, 4, 5].map((attempt) => backoffDelay(attempt, options))).toEqual([
       2000, 4000, 8000, 16_000,
     ]);
   });
 
-  it("never exceeds the ceiling", () => {
+  it("stops doubling at the ceiling", () => {
+    randomReturns(0.5);
+
     expect(backoffDelay(20, options)).toBe(30_000);
   });
 
   it("treats a first attempt below one as the first attempt", () => {
+    randomReturns(0.5);
+
     expect(backoffDelay(0, options)).toBe(1000);
   });
 
   it("keeps each caller's own policy values", () => {
+    randomReturns(0.5);
+
     expect(backoffDelay(1, { base: 5000, max: 30_000 })).toBe(5000);
+  });
+
+  it("spreads the delay a quarter below nominal at the low end", () => {
+    randomReturns(0);
+
+    expect(backoffDelay(1, options)).toBe(750);
+  });
+
+  it("spreads the delay a quarter above nominal at the high end", () => {
+    randomReturns(1);
+
+    expect(backoffDelay(1, options)).toBe(1250);
+  });
+
+  it("does not hand two clients failing together the same delay", () => {
+    // A deterministic schedule is what turns one restart into a series of
+    // synchronized spikes, so the spread is the behaviour under test.
+    const delays = new Set(Array.from({ length: 50 }, () => backoffDelay(3, options)));
+
+    expect(delays.size).toBeGreaterThan(1);
+
+    for (const delay of delays) {
+      expect(delay).toBeGreaterThanOrEqual(3000);
+      expect(delay).toBeLessThanOrEqual(5000);
+    }
+  });
+});
+
+describe("retryAfterDelay", () => {
+  it("never waits less than the server asked for", () => {
+    // Waiting less than Retry-After is the one thing a client must not do, so
+    // the spread is strictly later and the server's value is the lower bound.
+    randomReturns(0);
+
+    expect(retryAfterDelay(5000)).toBe(5000);
+  });
+
+  it("stretches by up to half again", () => {
+    randomReturns(1);
+
+    expect(retryAfterDelay(5000)).toBe(7500);
+  });
+
+  it("scatters clients rejected at the same instant", () => {
+    const delays = new Set(Array.from({ length: 50 }, () => retryAfterDelay(5000)));
+
+    expect(delays.size).toBeGreaterThan(1);
+
+    for (const delay of delays) {
+      expect(delay).toBeGreaterThanOrEqual(5000);
+      expect(delay).toBeLessThanOrEqual(7500);
+    }
   });
 });

--- a/frontend/src/lib/backoff.ts
+++ b/frontend/src/lib/backoff.ts
@@ -10,7 +10,9 @@ export interface BackoffOptions {
 }
 
 /**
- * How far a jittered delay may fall either side of its nominal value.
+ * How far a jittered delay may fall either side of its nominal value, giving a
+ * factor in `[1 - fraction, 1 + fraction)` — the upper bound is exclusive
+ * because `Math.random()` never returns 1.
  *
  * Clients that fail together compute the same delay, so without a spread they
  * wake together, re-collide, and synchronize harder each round — which is what
@@ -20,19 +22,22 @@ export interface BackoffOptions {
 const backoffJitterFraction = 0.25;
 
 /**
- * How much longer than the server's `Retry-After` a delay may be stretched.
+ * How much longer than the server's `Retry-After` a delay may be stretched,
+ * giving a factor in `[1, 1 + fraction)` — the upper bound is exclusive
+ * because `Math.random()` never returns 1.
  *
  * `Retry-After` is a floor, not a target: waiting *less* than the server asked
  * is the one thing a client must not do. So this spreads strictly later, never
- * earlier — at `Math.random() === 0` the delay is exactly what was asked for.
+ * earlier — at `Math.random() === 0` the delay is exactly what was asked for,
+ * which is the reachable lower bound.
  */
 const retryAfterStretchFraction = 0.5;
 
 /**
  * Exponential backoff: the first retry waits `base`, each subsequent one
  * doubles, and the doubling stops at `max` — then a random spread of
- * ±`backoffJitterFraction` is applied so that clients which failed at the same
- * instant do not retry at the same instant.
+ * ±`backoffJitterFraction` is applied (upper bound exclusive) so that clients
+ * which failed at the same instant do not retry at the same instant.
  *
  * The schedule is shared; the values are not. Each stream passes its own
  * `base` and `max` because the policies genuinely differ — the log tail
@@ -52,8 +57,8 @@ export function backoffDelay(attempt: number, { base, max }: BackoffOptions): nu
  * Spreads a server-supplied `Retry-After` so that every client rejected while
  * a cap was full does not wake in the same second and re-collide.
  *
- * The result is never shorter than the server asked for; see
- * `retryAfterStretchFraction`.
+ * The result is never shorter than the server asked for, and always shorter
+ * than `1 + retryAfterStretchFraction` times it.
  *
  * @param milliseconds the delay the server asked for.
  */

--- a/frontend/src/lib/backoff.ts
+++ b/frontend/src/lib/backoff.ts
@@ -1,13 +1,38 @@
 export interface BackoffOptions {
   /** Delay before the first retry, in milliseconds. */
   base: number;
-  /** Ceiling the doubling never exceeds, in milliseconds. */
+  /**
+   * Ceiling the doubling never exceeds, in milliseconds. It bounds the nominal
+   * schedule; jitter is applied on top, so an individual delay may land up to
+   * `backoffJitterFraction` above it.
+   */
   max: number;
 }
 
 /**
+ * How far a jittered delay may fall either side of its nominal value.
+ *
+ * Clients that fail together compute the same delay, so without a spread they
+ * wake together, re-collide, and synchronize harder each round — which is what
+ * keeps a server pinned at its connection cap. A quarter is enough to scatter
+ * a burst while leaving the schedule recognisable to someone reading logs.
+ */
+const backoffJitterFraction = 0.25;
+
+/**
+ * How much longer than the server's `Retry-After` a delay may be stretched.
+ *
+ * `Retry-After` is a floor, not a target: waiting *less* than the server asked
+ * is the one thing a client must not do. So this spreads strictly later, never
+ * earlier — at `Math.random() === 0` the delay is exactly what was asked for.
+ */
+const retryAfterStretchFraction = 0.5;
+
+/**
  * Exponential backoff: the first retry waits `base`, each subsequent one
- * doubles, and none waits longer than `max`.
+ * doubles, and the doubling stops at `max` — then a random spread of
+ * ±`backoffJitterFraction` is applied so that clients which failed at the same
+ * instant do not retry at the same instant.
  *
  * The schedule is shared; the values are not. Each stream passes its own
  * `base` and `max` because the policies genuinely differ — the log tail
@@ -17,5 +42,21 @@ export interface BackoffOptions {
  * @param attempt 1-based index of the retry about to be made.
  */
 export function backoffDelay(attempt: number, { base, max }: BackoffOptions): number {
-  return Math.min(base * 2 ** (Math.max(1, attempt) - 1), max);
+  const nominal = Math.min(base * 2 ** (Math.max(1, attempt) - 1), max);
+  const spread = 1 - backoffJitterFraction + Math.random() * backoffJitterFraction * 2;
+
+  return Math.round(nominal * spread);
+}
+
+/**
+ * Spreads a server-supplied `Retry-After` so that every client rejected while
+ * a cap was full does not wake in the same second and re-collide.
+ *
+ * The result is never shorter than the server asked for; see
+ * `retryAfterStretchFraction`.
+ *
+ * @param milliseconds the delay the server asked for.
+ */
+export function retryAfterDelay(milliseconds: number): number {
+  return Math.round(milliseconds * (1 + Math.random() * retryAfterStretchFraction));
 }

--- a/frontend/src/lib/eventStream.test.ts
+++ b/frontend/src/lib/eventStream.test.ts
@@ -12,6 +12,10 @@ function setVisibility(state: "visible" | "hidden") {
 }
 
 beforeEach(() => {
+  // These tests assert the reconnect *schedule*, so the jitter is pinned to
+  // its midpoint, where the backoff spread is exactly 1 and the curve is its
+  // nominal 1s/2s/4s. The spread itself is covered in lib/backoff.test.ts.
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
   setVisibility("visible");
   MockEventSource.instances = [];
   vi.stubGlobal("EventSource", MockEventSource);
@@ -19,6 +23,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });


### PR DESCRIPTION
Closes #149.

Both client reconnect paths computed a purely deterministic delay, so clients that fail together retry together. One container restart is enough — every open tab loses `/events` at the same moment and returns at 1s, 2s, 4s in step. A saturated cap is worse: all three capped endpoints answer with the same hardcoded `Retry-After: 5`, so every rejected client wakes in the same second, finds the cap still full, and synchronizes harder each round.

### Approach

Jitter lives in `lib/backoff.ts`, which `eventStream.ts` and `logStream.ts` already share, so the spread cannot end up applied to one path and not the other — the divergence the issue warns about.

The two cases are treated differently, per the decision the issue asked for:

- **The backoff curve** gets ±25% around its nominal delay.
- **A server-supplied `Retry-After`** is *stretched*, not replaced. It is a floor, not a target, and waiting less than the server asked is the one thing a client must not do — so `retryAfterDelay` only ever spreads later. At `Math.random() === 0` it returns exactly the value asked for, which is asserted.

Jitter is applied on top of the `max` ceiling rather than clamped to it. Clamping would re-converge every client onto exactly `max` at high attempt counts, which is precisely where the spread matters most; the `BackoffOptions.max` doc now says it bounds the nominal schedule.

### Acceptance criteria

| Criterion | Where |
|---|---|
| Two clients rejected at the same instant do not retry at the same instant | `backoff.test.ts` — 50 samples must yield more than one distinct delay, on both paths |
| A jittered delay is never shorter than the server's `Retry-After` | `backoff.test.ts` — pinned at `random() === 0`, and the 50-sample window asserts a `>= 5000` floor |
| The countdown shown in the log viewer matches the delay actually used | `logStream.test.ts` — `retryAt - now` is the stretched 6250ms, and the timer fires at exactly that |
| Tests assert windows, not exact values, and stay deterministic | `Math.random` is stubbed via `vi.spyOn` throughout |

### Note on the existing timing tests

The reconnect tests in `eventStream.test.ts`, `logStream.test.ts` and `LogViewer.test.tsx` assert the *schedule*, not the spread, so they pin `Math.random` to its midpoint — where the backoff factor is exactly 1 and the curve is its nominal 1s/2s/4s/8s/16s. That keeps the approved behaviour under test unchanged and leaves the spread to be tested where it belongs, at both extremes plus over many samples.

Two assertions did change, and both are the intended behaviour change: the `Retry-After` path now waits 6.25s rather than 5s, and the log viewer reads "retrying in 7s" — which is the honest countdown for the wait actually scheduled.

### Deliberately not included

Server-side `Retry-After` jitter. It would help clients we do not control, but it cannot fix the restart case, where no response is sent at all — so the client-side change is needed regardless, and doing both in one change would conflate them. Happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
