### PR TITLE
feat: one public URL for the OAuth issuer, OIDC callback and feed links

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,125 @@
+# Backlog
+
+Working scratch, deliberately untracked. Everything still open after 0.13.0,
+consolidated from the plan and review docs before they left `docs/specs/`, from
+the open issues, and from the MCP evaluation set. Delete it when it is empty or
+when the items have become issues.
+
+Verified against `main` at `2343d3f0`: CI green, `[Unreleased]` empty, one TODO
+in the source tree, all 45 MCP review findings marked fixed, issues #69-74 all
+closed. Docker tag aliases (`v0`, `v0.13`, `latest`) and release attestation are
+already in `release.yml` — both were on the loose-end list and are done.
+
+## In flight
+
+- **PR #197 — internal docs consolidation.** Plans and point-in-time reviews out
+  of `docs/specs/`, `docs/specs/README.md` recording the split. All 11 checks
+  green; ready to merge.
+- **PR #198 — label-based ACL,** superseding #16 and closing #11. Ported onto
+  current `main` with two defects fixed on the way: the allow-all suppression was
+  global rather than per resource (one boolean turned an unpolicied cluster dark),
+  and `Filter` was quadratic against the real cache — 41ms to filter a page of
+  2000 services, now 1.2ms. #16 is closed with both recorded.
+- **Validate 0.13.0 live.** The evaluation set's coverage markers were re-derived
+  by reading the build, not by asking a cluster, so the release's headline claim
+  is unverified end to end. Rolling out to prod to run it. `docs/test_protocol.md`
+  now has a "Label-Based ACL" section that also wants a real cluster with a
+  non-`none` auth provider.
+
+## Housekeeping
+
+- Delete `feature/mcp-server` — 5 months old, 113 behind, 50 conflicts, entirely
+  superseded by the MCP server that shipped in 0.13.0.
+- Delete `fix/release-build-widgets` — fully in `main` via the #194/#195 squashes;
+  `main` is now strictly ahead of it. Remote is already gone.
+- The worktree at `../cetacean-acl-labels` now holds a closed branch. It is the
+  only remaining copy of #16's original 23 commits outside the reflog, so keep it
+  until #198 lands, then remove both it and `feature/acl-labels`.
+- The `- [ ]` checkboxes in the moved plan files were never maintained — every
+  plan showed 0 of N checked including the ones that fully shipped. If plans come
+  back, either maintain them or drop the checkbox syntax.
+
+## Stagnant work — needs a decision, not a task
+
+- **`feature/alertmanager-integration`** — the largest unlanded feature in the
+  repo and never opened as a PR. 35 commits, 228 behind, 55 files: an
+  `internal/alertmanager` package (client, discovery, webhook), alert and silence
+  API handlers, swarm state gauges, Prometheus rules wired to Cetacean's own
+  metrics, and a frontend alert badge. 18 conflicts, concentrated where it hurts —
+  `docs/configuration.md` no longer exists (it is `configuration.mdx`), plus
+  `App.tsx`, `api/types.ts`, `NodeDetail.tsx`.
+  Per-commit rebase is not the move at this distance: squash to one diff and
+  re-apply, or re-implement with the branch as reference. Sits in
+  `.worktrees/alertmanager`.
+
+## Carried forward from the removed reviews
+
+Two items that were real and are not in any issue:
+
+- **`SegmentPrefixMatch` allocates a memo map per call on a hot path** —
+  `internal/cluster/search.go:457`, the one TODO in the tree. Was M-39, closed
+  with the marker rather than the fix, pending a benchmark to show it matters.
+  Benchmark first; the fix is only worth it if the benchmark says so.
+- **`BacklogFilter` clock-drift suppression** — the one residual the SSE review
+  bounded rather than eliminated. A task's backlog ends only when one of *that
+  task's* lines clears the cursor, so on a multi-node swarm a replica whose node
+  clock trails the one that stamped the cursor stays silent for the drift
+  duration after a resume, behind a healthy "Live" badge. It self-heals and no
+  other replica is affected. Bounding the backlog by line count or elapsed time,
+  rather than purely by "a line cleared the cursor", would close it.
+
+## Found while porting #198
+
+- **`internal/acl/bench_test.go` benchmarks the stub, not the cache.** Every ACL
+  benchmark drives a map-backed `stubResolver`, which is why a 41ms quadratic
+  `Filter` sat in the branch for five months without showing up. The
+  `TestFilter_ReadsLabelsOncePerType` guard covers the specific regression, but a
+  benchmark against the real `cache.Cache` would catch the next one of these by
+  measurement rather than by reading. Cheap to add: the throwaway one used to get
+  the numbers above lived in `internal/cache` and imported `acl`, which is
+  acyclic.
+
+## Open issues
+
+- **#171** jitter `Retry-After` server-side so clients we do not control also
+  de-synchronize. Small, well-scoped, filed 2026-09-07.
+- **#89** Windows nanoserver container image.
+- **#5** show image vulnerabilities on the service detail page via Trivy.
+- **#6** interactive container shell via ghostty-web — blocked: needs the
+  per-node agent architecture first, so it is not pickable as written.
+
+## Agent surface — from the evaluation set
+
+`docs/specs/2026-09-07-mcp-evaluation-set.md` is the source and stays
+authoritative; this is only the shape of what it leaves open. 17 of 73 asks are
+still short, and the split is the finding: only four want a genuinely new *read*.
+The rest is composition and self-description.
+
+Highest leverage, because it needs **no new tools** — three prompts, ranked by
+how often the asks recur and what they cost unaided:
+
+1. **Secret rotation** (asks 53, 60, 38) — four steps, a destructive last one, an
+   ordering that matters. The eval set calls it the strongest candidate by some
+   distance, and 0.13.0 just shipped every underlying call (`create_secret`,
+   `update_service_secrets`, `remove_secret`).
+2. **Incident triage** (2, 3, 7, 24, 25) — the on-call entry point, three or four
+   separate calls every time.
+3. **Deploy and verify** (15-18, 20) — push, wait, confirm, roll back if it did
+   not take.
+
+Then, in rough order of value:
+
+- **Bulk / fan-out argument** (61 restart a stack, 62 scale a stack). One call
+  per member service is the entire cost.
+- **Self-description** (65 what am I allowed to change, 66 why was that refused).
+  An agent currently discovers its limits by being refused, and cannot tell a
+  permission failure from an impossibility.
+- **Aggregates over existing reads** (44 orphaned secrets, 45 image inventory).
+  Both are answerable one resource at a time, which is the problem.
+- **New reads** (21 spec diff, 34 volume fill, 41 published ports, 73 socket
+  mounts and privileged services).
+- **Watch, do not fix** (12 app or infrastructure, 32 will it fit). Judgement, not
+  lookup — if a prompt makes either reliable, that is the answer.
+- **Out of scope** (22 stack deploy, a compose-file operation; 27 live tail, which
+  the transport cannot do — repeated cursor reads are the closest thing and are
+  what the logs widget already does).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `server.public_url` sets the canonical external URL once, supplying the OAuth issuer for the MCP server and the OIDC redirect URL instead of configuring each separately
 
 ### Fixed
-- The MCP server no longer advertises an unreachable OAuth issuer when the listen address has no host. Startup now stops and says what to set.
+- The MCP server no longer advertises an unreachable OAuth issuer when the listen address has no host. Startup now stops when authentication is enabled and says what to set.
 - Atom and JSON Feed links are built from `server.public_url` when it is set, rather than from request headers a client can control.
 
 ## [0.13.0] - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `server.public_url` sets the canonical external URL once, supplying the OAuth issuer for the MCP server and the OIDC redirect URL instead of configuring each separately
 
 ### Fixed
-- The MCP server no longer advertises an unreachable OAuth issuer when the listen address has no host. Startup now stops when authentication is enabled and says what to set.
+- The MCP server no longer advertises an unreachable OAuth issuer when the listen address has no host. Startup now stops when MCP sign-in is actually in use and says what to set, rather than for every deployment with authentication enabled.
 - Atom and JSON Feed links are built from `server.public_url` when it is set, rather than from request headers a client can control.
 
 ## [0.13.0] - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `server.public_url` sets the canonical external URL once, supplying the OAuth issuer for the MCP server and the OIDC redirect URL instead of configuring each separately
+
+### Fixed
+- The MCP server no longer advertises an unreachable OAuth issuer when the listen address has no host. Startup now stops and says what to set.
+- Atom and JSON Feed links are built from `server.public_url` when it is set, rather than from request headers a client can control.
+
 ## [0.13.0] - 2026-09-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ docker stack deploy -c compose.monitoring.yaml monitoring  # Deploy standalone m
 | `CETACEAN_DOCKER_HOST` | `unix:///var/run/docker.sock` | No |
 | `CETACEAN_LISTEN_ADDR` | `:9000` | No |
 | `CETACEAN_BASE_PATH` | — | No (serve at root by default) |
+| `CETACEAN_PUBLIC_URL` | — | No (canonical external URL; defaults `mcp.issuer` and `auth.oidc.redirect_url`) |
 | `CETACEAN_LOG_FORMAT` | `json` | No |
 | `CETACEAN_LOG_LEVEL` | `info` | No |
 | `CETACEAN_SSE_BATCH_INTERVAL` | `100ms` | No |

--- a/internal/api/atom_handlers_test.go
+++ b/internal/api/atom_handlers_test.go
@@ -95,6 +95,20 @@ func TestFeedID(t *testing.T) {
 			t.Errorf("feedID = %q, want %q", got, want)
 		}
 	})
+
+	t.Run("prefers server.public_url host over r.Host", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/history", nil)
+		req.Host = "internal:9000"
+		ctx := context.WithValue(req.Context(), publicURLKey, "https://cetacean.example.com")
+		req = req.WithContext(ctx)
+
+		got := feedID(req)
+		want := "tag:cetacean.example.com,2026:/history"
+
+		if got != want {
+			t.Errorf("feedID = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestHistoryToEntries(t *testing.T) {

--- a/internal/api/basepath.go
+++ b/internal/api/basepath.go
@@ -69,9 +69,8 @@ func absURL(r *http.Request, path string) string {
 }
 
 // publicURLMiddleware stores server.public_url in the request context so
-// absURL can build links from configuration rather than from X-Forwarded-*,
-// which nothing validates against server.trusted_proxies — any client can set
-// those headers. A no-op when public_url is unset.
+// absURL builds links from configuration rather than from X-Forwarded-*,
+// which any client can set. A no-op when public_url is unset.
 func publicURLMiddleware(publicURL string, next http.Handler) http.Handler {
 	if publicURL == "" {
 		return next

--- a/internal/api/basepath.go
+++ b/internal/api/basepath.go
@@ -11,10 +11,23 @@ type basePathCtxKey struct{}
 
 var basePathKey = basePathCtxKey{}
 
+type publicURLCtxKey struct{}
+
+var publicURLKey = publicURLCtxKey{}
+
 // BasePathFromContext extracts the base path from the context.
 // Returns "" if not set.
 func BasePathFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(basePathKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// PublicURLFromContext extracts the configured external origin.
+// Returns "" when server.public_url is unset.
+func PublicURLFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(publicURLKey).(string); ok {
 		return v
 	}
 	return ""
@@ -30,10 +43,15 @@ func absPath(ctx context.Context, path string) string {
 	return base + path
 }
 
-// absURL builds a full absolute URL (scheme://host/base/path) from the request.
-// Uses X-Forwarded-Proto/Host when present (reverse proxy), falling back to
-// r.TLS and r.Host. Intended for Atom feeds where RFC 4287 requires IRIs.
+// absURL builds a full absolute URL (scheme://host/base/path) from the
+// request. Uses server.public_url when configured; otherwise
+// X-Forwarded-Proto/Host, falling back to r.TLS and r.Host. Intended for Atom
+// feeds where RFC 4287 requires IRIs.
 func absURL(r *http.Request, path string) string {
+	if base := PublicURLFromContext(r.Context()); base != "" {
+		return base + absPath(r.Context(), path)
+	}
+
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
@@ -48,6 +66,21 @@ func absURL(r *http.Request, path string) string {
 	}
 
 	return scheme + "://" + host + absPath(r.Context(), path)
+}
+
+// publicURLMiddleware stores server.public_url in the request context so
+// absURL can build links from configuration rather than from X-Forwarded-*,
+// which nothing validates against server.trusted_proxies — any client can set
+// those headers. A no-op when public_url is unset.
+func publicURLMiddleware(publicURL string, next http.Handler) http.Handler {
+	if publicURL == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), publicURLKey, publicURL)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 // basePathMiddleware strips the base path prefix from incoming requests,

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -193,6 +193,31 @@ func TestAbsURLPrefersPublicURL(t *testing.T) {
 	}
 }
 
+func TestAbsURLPrefersPublicURLWithBasePath(t *testing.T) {
+	called := false
+	handler := publicURLMiddleware(
+		"https://cetacean.example.com",
+		basePathMiddleware(
+			"/cetacean",
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				want := "https://cetacean.example.com/cetacean/services"
+				if got := absURL(r, "/services"); got != want {
+					t.Errorf("absURL = %q, want %q", got, want)
+				}
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/cetacean/services", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("handler was never invoked")
+	}
+}
+
 func TestAbsURLFallsBackToForwardedHeaders(t *testing.T) {
 	called := false
 	handler := publicURLMiddleware(

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -168,3 +168,51 @@ func TestBasePathMiddleware_Empty(t *testing.T) {
 		t.Errorf("path = %q, want %q", capturedPath, "/nodes")
 	}
 }
+
+func TestAbsURLPrefersPublicURL(t *testing.T) {
+	called := false
+	handler := publicURLMiddleware(
+		"https://cetacean.example.com",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if got := absURL(r, "/services"); got != "https://cetacean.example.com/services" {
+				t.Errorf("absURL = %q, want %q", got, "https://cetacean.example.com/services")
+			}
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/services", nil)
+	req.Host = "internal:9000"
+	req.Header.Set("X-Forwarded-Host", "attacker.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !called {
+		t.Fatal("handler was never invoked")
+	}
+}
+
+func TestAbsURLFallsBackToForwardedHeaders(t *testing.T) {
+	called := false
+	handler := publicURLMiddleware(
+		"",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if got := absURL(r, "/services"); got != "https://proxy.example.com/services" {
+				t.Errorf("absURL = %q, want %q", got, "https://proxy.example.com/services")
+			}
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/services", nil)
+	req.Host = "internal:9000"
+	req.Header.Set("X-Forwarded-Host", "proxy.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !called {
+		t.Fatal("handler was never invoked")
+	}
+}

--- a/internal/api/feed_handlers.go
+++ b/internal/api/feed_handlers.go
@@ -386,6 +386,7 @@ func (h *Handlers) filterHistoryACL(
 }
 
 // feedID builds a tag URI (RFC 4151) for the feed: tag:{host},{year}:{path}.
+// {host} is server.public_url's host when configured, otherwise r.Host.
 // The year 2026 is the date the tag namespace was minted and must remain constant.
 func feedID(r *http.Request) string {
 	// RFC 4151 tag URIs are permanent identifiers, so prefer the configured

--- a/internal/api/feed_handlers.go
+++ b/internal/api/feed_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -387,7 +388,17 @@ func (h *Handlers) filterHistoryACL(
 // feedID builds a tag URI (RFC 4151) for the feed: tag:{host},{year}:{path}.
 // The year 2026 is the date the tag namespace was minted and must remain constant.
 func feedID(r *http.Request) string {
-	return fmt.Sprintf("tag:%s,2026:%s", r.Host, absPath(r.Context(), r.URL.Path))
+	// RFC 4151 tag URIs are permanent identifiers, so prefer the configured
+	// origin: derived from r.Host, an entry's identity changes with the
+	// hostname a reader happened to reach the server by.
+	host := r.Host
+	if base := PublicURLFromContext(r.Context()); base != "" {
+		if u, err := url.Parse(base); err == nil {
+			host = u.Host
+		}
+	}
+
+	return fmt.Sprintf("tag:%s,2026:%s", host, absPath(r.Context(), r.URL.Path))
 }
 
 // parseFeedPagination reads ?before= and ?limit= from the query string.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -37,6 +37,7 @@ type RouterConfig struct {
 	EnableSelfMetrics bool
 	AuthProvider      auth.Provider
 	BasePath          string
+	PublicURL         string
 	CORS              *CORSConfig
 	TLSEnabled        bool
 	TrustedProxies    []netip.Prefix
@@ -676,7 +677,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	handler = recovery(handler)
 	handler = realIP(cfg.TrustedProxies)(handler)
 	handler = requestID(handler)
-	return basePathMiddleware(cfg.BasePath, handler)
+	return publicURLMiddleware(cfg.PublicURL, basePathMiddleware(cfg.BasePath, handler))
 }
 
 func requireReady(h *Handlers) func(http.Handler) http.Handler {

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -54,7 +54,9 @@ var validModes = map[string]bool{
 	"headers":   true,
 }
 
-func LoadAuth(flags *Flags, fc *fileConfig) (*AuthConfig, error) {
+// publicURL and basePath come from Config and supply the default OIDC
+// redirect URL; pass "" for both to keep auth.oidc.redirect_url required.
+func LoadAuth(flags *Flags, fc *fileConfig, publicURL, basePath string) (*AuthConfig, error) {
 	if flags == nil {
 		flags = &Flags{}
 	}
@@ -118,7 +120,7 @@ func LoadAuth(flags *Flags, fc *fileConfig) (*AuthConfig, error) {
 				flags.OIDCRedirectURL,
 				"CETACEAN_AUTH_OIDC_REDIRECT_URL",
 				fileField(fo, func(o *fileAuthOIDC) *string { return o.RedirectURL }),
-				"",
+				defaultRedirectURL(publicURL, basePath),
 			),
 			Scopes: parseScopes(
 				resolve(
@@ -370,4 +372,19 @@ func parseScopes(s string) []string {
 		}
 	}
 	return scopes
+}
+
+// defaultRedirectURL builds the OIDC callback URL from server.public_url. The
+// callback route is fixed at GET /auth/callback (internal/auth/oidc.go), so
+// the value is mechanically derivable and only has to be typed when the
+// callback lives somewhere else.
+//
+// Returns "" when public_url is unset, which leaves the existing "oidc mode
+// requires ..." rejection in place rather than inventing a URL.
+func defaultRedirectURL(publicURL, basePath string) string {
+	if publicURL == "" {
+		return ""
+	}
+
+	return publicURL + basePath + "/auth/callback"
 }

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -375,12 +375,9 @@ func parseScopes(s string) []string {
 }
 
 // defaultRedirectURL builds the OIDC callback URL from server.public_url. The
-// callback route is fixed at GET /auth/callback (internal/auth/oidc.go), so
-// the value is mechanically derivable and only has to be typed when the
-// callback lives somewhere else.
-//
-// Returns "" when public_url is unset, which leaves the existing "oidc mode
-// requires ..." rejection in place rather than inventing a URL.
+// callback route is fixed at GET /auth/callback, so it only has to be typed
+// when the callback lives elsewhere. Returns "" when public_url is unset,
+// which leaves auth.oidc.redirect_url required.
 func defaultRedirectURL(publicURL, basePath string) string {
 	if publicURL == "" {
 		return ""

--- a/internal/config/auth_test.go
+++ b/internal/config/auth_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLoadAuth_DefaultsToNone(t *testing.T) {
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -24,7 +24,7 @@ func TestLoadAuth_DefaultScopes(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
 	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "https://app.example.com/auth/callback")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestLoadAuth_DefaultScopes(t *testing.T) {
 
 func TestLoadAuth_InvalidMode(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "bogus")
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for invalid mode")
 	}
@@ -49,7 +49,7 @@ func TestLoadAuth_InvalidMode(t *testing.T) {
 
 func TestLoadAuth_OIDCRequiresFields(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "oidc")
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing OIDC fields")
 	}
@@ -63,7 +63,7 @@ func TestLoadAuth_OIDCHappyPath(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "https://app.example.com/auth/callback")
 	t.Setenv("CETACEAN_AUTH_OIDC_SCOPES", "openid, custom")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestLoadAuth_OIDCRejectsHTTPRedirectURL(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
 	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "http://app.example.com/auth/callback")
 
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for HTTP redirect URL")
 	}
@@ -96,7 +96,7 @@ func TestLoadAuth_OIDCAllowsLocalhostHTTP(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
 	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "http://localhost/auth/callback")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestLoadAuth_OIDCAllows127001HTTP(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
 	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "http://127.0.0.1:8080/auth/callback")
 
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error for loopback HTTP: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestLoadAuth_OIDCSessionKey(t *testing.T) {
 		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	)
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestLoadAuth_OIDCSessionKey(t *testing.T) {
 func TestLoadAuth_TailscaleLocalDefault(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "tailscale")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestLoadAuth_TailscaleInvalidMode(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "tailscale")
 	t.Setenv("CETACEAN_AUTH_TAILSCALE_MODE", "invalid")
 
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for invalid tailscale mode")
 	}
@@ -167,7 +167,7 @@ func TestLoadAuth_TailscaleTsnetRequiresAuthKey(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "tailscale")
 	t.Setenv("CETACEAN_AUTH_TAILSCALE_MODE", "tsnet")
 
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for tsnet without auth key")
 	}
@@ -178,7 +178,7 @@ func TestLoadAuth_TailscaleTsnetHappyPath(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_TAILSCALE_MODE", "tsnet")
 	t.Setenv("CETACEAN_AUTH_TAILSCALE_AUTHKEY", "tskey-abc123")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestLoadAuth_TailscaleTsnetHappyPath(t *testing.T) {
 
 func TestLoadAuth_CertRequiresCA(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "cert")
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing CA")
 	}
@@ -199,7 +199,7 @@ func TestLoadAuth_CertHappyPath(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "cert")
 	t.Setenv("CETACEAN_AUTH_CERT_CA", "/path/to/ca.pem")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestLoadAuth_CertHappyPath(t *testing.T) {
 
 func TestLoadAuth_HeadersRequiresSubject(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_MODE", "headers")
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing subject header")
 	}
@@ -221,7 +221,7 @@ func TestLoadAuth_HeadersSecretRequiresValue(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SUBJECT", "X-User")
 	t.Setenv("CETACEAN_AUTH_HEADERS_SECRET_HEADER", "X-Secret")
 
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for secret header without value")
 	}
@@ -237,7 +237,7 @@ func TestLoadAuth_HeadersHappyPath(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SECRET_VALUE", "s3cret")
 	t.Setenv("CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES", "10.0.0.0/8")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestLoadAuth_HeadersNoTrustedProxies(t *testing.T) {
 	// LoadAuth no longer rejects missing trusted proxies — that check
 	// moved to main.go where the general CETACEAN_TRUSTED_PROXIES is
 	// resolved and can provide the value.
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestLoadAuth_HeadersTrustedProxiesOnly(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SUBJECT", "X-User")
 	t.Setenv("CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES", "10.0.0.0/8, 192.168.1.1")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestLoadAuth_HeadersTrustedProxiesIPv6(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SUBJECT", "X-User")
 	t.Setenv("CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES", "fd00::/8, ::1")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestLoadAuth_HeadersTrustedProxiesInvalid(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SUBJECT", "X-User")
 	t.Setenv("CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES", "not-an-ip")
 
-	_, err := LoadAuth(nil, nil)
+	_, err := LoadAuth(nil, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for invalid trusted proxy")
 	}
@@ -323,7 +323,7 @@ func TestLoadAuth_HeadersBothSecretAndTrustedProxies(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SECRET_VALUE", "s3cret")
 	t.Setenv("CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES", "10.0.0.0/8")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestLoadAuth_FromConfigFile(t *testing.T) {
 		},
 	}
 
-	cfg, err := LoadAuth(nil, fc)
+	cfg, err := LoadAuth(nil, fc, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestLoadAuth_EnvOverridesFile(t *testing.T) {
 		},
 	}
 
-	cfg, err := LoadAuth(nil, fc)
+	cfg, err := LoadAuth(nil, fc, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestLoadAuth_FlagOverridesEnvAndFile(t *testing.T) {
 	}
 	flags := &Flags{AuthMode: new("none")}
 
-	cfg, err := LoadAuth(flags, fc)
+	cfg, err := LoadAuth(flags, fc, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestLoadAuth_HeadersFromFile(t *testing.T) {
 		},
 	}
 
-	cfg, err := LoadAuth(nil, fc)
+	cfg, err := LoadAuth(nil, fc, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestLoadAuth_TailscaleFromFile(t *testing.T) {
 		},
 	}
 
-	cfg, err := LoadAuth(nil, fc)
+	cfg, err := LoadAuth(nil, fc, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -478,7 +478,7 @@ func TestLoadAuth_OIDCSecretFromFile(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET_FILE", secretPath)
 	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "https://app.example.com/auth/callback")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestLoadAuth_TailscaleAuthKeyFromFile(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_TAILSCALE_MODE", "tsnet")
 	t.Setenv("CETACEAN_AUTH_TAILSCALE_AUTHKEY_FILE", keyPath)
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -520,7 +520,7 @@ func TestLoadAuth_HeadersSecretFromFile(t *testing.T) {
 	t.Setenv("CETACEAN_AUTH_HEADERS_SECRET_VALUE_FILE", secretPath)
 	t.Setenv("CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES", "10.0.0.0/8")
 
-	cfg, err := LoadAuth(nil, nil)
+	cfg, err := LoadAuth(nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -586,5 +586,68 @@ func TestParseScopes(t *testing.T) {
 				t.Errorf("parseScopes(%q)[%d]: got %q, want %q", tt.input, i, got[i], tt.want[i])
 			}
 		}
+	}
+}
+
+func TestOIDCRedirectURLDefaultsFromPublicURL(t *testing.T) {
+	t.Setenv("CETACEAN_AUTH_MODE", "oidc")
+	t.Setenv("CETACEAN_AUTH_OIDC_ISSUER", "https://idp.example.com")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_ID", "cetacean")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
+
+	cfg, err := LoadAuth(nil, nil, "https://cetacean.example.com", "")
+	if err != nil {
+		t.Fatalf("LoadAuth: %v", err)
+	}
+
+	want := "https://cetacean.example.com/auth/callback"
+	if cfg.OIDC.RedirectURL != want {
+		t.Errorf("RedirectURL = %q, want %q", cfg.OIDC.RedirectURL, want)
+	}
+}
+
+func TestOIDCRedirectURLIncludesBasePath(t *testing.T) {
+	t.Setenv("CETACEAN_AUTH_MODE", "oidc")
+	t.Setenv("CETACEAN_AUTH_OIDC_ISSUER", "https://idp.example.com")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_ID", "cetacean")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
+
+	cfg, err := LoadAuth(nil, nil, "https://cetacean.example.com", "/cetacean")
+	if err != nil {
+		t.Fatalf("LoadAuth: %v", err)
+	}
+
+	want := "https://cetacean.example.com/cetacean/auth/callback"
+	if cfg.OIDC.RedirectURL != want {
+		t.Errorf("RedirectURL = %q, want %q", cfg.OIDC.RedirectURL, want)
+	}
+}
+
+func TestOIDCRedirectURLExplicitWins(t *testing.T) {
+	t.Setenv("CETACEAN_AUTH_MODE", "oidc")
+	t.Setenv("CETACEAN_AUTH_OIDC_ISSUER", "https://idp.example.com")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_ID", "cetacean")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
+	t.Setenv("CETACEAN_AUTH_OIDC_REDIRECT_URL", "https://other.example.com/auth/callback")
+
+	cfg, err := LoadAuth(nil, nil, "https://cetacean.example.com", "")
+	if err != nil {
+		t.Fatalf("LoadAuth: %v", err)
+	}
+
+	want := "https://other.example.com/auth/callback"
+	if cfg.OIDC.RedirectURL != want {
+		t.Errorf("RedirectURL = %q, want %q", cfg.OIDC.RedirectURL, want)
+	}
+}
+
+func TestOIDCStillRequiresRedirectURLWithoutPublicURL(t *testing.T) {
+	t.Setenv("CETACEAN_AUTH_MODE", "oidc")
+	t.Setenv("CETACEAN_AUTH_OIDC_ISSUER", "https://idp.example.com")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_ID", "cetacean")
+	t.Setenv("CETACEAN_AUTH_OIDC_CLIENT_SECRET", "secret")
+
+	if _, err := LoadAuth(nil, nil, "", ""); err == nil {
+		t.Fatal("LoadAuth = nil error, want the existing 'oidc mode requires' rejection")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,15 +36,11 @@ const (
 )
 
 type Config struct {
-	DockerHost    string
-	PrometheusURL string
-	ListenAddr    string
-	BasePath      string // CETACEAN_BASE_PATH, default ""
-	// PublicURL is the canonical external origin clients reach this
-	// deployment at, e.g. "https://cetacean.example.com". Origin only: the
-	// external path prefix is BasePath, which absPath already prepends to
-	// outbound links. Empty means every consumer keeps its own fallback.
-	PublicURL        string          // CETACEAN_PUBLIC_URL, default ""
+	DockerHost       string
+	PrometheusURL    string
+	ListenAddr       string
+	BasePath         string          // CETACEAN_BASE_PATH, default ""
+	PublicURL        string          // CETACEAN_PUBLIC_URL, external origin, default ""
 	LogLevel         string          // "debug", "info", "warn", "error"
 	LogFormat        string          // "json", "text"
 	DataDir          string          // CETACEAN_DATA_DIR, default "./data"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,10 +36,15 @@ const (
 )
 
 type Config struct {
-	DockerHost       string
-	PrometheusURL    string
-	ListenAddr       string
-	BasePath         string          // CETACEAN_BASE_PATH, default ""
+	DockerHost    string
+	PrometheusURL string
+	ListenAddr    string
+	BasePath      string // CETACEAN_BASE_PATH, default ""
+	// PublicURL is the canonical external origin clients reach this
+	// deployment at, e.g. "https://cetacean.example.com". Origin only: the
+	// external path prefix is BasePath, which absPath already prepends to
+	// outbound links. Empty means every consumer keeps its own fallback.
+	PublicURL        string          // CETACEAN_PUBLIC_URL, default ""
 	LogLevel         string          // "debug", "info", "warn", "error"
 	LogFormat        string          // "json", "text"
 	DataDir          string          // CETACEAN_DATA_DIR, default "./data"
@@ -81,6 +86,7 @@ func Load(fc *fileConfig, flags *Flags) (*Config, error) {
 		fSnapshot        *bool
 		fOpsLevel        *int
 		fBasePath        *string
+		fPublicURL       *string
 		fCORSOrigins     []string
 		fTrustedProxies  *string
 		fOTelEndpoint    *string
@@ -93,6 +99,7 @@ func Load(fc *fileConfig, flags *Flags) (*Config, error) {
 			fRecommendations = fc.Server.Recommendations
 			fOpsLevel = fc.Server.OperationsLevel
 			fBasePath = fc.Server.BasePath
+			fPublicURL = fc.Server.PublicURL
 			fTrustedProxies = fc.Server.TrustedProxies
 			if fc.Server.SSE != nil {
 				fSSEBatch = fc.Server.SSE.BatchInterval
@@ -155,6 +162,10 @@ func Load(fc *fileConfig, flags *Flags) (*Config, error) {
 		BasePath: NormalizeBasePath(
 			resolve(flags.BasePath, "CETACEAN_BASE_PATH", fBasePath, ""),
 		),
+		PublicURL: strings.TrimRight(
+			resolve(flags.PublicURL, "CETACEAN_PUBLIC_URL", fPublicURL, ""),
+			"/",
+		),
 		LogLevel:         resolve(flags.LogLevel, "CETACEAN_LOG_LEVEL", fLogLevel, "info"),
 		LogFormat:        resolve(flags.LogFormat, "CETACEAN_LOG_FORMAT", fLogFormat, "json"),
 		DataDir:          resolve(flags.DataDir, "CETACEAN_DATA_DIR", fDataDir, "./data"),
@@ -182,6 +193,10 @@ func Load(fc *fileConfig, flags *Flags) (*Config, error) {
 	}
 
 	if err := ValidateBasePath(cfg.BasePath); err != nil {
+		return nil, err
+	}
+
+	if err := ValidatePublicURL(cfg.PublicURL); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -117,6 +117,7 @@ type fileServer struct {
 	CORS            *fileCORS `toml:"cors"`
 	OperationsLevel *int      `toml:"operations_level"`
 	BasePath        *string   `toml:"base_path"`
+	PublicURL       *string   `toml:"public_url"`
 	TrustedProxies  *string   `toml:"trusted_proxies"`
 }
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -18,6 +18,7 @@ type Flags struct {
 	SelfMetrics     *bool
 	Recommendations *bool
 	BasePath        *string
+	PublicURL       *string
 	Version         bool
 
 	// Auth
@@ -186,6 +187,11 @@ func ParseFlags(args []string) (*Flags, error) {
 		"SSE batch interval (env: CETACEAN_SSE_BATCH_INTERVAL, default \"100ms\")",
 	)
 	corsOrigins := fs.String("cors-origins", "", "CORS origins (env: CETACEAN_CORS_ORIGINS)")
+	publicURL := fs.String(
+		"public-url",
+		"",
+		"Canonical external URL, e.g. https://cetacean.example.com (env: CETACEAN_PUBLIC_URL)",
+	)
 	trustedProxies := fs.String(
 		"trusted-proxies",
 		"",
@@ -271,6 +277,8 @@ func ParseFlags(args []string) (*Flags, error) {
 			f.SSEBatchInterval = sseBatch
 		case "cors-origins":
 			f.CORSOrigins = corsOrigins
+		case "public-url":
+			f.PublicURL = publicURL
 		case "trusted-proxies":
 			f.TrustedProxies = trustedProxies
 		}

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -417,8 +417,8 @@ func resolveMCPOpsLevel(file *int) (OperationsLevel, error) {
 }
 
 // MCPIssuer returns the canonical external base URL clients reach this
-// deployment at: mcp.issuer when set, otherwise derived from
-// server.listen_addr and whether TLS terminates here.
+// deployment at: mcp.issuer when set, then server.public_url, otherwise
+// derived from server.listen_addr and whether TLS terminates here.
 //
 // The second return is false when the derivation produced a URL nothing can
 // reach. server.listen_addr defaults to ":9000", so the derived issuer is
@@ -433,6 +433,10 @@ func resolveMCPOpsLevel(file *int) (OperationsLevel, error) {
 func (c *Config) MCPIssuer(tlsEnabled bool) (string, bool) {
 	if c.MCP.Issuer != "" {
 		return c.MCP.Issuer, true
+	}
+
+	if c.PublicURL != "" {
+		return c.PublicURL, true
 	}
 
 	scheme := "http"

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -418,20 +418,13 @@ func resolveMCPOpsLevel(file *int) (OperationsLevel, error) {
 }
 
 // MCPIssuer returns the canonical external base URL clients reach this
-// deployment at: mcp.issuer when set, then server.public_url, otherwise
-// derived from server.listen_addr and whether TLS terminates here.
+// deployment at: mcp.issuer, then server.public_url, then a derivation from
+// server.listen_addr and whether TLS terminates here.
 //
-// The second return is false when the derivation produced a URL nothing can
-// reach. server.listen_addr defaults to ":9000", so the derived issuer is
-// "http://:9000" — a URL with an empty host, which resolveMCPIssuer rejects
-// when an operator types it. A wildcard bind ("0.0.0.0", "::") parses to a
-// host but is equally unreachable.
-//
-// The string is returned either way, because how bad an unreachable issuer is
-// depends on the caller: an OAuth client fetches .well-known documents from
-// it and cannot work at all, while auth mode "none" — or an auth mode fully
-// covered by mcp.oauth.auth_bypass, see MCPIssuerRequired — never depends on
-// that flow and ends up only with unreachable icon URLs.
+// The second return is false when that derivation reaches nothing: the
+// default ":9000" has an empty host, and a wildcard bind ("0.0.0.0", "::")
+// parses but resolves nowhere. The string is returned either way, since only
+// OAuth truly breaks on it — see MCPIssuerRequired.
 func (c *Config) MCPIssuer(tlsEnabled bool) (string, bool) {
 	if c.MCP.Issuer != "" {
 		return c.MCP.Issuer, true
@@ -461,16 +454,11 @@ func (c *Config) MCPIssuer(tlsEnabled bool) (string, bool) {
 	return issuer, true
 }
 
-// MCPIssuerRequired reports whether a working /mcp needs a reachable issuer,
-// as opposed to one that only feeds cosmetic tool-icon URLs (main.go's
-// IconBaseURL). OAuth is genuinely in play whenever the upstream auth mode is
-// not "none" and that mode is not fully covered by mcp.oauth.auth_bypass:
-// a bypassed mode (cert, headers, tailscale) authenticates every /mcp request
-// from the upstream provider's own identity instead of a JWT, which is
-// exactly the deployment docs/mcp.md recommends for mTLS clients — one that
-// never drives the OAuth authorize/token flow an unreachable issuer would
-// break. setupMCP downgrades an unreachable issuer to a warning rather than
-// exiting when this returns false.
+// MCPIssuerRequired reports whether /mcp needs a reachable issuer, rather than
+// one that only feeds cosmetic tool-icon URLs. OAuth is in play unless the
+// auth mode is "none" or is listed in mcp.oauth.auth_bypass: a bypassed mode
+// authenticates each request from the upstream identity and never drives the
+// authorize/token flow.
 func (c *Config) MCPIssuerRequired(authMode string) bool {
 	return authMode != "none" && !slices.Contains(c.MCP.AuthBypass, authMode)
 }

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -427,9 +428,10 @@ func resolveMCPOpsLevel(file *int) (OperationsLevel, error) {
 // host but is equally unreachable.
 //
 // The string is returned either way, because how bad an unreachable issuer is
-// depends on the caller: OAuth clients fetch .well-known documents from it and
-// cannot work at all, while auth mode "none" builds no OAuth server and ends
-// up only with unreachable icon URLs.
+// depends on the caller: an OAuth client fetches .well-known documents from
+// it and cannot work at all, while auth mode "none" — or an auth mode fully
+// covered by mcp.oauth.auth_bypass, see MCPIssuerRequired — never depends on
+// that flow and ends up only with unreachable icon URLs.
 func (c *Config) MCPIssuer(tlsEnabled bool) (string, bool) {
 	if c.MCP.Issuer != "" {
 		return c.MCP.Issuer, true
@@ -457,4 +459,18 @@ func (c *Config) MCPIssuer(tlsEnabled bool) (string, bool) {
 	}
 
 	return issuer, true
+}
+
+// MCPIssuerRequired reports whether a working /mcp needs a reachable issuer,
+// as opposed to one that only feeds cosmetic tool-icon URLs (main.go's
+// IconBaseURL). OAuth is genuinely in play whenever the upstream auth mode is
+// not "none" and that mode is not fully covered by mcp.oauth.auth_bypass:
+// a bypassed mode (cert, headers, tailscale) authenticates every /mcp request
+// from the upstream provider's own identity instead of a JWT, which is
+// exactly the deployment docs/mcp.md recommends for mTLS clients — one that
+// never drives the OAuth authorize/token flow an unreachable issuer would
+// break. setupMCP downgrades an unreachable issuer to a warning rather than
+// exiting when this returns false.
+func (c *Config) MCPIssuerRequired(authMode string) bool {
+	return authMode != "none" && !slices.Contains(c.MCP.AuthBypass, authMode)
 }

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -415,3 +415,42 @@ func resolveMCPOpsLevel(file *int) (OperationsLevel, error) {
 
 	return OpsInherit, nil
 }
+
+// MCPIssuer returns the canonical external base URL clients reach this
+// deployment at: mcp.issuer when set, otherwise derived from
+// server.listen_addr and whether TLS terminates here.
+//
+// The second return is false when the derivation produced a URL nothing can
+// reach. server.listen_addr defaults to ":9000", so the derived issuer is
+// "http://:9000" — a URL with an empty host, which resolveMCPIssuer rejects
+// when an operator types it. A wildcard bind ("0.0.0.0", "::") parses to a
+// host but is equally unreachable.
+//
+// The string is returned either way, because how bad an unreachable issuer is
+// depends on the caller: OAuth clients fetch .well-known documents from it and
+// cannot work at all, while auth mode "none" builds no OAuth server and ends
+// up only with unreachable icon URLs.
+func (c *Config) MCPIssuer(tlsEnabled bool) (string, bool) {
+	if c.MCP.Issuer != "" {
+		return c.MCP.Issuer, true
+	}
+
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
+
+	issuer := scheme + "://" + c.ListenAddr
+
+	u, err := url.Parse(issuer)
+	if err != nil {
+		return issuer, false
+	}
+
+	switch u.Hostname() {
+	case "", "0.0.0.0", "::":
+		return issuer, false
+	}
+
+	return issuer, true
+}

--- a/internal/config/mcp_test.go
+++ b/internal/config/mcp_test.go
@@ -615,3 +615,68 @@ func TestLoadMCP_UnsetSigningKeyIsStillAllowed(t *testing.T) {
 		t.Errorf("signing key = %q, want empty", cfg.SigningKey)
 	}
 }
+
+func TestMCPIssuer(t *testing.T) {
+	tests := []struct {
+		name       string
+		issuer     string
+		listenAddr string
+		tlsEnabled bool
+		want       string
+		wantOK     bool
+	}{
+		{
+			name:       "explicit issuer wins",
+			issuer:     "https://cetacean.example.com",
+			listenAddr: ":9000",
+			want:       "https://cetacean.example.com",
+			wantOK:     true,
+		},
+		{
+			name:       "default listen address has no host",
+			listenAddr: ":9000",
+			want:       "http://:9000",
+			wantOK:     false,
+		},
+		{
+			name:       "wildcard bind is not reachable",
+			listenAddr: "0.0.0.0:9000",
+			want:       "http://0.0.0.0:9000",
+			wantOK:     false,
+		},
+		{
+			name:       "unspecified IPv6 bind is not reachable",
+			listenAddr: "[::]:9000",
+			want:       "http://[::]:9000",
+			wantOK:     false,
+		},
+		{
+			name:       "explicit host derives",
+			listenAddr: "cetacean.internal:9000",
+			want:       "http://cetacean.internal:9000",
+			wantOK:     true,
+		},
+		{
+			name:       "TLS derives https",
+			listenAddr: "cetacean.internal:9000",
+			tlsEnabled: true,
+			want:       "https://cetacean.internal:9000",
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{ListenAddr: tt.listenAddr, MCP: MCPConfig{Issuer: tt.issuer}}
+
+			got, ok := cfg.MCPIssuer(tt.tlsEnabled)
+
+			if got != tt.want {
+				t.Errorf("issuer = %q, want %q", got, tt.want)
+			}
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/config/mcp_test.go
+++ b/internal/config/mcp_test.go
@@ -700,3 +700,45 @@ func TestMCPIssuer(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPIssuerRequired(t *testing.T) {
+	tests := []struct {
+		name       string
+		authMode   string
+		authBypass []string
+		want       bool
+	}{
+		{
+			name:     "auth mode none never needs OAuth",
+			authMode: "none",
+			want:     false,
+		},
+		{
+			name:     "auth mode with no bypass configured needs OAuth",
+			authMode: "cert",
+			want:     true,
+		},
+		{
+			name:       "auth mode listed in AuthBypass is fully bypassed",
+			authMode:   "cert",
+			authBypass: []string{"cert"},
+			want:       false,
+		},
+		{
+			name:       "auth mode not listed while another mode is bypassed still needs OAuth",
+			authMode:   "oidc",
+			authBypass: []string{"cert"},
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{MCP: MCPConfig{AuthBypass: tt.authBypass}}
+
+			if got := cfg.MCPIssuerRequired(tt.authMode); got != tt.want {
+				t.Errorf("MCPIssuerRequired(%q) = %v, want %v", tt.authMode, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/mcp_test.go
+++ b/internal/config/mcp_test.go
@@ -620,6 +620,7 @@ func TestMCPIssuer(t *testing.T) {
 	tests := []struct {
 		name       string
 		issuer     string
+		publicURL  string
 		listenAddr string
 		tlsEnabled bool
 		want       string
@@ -630,6 +631,21 @@ func TestMCPIssuer(t *testing.T) {
 			issuer:     "https://cetacean.example.com",
 			listenAddr: ":9000",
 			want:       "https://cetacean.example.com",
+			wantOK:     true,
+		},
+		{
+			name:       "public_url is used when mcp.issuer is unset",
+			publicURL:  "https://cetacean.example.com",
+			listenAddr: ":9000",
+			want:       "https://cetacean.example.com",
+			wantOK:     true,
+		},
+		{
+			name:       "mcp.issuer overrides public_url",
+			issuer:     "https://mcp.example.com",
+			publicURL:  "https://cetacean.example.com",
+			listenAddr: ":9000",
+			want:       "https://mcp.example.com",
 			wantOK:     true,
 		},
 		{
@@ -667,7 +683,11 @@ func TestMCPIssuer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &Config{ListenAddr: tt.listenAddr, MCP: MCPConfig{Issuer: tt.issuer}}
+			cfg := &Config{
+				ListenAddr: tt.listenAddr,
+				PublicURL:  tt.publicURL,
+				MCP:        MCPConfig{Issuer: tt.issuer},
+			}
 
 			got, ok := cfg.MCPIssuer(tt.tlsEnabled)
 

--- a/internal/config/publicurl.go
+++ b/internal/config/publicurl.go
@@ -36,6 +36,10 @@ func ValidatePublicURL(raw string) error {
 		return fmt.Errorf("server.public_url must include a host, got %q", raw)
 	}
 
+	if u.User != nil {
+		return fmt.Errorf("server.public_url must not include userinfo, got %q", raw)
+	}
+
 	if u.Path != "" && u.Path != "/" {
 		return fmt.Errorf(
 			"server.public_url must not include a path, got %q; set server.base_path to %q instead",

--- a/internal/config/publicurl.go
+++ b/internal/config/publicurl.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ValidatePublicURL checks server.public_url is an http(s) origin: a scheme
+// and a host, and nothing after them.
+//
+// A path is rejected rather than accepted and ignored, because
+// server.base_path already carries the external prefix in both directions —
+// basePathMiddleware strips it from inbound requests and absPath prepends it
+// to outbound links — and two settings for one concept drift apart.
+//
+// An empty value is valid and means "unset": every consumer keeps the
+// fallback it had before this setting existed.
+func ValidatePublicURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("server.public_url is not a valid URL %q: %w", raw, err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf(
+			"server.public_url must use http or https, got %q",
+			raw,
+		)
+	}
+
+	if u.Hostname() == "" {
+		return fmt.Errorf("server.public_url must include a host, got %q", raw)
+	}
+
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf(
+			"server.public_url must not include a path, got %q; set server.base_path to %q instead",
+			raw, u.Path,
+		)
+	}
+
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("server.public_url must not include a query or fragment, got %q", raw)
+	}
+
+	return nil
+}

--- a/internal/config/publicurl_test.go
+++ b/internal/config/publicurl_test.go
@@ -31,6 +31,7 @@ func TestValidatePublicURL(t *testing.T) {
 		{"https://cetacean.example.com/cetacean", "server.base_path"},
 		{"https://cetacean.example.com?a=b", "query or fragment"},
 		{"https://cetacean.example.com#frag", "query or fragment"},
+		{"https://user:pass@cetacean.example.com", "userinfo"},
 	}
 
 	for _, tt := range invalid {

--- a/internal/config/publicurl_test.go
+++ b/internal/config/publicurl_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePublicURL(t *testing.T) {
+	valid := []string{
+		"",
+		"https://cetacean.example.com",
+		"http://localhost:9000",
+		"https://cetacean.example.com:8443",
+		"http://10.0.0.5:9000",
+	}
+
+	for _, raw := range valid {
+		if err := ValidatePublicURL(raw); err != nil {
+			t.Errorf("ValidatePublicURL(%q) = %v, want nil", raw, err)
+		}
+	}
+
+	invalid := []struct {
+		raw     string
+		wantSub string
+	}{
+		{"ftp://cetacean.example.com", "http or https"},
+		{"cetacean.example.com", "http or https"},
+		{"https://", "must include a host"},
+		{"http://:9000", "must include a host"},
+		{"https://cetacean.example.com/cetacean", "server.base_path"},
+		{"https://cetacean.example.com?a=b", "query or fragment"},
+		{"https://cetacean.example.com#frag", "query or fragment"},
+	}
+
+	for _, tt := range invalid {
+		err := ValidatePublicURL(tt.raw)
+		if err == nil {
+			t.Errorf("ValidatePublicURL(%q) = nil, want error", tt.raw)
+			continue
+		}
+		if !strings.Contains(err.Error(), tt.wantSub) {
+			t.Errorf("ValidatePublicURL(%q) = %q, want it to mention %q", tt.raw, err, tt.wantSub)
+		}
+	}
+}
+
+func TestLoadPublicURLStripsTrailingSlash(t *testing.T) {
+	t.Setenv("CETACEAN_PUBLIC_URL", "https://cetacean.example.com/")
+
+	cfg, err := Load(nil, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.PublicURL != "https://cetacean.example.com" {
+		t.Errorf("PublicURL = %q, want %q", cfg.PublicURL, "https://cetacean.example.com")
+	}
+}
+
+func TestLoadRejectsPublicURLWithPath(t *testing.T) {
+	t.Setenv("CETACEAN_PUBLIC_URL", "https://cetacean.example.com/cetacean")
+
+	if _, err := Load(nil, nil); err == nil {
+		t.Fatal("Load = nil error, want a rejection naming server.base_path")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -665,10 +665,8 @@ type mcpDeps struct {
 // a cleanup function the caller must invoke at shutdown so the MCP server's
 // cache change listener detaches before the cache itself is torn down.
 //
-// The issuer defaults to the listen address + TLS scheme, which only works
-// when the listen address carries a real host and no reverse proxy is in
-// front. Startup fails when OAuth is genuinely in play and no reachable
-// issuer could be derived; see Config.MCPIssuer and Config.MCPIssuerRequired.
+// Startup fails when MCP OAuth is in play and no reachable issuer could be
+// derived; see Config.MCPIssuer and Config.MCPIssuerRequired.
 func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string), func()) {
 	if !d.cfg.MCP.Enabled {
 		return nil, nil, func() {}

--- a/main.go
+++ b/main.go
@@ -665,8 +665,9 @@ type mcpDeps struct {
 // cache change listener detaches before the cache itself is torn down.
 //
 // The issuer defaults to the listen address + TLS scheme, which only works
-// when no reverse proxy is in front. Behind a proxy, set CETACEAN_MCP_ISSUER
-// (or [mcp].issuer) to the canonical external URL.
+// when the listen address carries a real host and no reverse proxy is in
+// front. Startup fails when OAuth is in play and no reachable issuer could be
+// derived; see Config.MCPIssuer.
 func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string), func()) {
 	if !d.cfg.MCP.Enabled {
 		return nil, nil, func() {}
@@ -683,13 +684,21 @@ func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string
 		mcp.SetWidgetFS(widgets)
 	}
 
-	issuer := d.cfg.MCP.Issuer
-	if issuer == "" {
-		scheme := "http"
-		if d.tlsEnabled {
-			scheme = "https"
+	issuer, reachable := d.cfg.MCPIssuer(d.tlsEnabled)
+	if !reachable {
+		if d.authMode != "none" {
+			slog.Error(
+				"MCP OAuth needs an issuer clients can reach, and none could be derived from server.listen_addr. Set mcp.issuer to the URL clients reach from outside.",
+				"derived_issuer", issuer,
+				"listen_addr", d.cfg.ListenAddr,
+			)
+			os.Exit(1)
 		}
-		issuer = scheme + "://" + d.cfg.ListenAddr
+		slog.Warn(
+			"no reachable MCP issuer could be derived from server.listen_addr; MCP tool icons will point at an unreachable URL. Set mcp.issuer to the URL clients reach from outside.",
+			"derived_issuer", issuer,
+			"listen_addr", d.cfg.ListenAddr,
+		)
 	}
 	mcpResource := issuer + d.cfg.BasePath + "/mcp"
 

--- a/main.go
+++ b/main.go
@@ -688,14 +688,14 @@ func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string
 	if !reachable {
 		if d.authMode != "none" {
 			slog.Error(
-				"MCP OAuth needs an issuer clients can reach, and none could be derived from server.listen_addr. Set mcp.issuer to the URL clients reach from outside.",
+				"MCP OAuth needs an issuer clients can reach, and none could be derived from server.listen_addr. Set server.public_url to the URL clients reach from outside, or mcp.issuer to override it for MCP alone.",
 				"derived_issuer", issuer,
 				"listen_addr", d.cfg.ListenAddr,
 			)
 			os.Exit(1)
 		}
 		slog.Warn(
-			"no reachable MCP issuer could be derived from server.listen_addr; MCP tool icons will point at an unreachable URL. Set mcp.issuer to the URL clients reach from outside.",
+			"no reachable MCP issuer could be derived from server.listen_addr; MCP tool icons will point at an unreachable URL. Set server.public_url to the URL clients reach from outside.",
 			"derived_issuer", issuer,
 			"listen_addr", d.cfg.ListenAddr,
 		)

--- a/main.go
+++ b/main.go
@@ -690,15 +690,19 @@ func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string
 		if d.authMode != "none" {
 			slog.Error(
 				"MCP OAuth needs an issuer clients can reach, and none could be derived from server.listen_addr. Set server.public_url to the URL clients reach from outside, or mcp.issuer to override it for MCP alone.",
-				"derived_issuer", issuer,
-				"listen_addr", d.cfg.ListenAddr,
+				"derived_issuer",
+				issuer,
+				"listen_addr",
+				d.cfg.ListenAddr,
 			)
 			os.Exit(1)
 		}
 		slog.Warn(
 			"no reachable MCP issuer could be derived from server.listen_addr; MCP tool icons will point at an unreachable URL. Set server.public_url to the URL clients reach from outside.",
-			"derived_issuer", issuer,
-			"listen_addr", d.cfg.ListenAddr,
+			"derived_issuer",
+			issuer,
+			"listen_addr",
+			d.cfg.ListenAddr,
 		)
 	}
 	mcpResource := issuer + d.cfg.BasePath + "/mcp"

--- a/main.go
+++ b/main.go
@@ -457,6 +457,7 @@ func main() {
 		EnableSelfMetrics: cfg.SelfMetrics,
 		AuthProvider:      authProvider,
 		BasePath:          cfg.BasePath,
+		PublicURL:         cfg.PublicURL,
 		CORS:              corsConfig,
 		TLSEnabled:        tlsCfg.Enabled(),
 		TrustedProxies:    cfg.TrustedProxies,

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 		slog.Info("loaded config file", "path", configPath)
 	}
 
-	authCfg, err := config.LoadAuth(flags, fc)
+	authCfg, err := config.LoadAuth(flags, fc, cfg.PublicURL, cfg.BasePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "auth configuration error: %v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -667,8 +667,8 @@ type mcpDeps struct {
 //
 // The issuer defaults to the listen address + TLS scheme, which only works
 // when the listen address carries a real host and no reverse proxy is in
-// front. Startup fails when OAuth is in play and no reachable issuer could be
-// derived; see Config.MCPIssuer.
+// front. Startup fails when OAuth is genuinely in play and no reachable
+// issuer could be derived; see Config.MCPIssuer and Config.MCPIssuerRequired.
 func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string), func()) {
 	if !d.cfg.MCP.Enabled {
 		return nil, nil, func() {}
@@ -687,7 +687,7 @@ func setupMCP(d mcpDeps) (http.Handler, func(mux *http.ServeMux, basePath string
 
 	issuer, reachable := d.cfg.MCPIssuer(d.tlsEnabled)
 	if !reachable {
-		if d.authMode != "none" {
+		if d.cfg.MCPIssuerRequired(d.authMode) {
 			slog.Error(
 				"MCP OAuth needs an issuer clients can reach, and none could be derived from server.listen_addr. Set server.public_url to the URL clients reach from outside, or mcp.issuer to override it for MCP alone.",
 				"derived_issuer",


### PR DESCRIPTION
Cetacean had three unrelated answers to "what URL do clients reach me at?" — `mcp.issuer` for the OAuth issuer,
`auth.oidc.redirect_url` for the sign-in callback, and the `X-Forwarded-*` headers for Atom and JSON Feed links.
Each had to be configured separately, and one of them was derived wrong.

This replaces them with a single `server.public_url`, and fixes the derivation.

## The bug

With MCP enabled behind a reverse proxy and no `mcp.issuer` set, the issuer was derived from the listen address.
The default listen address is `:9000`, which has no host — so the issuer came out as `http://:9000`, an origin no
client can resolve. The OAuth discovery chain advertised it anyway, and sign-in failed somewhere the error did not
point at.

The derivation now lives in `internal/config` where it can be tested, rather than in `main.go` where it could not.
When the listen address yields no reachable host and MCP OAuth is genuinely in use, startup stops and names the
setting to fix, rather than advertising an address that cannot work. Auth mode `none` registers no OAuth endpoints,
so it is not affected.

## The setting

`server.public_url` (`-public-url`, `CETACEAN_PUBLIC_URL`) is the canonical external URL, origin only — a path,
query or fragment is a config error, because the path prefix is `server.base_path`'s job and is already applied to
both inbound and outbound paths. It supplies the default for:

- **`mcp.issuer`** — set it only to give MCP a different URL from the rest of Cetacean.
- **`auth.oidc.redirect_url`** — derived as `{public_url}{base_path}/auth/callback`, so it is no longer required
  when `server.public_url` is set. It still overrides, for a callback that lives elsewhere.
- **Atom and JSON Feed links** — built from `server.public_url` when set, rather than from `X-Forwarded-Host` and
  `X-Forwarded-Proto`, which a client can set. Without it, the existing header behaviour is unchanged.

Precedence throughout is explicit setting > `server.public_url` > existing fallback, so no existing configuration
changes meaning. `server.cors.origins` is deliberately untouched: it lists third-party origins, not Cetacean's own.

## Verification

`make check` is green — golangci-lint, oxlint, gofmt/oxfmt and `go test ./...`. The new behaviour is covered by
tests in `internal/config` (issuer derivation, the origin-only validator, the OIDC redirect default) and
`internal/api` (feed links from `public_url` versus from headers).

## Documentation

`CLAUDE.md` and `CHANGELOG.md` are updated here. The user-facing guides — the `configuration` reference entry, the
MCP guide's callout and the OIDC section's note — are written but land with the docs branch, which they depend on
for its link infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSFjBrr9pkYpkHagXM1tdB
