### PR TITLE
style(website): restore the formatter's output in the lib modules

### DIFF
--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,6 +1,6 @@
-import {glob} from "astro/loaders";
-import {z} from "astro/zod";
-import {defineCollection} from "astro:content";
+import { glob } from "astro/loaders";
+import { z } from "astro/zod";
+import { defineCollection } from "astro:content";
 
 const docs = defineCollection({
   loader: glob({
@@ -15,4 +15,4 @@ const docs = defineCollection({
   }),
 });
 
-export const collections = {docs};
+export const collections = { docs };

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -1,6 +1,6 @@
-import {getCollection} from "astro:content";
-import {readFileSync} from "node:fs";
-import {resolve} from "node:path";
+import { getCollection } from "astro:content";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 export const docsDir = resolve("../docs");
 export const changelogPath = resolve("../CHANGELOG.md");
@@ -21,14 +21,11 @@ export function latestVersion(): string {
 }
 
 export function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/\W+/g, "-")
-    .replace(/^-|-$/g, "");
+  return text.toLowerCase().replace(/\W+/g, "-").replace(/^-|-$/g, "");
 }
 
 export async function getDocPaths() {
   const docs = await getCollection("docs");
 
-  return docs.filter(({data: {category}}) => category !== "overview");
+  return docs.filter(({ data: { category } }) => category !== "overview");
 }

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -1,11 +1,11 @@
-import {defineMiddleware} from "astro:middleware";
-import {existsSync, readFileSync} from "node:fs";
-import {resolve} from "node:path";
+import { defineMiddleware } from "astro:middleware";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-const spaPath = [
-                  resolve("public/demo/index.html"),
-                  resolve("../website/public/demo/index.html"),
-                ].find(existsSync) ?? "";
+const spaPath =
+  [resolve("public/demo/index.html"), resolve("../website/public/demo/index.html")].find(
+    existsSync,
+  ) ?? "";
 
 function readSpaHTML(): string {
   if (!spaPath) {
@@ -41,7 +41,7 @@ function isSPARoute(pathname: string): boolean {
  * Serve the demo SPA for /demo/ and all deep links under /demo/*.
  * Static assets (JS, CSS, images, service worker) pass through to Astro/Vite.
  */
-export const onRequest = defineMiddleware(({request, url}, next) => {
+export const onRequest = defineMiddleware(({ request, url }, next) => {
   if (url.pathname === "/demo") {
     return Response.redirect(new URL("/demo/", url), 302);
   }
@@ -51,7 +51,7 @@ export const onRequest = defineMiddleware(({request, url}, next) => {
   if (html && isSPARoute(url.pathname) && request.headers.get("accept")?.includes("text/html")) {
     return new Response(html, {
       status: 200,
-      headers: {"Content-Type": "text/html; charset=utf-8"},
+      headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   }
 


### PR DESCRIPTION
The style pass in #201 rewrote imports and destructuring without the brace spacing oxfmt emits. `lint-website`
failed on that pull request and it merged anyway, so **main is currently red** — and so is every dependabot
pull request that touches the website (#203).

Reformatted with `oxfmt`; no behaviour change. `npx oxlint` and `npx oxfmt --check .` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Yr4m3zdEsiJVX6ykbkG7F