### PR TITLE
chore(release): cut 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-10
+
 ### Added
 - `server.public_url` sets the canonical external URL once, supplying the OAuth issuer for the MCP server and the OIDC redirect URL instead of configuring each separately
 - The documentation site now carries an error reference: every code the API can return, with its HTTP status, what it means and how to resolve it, grouped by domain. A `type` URI out of an error response — `/api/errors/SVC001` — previously led somewhere only a running Cetacean could answer. The page is generated from the server's own catalog at build time, so it cannot fall behind it. Links into the references also now show what they point at, so a setting, an error code, a schema type and an MCP tool are distinguishable before you follow them
@@ -15,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - MCP tools now advertise the values each argument accepts, so a client can offer them and a model no longer has to infer them from prose: the resource types `find` and `describe` take, `get_topology`'s views, `get_metrics`' target, metric, range and ranking key, and `get_logs`' levels — which also gained `fatal`, a level the log filter has always accepted and no description mentioned
 - The MCP tool reference now gives every tool its own entry — what it does, its arguments, and the detail that applies to it — instead of a table per operations level followed by paragraphs describing tools further down the page. Each tool can also be linked to directly
 - Deploying Cetacean as a stack no longer requires creating an overlay network first. `compose.yaml` now stands on its own — `docker stack deploy -c compose.yaml cetacean` and nothing else. Connecting it to the bundled Prometheus is a second file, `compose.prometheus.yaml`, layered on top: `docker stack deploy -c compose.yaml -c compose.prometheus.yaml cetacean`. That replaces passing `CETACEAN_PROMETHEUS_URL` through the shell on every deploy, where forgetting it once silently disconnected the charts
-
-### Changed
 - The topology view now draws its graph as soon as the page opens rather than waiting for the layout engine to download first — the engine is half a megabyte and everything else was queued behind it
 - A dropped connection or a server restart no longer leaves a page stuck on an error. Requests that fail for transport reasons are retried briefly before the error is shown; a request the server actually refused is still reported straight away
 - Status colours are consistent across the dashboard and adapt to dark mode on their own. Every badge, dot, banner and status figure now draws from one palette of five meanings — healthy, warning, failed, in-progress, inactive — where each screen previously picked its own light and dark shades independently, so the same state could be a different red in two places and a state badge could disagree with the dot beside it. In light mode the palette is deeper than the shades it replaces, so a status badge is legible against its own tint rather than washing into it


### PR DESCRIPTION
Closes the `[Unreleased]` section as **0.14.0** and opens a fresh one. Thirty-one entries: two additions, seven changes and twenty-two fixes.

Minor rather than patch: the release adds `server.public_url`, and `compose.yaml` now deploys without an overlay network having to exist first. Nothing breaking.

The section carried two `### Changed` headings, from two branches each opening one. They fold into a single section in the order the entries landed, so the release notes don't present the same category twice.

`release.yml` extracts release notes by matching `## [0.14.0]` in this file, so the heading has to land before the tag. Verified with the workflow's own awk — 38 lines, nothing bleeding in from 0.13.0.

The signed `v0.14.0` tag goes on `main` once this merges. `sbom-gate` should pass: `internal/api/sbom`, `go.sum` and `frontend/package-lock.json` were last touched by the same commit (`6fed71d5`), and no `chore/sbom-sync` PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASoJXwcwBZAAe2Fg1gHXAz