### PR TITLE
chore(deps): bump smol-toml to 1.8.0 in the website lockfile

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9922,9 +9922,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"


### PR DESCRIPTION
Closes the Dependabot alert for [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2) — denial of service via malformed TOML documents, affecting `smol-toml <= 1.7.0`.

### Exposure

None. `smol-toml` arrives transitively under `astro` and `@astrojs/internal-helpers`, which use it to parse TOML while the site builds. The only TOML it ever sees is this repository's own content, and a static build takes no attacker-supplied input. The advisory's "high" is its generic rating — GitHub reports the CVSS score for this one as `0`.

### The change

Lockfile only, three lines: `1.7.0` → `1.8.0`. Both parents declare `^1.6.0`, so the patched version already satisfies them — no package upgrade, nothing else in the tree moves.

Verified with a clean `npm ci` and `npm run build` on this branch: 17 pages built, sitemap written, `oxlint` clean.

### Still open

The other alert, [GHSA-866g-f22w-33x8](https://github.com/advisories/GHSA-866g-f22w-33x8) (`@ai-sdk/provider-utils`, low/4.3), is **not** fixable yet. It arrives under `@scalar/api-reference` → `@scalar/agent-chat`, and both `ai@6.0.33` and `@ai-sdk/vue@3.0.33` pin it at exactly `4.0.5`. `@scalar/api-reference@1.68.0` is already the latest release, so there is no version to upgrade to — only an `overrides` entry would force it, pushing one AI SDK package out of the lockstep versioning its siblings expect. Not worth it for a 4.3 in a chat feature nobody has configured; it should clear when Scalar bumps its own `ai` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASoJXwcwBZAAe2Fg1gHXAz
