### PR TITLE
ci: keep major bumps out of the grouped dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,10 @@ updates:
     labels:
       - dependencies
       - github-actions
-    # One PR for every action bump, including majors. Dependabot reads the
+    # One PR for every action bump, including majors — deliberately unlike
+    # the other ecosystems below, which leave majors out of their group. For
+    # a SHA-pinned action a major is usually just a runner bump, and holding
+    # one back would leave the pin stale for a week. Dependabot reads the
     # trailing `# v…` comment on each pinned SHA to figure out the current
     # version, so the SHA-pinning convention in ci.yml/pages.yml/release.yml
     # still works here.
@@ -38,11 +41,16 @@ updates:
     labels:
       - dependencies
       - go
-    # One PR for every Go module bump, including majors.
+    # One PR for every minor and patch Go module bump. Majors are left out
+    # of the group so each arrives as its own PR: a Go major is an import-path
+    # change (/v2 -> /v3) and never merges on sight.
     groups:
       go-deps:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     ignore:
       # docker/docker periodically ships advisories (docker cp races, etc.)
       # that target the daemon, not SDK consumers. Cetacean uses the SDK
@@ -78,13 +86,22 @@ updates:
         patterns:
           - "oxlint"
           - "oxfmt"
-      # One PR for every other frontend dependency bump, including majors.
+        update-types:
+          - minor
+          - patch
+      # One PR for every other minor and patch frontend bump. Majors are
+      # excluded from the group so a grouped PR stays mergeable on sight;
+      # each major then arrives on its own and can be reviewed and tested
+      # without holding up the safe bumps beside it.
       frontend:
         patterns:
           - "*"
         exclude-patterns:
           - "oxlint"
           - "oxfmt"
+        update-types:
+          - minor
+          - patch
 
   # Marketing/docs site (Astro).
   - package-ecosystem: npm
@@ -105,3 +122,6 @@ updates:
       website-all:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Every ecosystem grouped on `patterns: ["*"]` with no `update-types`, so a major bump landed in the same PR as the patches. This week showed the cost: PR #187 is ten patch/minor frontend bumps plus `vitest` 4.1.11 → 5.0.0, and PR #186 is six plus `@astrojs/mdx` 7.0.8 → 8.0.0. The safe bumps can't be taken without the major, and the major can't be reviewed on its own.

Restricts the `go-deps`, `frontend`, `frontend-lint` and `website-all` groups to `minor` and `patch`. Dependabot then opens each major as its own single-dependency PR.

`github-actions` keeps grouping majors deliberately — for a SHA-pinned action a major is usually just a runner bump, and holding it back would leave the pin stale for a week. The comment there now says that's intentional rather than an oversight.

No user-facing change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oMRxgQVKcZjnuB6WLx4wE