### PR TITLE
fix(ci): stop the SBOM losing every npm integrity hash after a build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
       # cyclonedx-gomod compiles the package, so main.go's //go:embed needs the
       # built frontend present.
       - run: cd frontend && npm run build && npm run build:widgets
+      # The build mutates node_modules enough that npm stops reporting
+      # `integrity` for the installed tree, and cyclonedx-npm reads that tree —
+      # so generating the SBOM straight after a build silently drops every
+      # npm SHA-512 hash and this gate then fails against the committed file.
+      # dist/ and dist-widgets/ survive npm ci, so reinstalling is enough.
+      - run: cd frontend && npm ci
       - run: make sbom
       - name: Verify the tagged SBOM matches the tagged dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - The Tailscale tsnet deployment example now sets the state directory it mounts a volume for. Without it tsnet chose its own location, the volume went unused, and the node re-authenticated on every restart
 - Corrected several documentation claims: the log viewer does not tail live until the tail is turned on, the logical topology draws one edge per pair of services rather than one per shared network, Swarm ignores Compose's `depends_on`, and the default operations level permits operational writes rather than everything
 - The keyboard shortcut overlay lists every shortcut again. The chords for the metrics console and the recommendations page were missing from it, so `?` claimed to show the full list while omitting two, and it described `/` as focusing a search field rather than opening the command palette
+- The SBOM no longer loses the integrity hash of every npm dependency depending on when it was generated. The frontend build mutates `node_modules` enough that npm stops reporting `integrity` for the installed tree, so regenerating the SBOM after a build dropped all 157 hashes and looked like ordinary dependency drift. Generation now refuses to write a hash-less SBOM rather than quietly shipping one
 
 ## [0.12.0] - 2026-08-28
 

--- a/scripts/build-sbom.sh
+++ b/scripts/build-sbom.sh
@@ -43,6 +43,19 @@ toolbin="$tmp/cyclonedx-gomod"
 echo "==> npm packages (production only)"
 ( cd "$repo_root/frontend" && npx --no-install cyclonedx-npm --omit dev --output-file "$tmp/npm.cdx.json" )
 
+# cyclonedx-npm reads the *installed* tree, and npm stops reporting `integrity`
+# for a tree the frontend build has touched — so running this right after a
+# build yields an SBOM with no npm hashes at all. That is a silent loss of
+# supply-chain data, and it looks like ordinary dependency drift to the release
+# gate, so fail loudly and say how to fix it.
+if grep -q '"integrity"' "$repo_root/frontend/package-lock.json" \
+   && ! grep -q 'SHA-512' "$tmp/npm.cdx.json"; then
+  echo "error: npm components came out with no integrity hashes." >&2
+  echo "  node_modules has been mutated since it was installed (usually by the" >&2
+  echo "  frontend build). Run 'cd frontend && npm ci' and try again." >&2
+  exit 1
+fi
+
 echo "==> merge + strip volatile fields (deterministic output)"
 # Version is intentionally omitted from the envelope so the committed file
 # only diffs when dependencies change, not when a release tag is cut.


### PR DESCRIPTION
**The v0.13.0 tag is blocked on this.** `sbom-gate` failed and skipped `build`, `docker` and `release` — the gate working as designed. But the SBOM was not stale.

## Cause

`cyclonedx-npm` reads the **installed tree**, and npm stops reporting `integrity` for a tree the frontend build has touched. Proven locally on the tagged commit:

| Sequence | npm SHA-512 hashes | Drift vs committed |
|---|---|---|
| `npm ci` → build → `make sbom` | **0** | yes |
| `npm ci` → build → `npm ci` → `make sbom` | **157** | none |

That is exactly the difference between the two jobs, which disagreed on commit `144e4897` **90 seconds apart**:

- CI `sbom-sync` generates straight after `npm ci` and reuses the `build-frontend` artifact → reported `main` current.
- `release.yml` `sbom-gate` builds the frontend first → wanted to delete all 157 hashes.

## Fix

**`sbom-gate` reinstalls `node_modules` after building.** `dist/` and `dist-widgets/` live outside `node_modules` and survive `npm ci`, so the `//go:embed` still resolves.

**`build-sbom.sh` refuses to write a hash-less SBOM** when the lockfile has integrity, naming the remedy. Without it the failure is silent and reads as a dependency change — I twice diagnosed the regenerated file as "stale local `node_modules`" and nearly committed the degraded version, which would have shipped a release whose SBOM had no npm hashes. The pre-commit hook runs the same script, so it is guarded too.

Also worth noting: `make sbom-verify` only diffs the working tree, so running it alone proves nothing about reproducibility — it passes on a clean tree whether or not regeneration agrees.

## Rejected alternatives

- **`--package-lock-only`** restores the hashes but reads no per-package `package.json`, losing `externalReferences` and author names — and 155 lines of `THIRD_PARTY_LICENSES`, which is legally relevant.
- **Joining the two passes** (metadata from the tree, hashes from the lockfile) works but did not byte-reproduce the committed file, so it would have churned the artifact for no gain.

The committed SBOM is unchanged by this PR; only the way it is regenerated is.

## Test plan

- [x] Guard fires after a build and leaves the tree untouched
- [x] After `npm ci`, regeneration reproduces the committed artifacts byte for byte
- [x] `make check` exit 0; `actionlint` clean; `bash -n` on the script
- [ ] After merge: re-tag `v0.13.0` and confirm `sbom-gate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)