### PR TITLE
fix: address the review findings from #209

### DIFF
--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -75,7 +75,7 @@ export default function ConnectionStatus() {
       <div
         data-connected={connected || undefined}
         data-pulsing={pulsing || undefined}
-        className="size-2 animate-pulse rounded-full bg-status-danger transition-shadow duration-300 data-connected:animate-none data-connected:bg-status-ok data-pulsing:shadow-[0_0_6px_2px_rgba(34,197,94,0.5)]"
+        className="size-2 animate-pulse rounded-full bg-status-danger transition-shadow duration-300 data-connected:animate-none data-connected:bg-status-ok data-pulsing:shadow-[0_0_6px_2px_oklch(from_var(--status-ok)_l_c_h/50%)]"
       />
       <span className="hidden text-xs text-muted-foreground sm:inline">
         {connected ? (

--- a/frontend/src/components/log/LogTable.tsx
+++ b/frontend/src/components/log/LogTable.tsx
@@ -74,7 +74,7 @@ function LogRow({
       key={line.index}
       ref={measureRef}
       data-index={dataIndex}
-      data-virtual-row=""
+      data-virtual-row={dataIndex !== undefined ? "" : undefined}
       data-stripe={dataIndex !== undefined && dataIndex % 2 === 1 ? "" : undefined}
       data-json={jsonLine ? "" : undefined}
       data-highlight={highlight || undefined}

--- a/frontend/src/components/metrics/TimeSeriesChart.tsx
+++ b/frontend/src/components/metrics/TimeSeriesChart.tsx
@@ -143,6 +143,15 @@ export default function TimeSeriesChart({
   const syncIndexRef = useRef<number | null>(null);
 
   useEffect(() => {
+    return () => {
+      if (clickTimerRef.current) {
+        clearTimeout(clickTimerRef.current);
+        clickTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     return sync.subscribe(chartId, (timestamp) => {
       const current = dataRef.current;
 

--- a/frontend/src/components/metrics/chartDatasets.ts
+++ b/frontend/src/components/metrics/chartDatasets.ts
@@ -103,13 +103,11 @@ export function computeSuggestedMax(
     return undefined;
   }
 
-  let high = Math.max(...metrics.series.flatMap(({ data }) => data));
+  const points = metrics.series.flatMap(({ data }) => data);
+  const thresholdValues = thresholds.map(({ value }) => value);
 
-  for (const threshold of thresholds) {
-    high = Math.max(high, threshold.value);
-  }
-
-  const low = yMin ?? Math.min(...metrics.series.flatMap(({ data }) => data));
+  const high = Math.max(...thresholdValues, ...points);
+  const low = yMin ?? (points.length > 0 ? Math.min(...points) : Math.min(...thresholdValues));
 
   return high + (high - low) * 0.1 || high + 1;
 }

--- a/frontend/src/components/metrics/useMetricsSeries.ts
+++ b/frontend/src/components/metrics/useMetricsSeries.ts
@@ -189,6 +189,13 @@ export function useMetricsSeries({
     pendingFetchCancel.current = fetchDataRef.current();
   }, []);
 
+  useEffect(() => {
+    return () => {
+      pendingFetchCancel.current?.();
+      pendingFetchCancel.current = null;
+    };
+  }, []);
+
   const live = loadedKey === key && from == null && to == null && streaming;
 
   useEffect(() => {

--- a/frontend/src/pages/ErrorIndex.tsx
+++ b/frontend/src/pages/ErrorIndex.tsx
@@ -26,7 +26,7 @@ export default function ErrorIndex() {
         return res.json();
       })
       .then(setErrors)
-      .catch((definition) => setError(definition.message));
+      .catch((caught) => setError(caught.message));
   }, []);
 
   if (error) {

--- a/frontend/src/pages/PluginDetail.tsx
+++ b/frontend/src/pages/PluginDetail.tsx
@@ -247,11 +247,7 @@ export default function PluginDetail() {
         <InfoCard
           label="Status"
           value={
-            <span
-              className={
-                plugin.Enabled ? "text-status-ok dark:text-status-ok" : "text-muted-foreground"
-              }
-            >
+            <span className={plugin.Enabled ? "text-status-ok" : "text-muted-foreground"}>
               {plugin.Enabled ? "Enabled" : "Disabled"}
             </span>
           }

--- a/frontend/src/pages/StackList.tsx
+++ b/frontend/src/pages/StackList.tsx
@@ -161,8 +161,7 @@ function StackCard({ stack }: { stack: StackSummary }) {
       data-health={health}
       className={
         "group block rounded-lg border p-4 transition-all hover:border-foreground/20 hover:shadow-sm " +
-        "data-[health=critical]:border-status-danger/30 data-[health=critical]:bg-status-danger/10 " +
-        "dark:data-[health=critical]:border-status-danger/30 dark:data-[health=critical]:bg-status-danger/10"
+        "data-[health=critical]:border-status-danger/30 data-[health=critical]:bg-status-danger/10"
       }
     >
       {/* Header */}

--- a/internal/api/csp.go
+++ b/internal/api/csp.go
@@ -12,6 +12,9 @@ import (
 // scriptTag matches a <script> element and captures its attributes and body.
 var scriptTag = regexp.MustCompile(`(?is)<script([^>]*)>(.*?)</script>`)
 
+// srcAttr matches a `src` attribute on its own, so that `data-src` is not one.
+var srcAttr = regexp.MustCompile(`(?i)(^|[\s/])src\s*=`)
+
 // InlineScriptHashes returns a CSP source token per inline <script> in the
 // SPA's index.html, as `'sha256-<base64>'`.
 //
@@ -32,8 +35,8 @@ func InlineScriptHashes(fsys fs.FS) ([]string, error) {
 
 	var hashes []string
 	for _, match := range scriptTag.FindAllSubmatch(index, -1) {
-		attrs, body := string(match[1]), match[2]
-		if strings.Contains(strings.ToLower(attrs), "src=") || len(body) == 0 {
+		attrs, body := match[1], match[2]
+		if srcAttr.Match(attrs) || len(body) == 0 {
 			continue
 		}
 

--- a/internal/api/graphml/graphml.go
+++ b/internal/api/graphml/graphml.go
@@ -184,7 +184,6 @@ func Render(g jgf.Graph) ([]byte, error) {
 	return append([]byte(xml.Header), xmlBytes...), nil
 }
 
-// buildNodeElem constructs a <node> element from a JGF node.
 // intData renders one integer-typed metadata value. A JGF document built in
 // this process carries Go ints; one decoded from JSON carries float64, and both
 // reach here.
@@ -201,6 +200,7 @@ func intData(key string, value any) (dataElem, bool) {
 	}
 }
 
+// buildNodeElem constructs a <node> element from a JGF node.
 func buildNodeElem(urn string, node jgf.Node) nodeElem {
 	elem := nodeElem{ID: urn}
 


### PR DESCRIPTION
A review of #209 turned up eleven findings. Ten are fixed here; the eleventh is
described below and deliberately left alone. Everything corrects work that is
still under `[Unreleased]`, so there is no changelog entry — the behaviour being
fixed never shipped.

## Real defects

- **Short logs lost their striping.** `LogRow` set `data-virtual-row` on every
  row, but only `VirtualLogBody` passes `dataIndex` — so in the plain body
  (≤200 filtered lines) a row matched neither the new
  `tbody tr:nth-child(even):not([data-virtual-row])` rule nor `data-stripe`,
  while `even:bg-background/50` was deleted in the same hunk.
- **`data-src=` read as an external script.** `InlineScriptHashes` tested
  `strings.Contains(attrs, "src=")`, so `<script data-src="…">…</script>` would
  be skipped, left unhashed, and then blocked by `script-src` at runtime with no
  error on either side. Now a word-boundary `srcAttr` regexp.
- **`computeSuggestedMax` could return `-Infinity`.** A series present but
  carrying no points reduces `Math.max(...[])` to `-Infinity`, and with no
  `yMin` that becomes the axis ceiling and the plot collapses. The thresholds
  now seed both bounds.
- **A chart could publish an isolation after unmounting.** `TimeSeriesChart`
  never cleared its click-settle timer, so a click within
  `clickSettleMilliseconds` of navigating away still fired and pushed an
  isolation onto the sibling charts.
- **`useMetricsSeries` leaked a fetch.** The main effect's cleanup cancels only
  the fetch it started; one started by the refresh button or by the tab regaining
  visibility stayed outstanding and published into the hook's state after unmount.

## Leftovers from the palette sweep

- `ConnectionStatus`'s pulse glow was still a hardcoded `rgba(34,197,94,0.5)`
  while its dot had moved to `bg-status-ok`, so the two no longer matched in
  either theme — exactly the drift the sweep was undoing.
- `PluginDetail`'s `text-status-ok dark:text-status-ok` and `StackList`'s
  `dark:data-[health=critical]:*` classes are byte-identical to their base ones.
- A rename in `ErrorIndex` named a caught error `definition`.
- `graphml`'s `buildNodeElem` doc comment had come loose onto `intData`.

## Left as it is

`DataTable`'s keyboard cursor is positional and now survives data mutations.
`useSwarmQuery` drops an item in place on an SSE `remove`, shifting later rows
up one, so `selectedIndex` stays put and the highlight silently points at a
different resource — `Enter` then opens that one. The old `setSelectedIndex(-1)`
reset masked this. Tracking the selection by `keyFn` rather than index is the
fix, and that is a redesign of the component rather than a correction to this
work.

## Verification

`go build ./...`, `go test ./internal/api/...`, `npx tsc -b --noEmit`,
`npx oxlint`, `npm run fmt:check`, `npx vitest run` (767 tests) and
`npm run build` all pass. The `ConnectionStatus` glow was checked to compile
into `dist/assets/index-*.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8obYXbz5X3hTSPxJuPYUk
