### PR TITLE
ci: ask for a run after committing the SBOM to a branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      # open-sbom-pr.sh dispatches ci.yml on the branch it opens, because a
-      # pull request created with GITHUB_TOKEN raises no pull_request event and
-      # its required checks would never report. Dispatching needs actions:write,
-      # and a job-level block replaces the default rather than adding to it.
+      # Both write paths dispatch ci.yml afterwards, because nothing authored
+      # with GITHUB_TOKEN raises an event of its own: open-sbom-pr.sh for the
+      # pull request it opens, commit-sbom.sh for the commit it lands on a
+      # branch. Either way the required checks would otherwise never report.
+      # Dispatching needs actions:write, and a job-level block replaces the
+      # default rather than adding to it.
       actions: write
     # One sync per branch: two concurrent runs would race the same commit.
     concurrency:
@@ -188,6 +190,11 @@ jobs:
       # API, so the result is Verified with no signing key in CI secrets, and
       # because expectedHeadOid makes the write fail rather than clobber a
       # branch that moved since checkout.
+      #
+      # The script also dispatches a run for the branch afterwards. A commit
+      # authored with GITHUB_TOKEN raises no event, so without that the pull
+      # request sits blocked on required checks that passed one commit earlier
+      # and can never appear on the new head.
       - name: Commit regenerated SBOM
         if: >-
           github.event_name == 'pull_request' &&

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,11 @@ make sbom-verify                          # check the committed SBOM against the
 The SBOM (`internal/api/sbom/*`, `THIRD_PARTY_LICENSES`) is committed and embedded in the binary. You rarely need to
 regenerate it by hand: the `pre-commit` hook does it when a dependency manifest is staged (skipping when it cannot —
 a linked worktree, or a missing toolchain), and CI's `sbom-sync` job regenerates it on every pull request and
-**commits the result back to the branch**, signed, via `createCommitOnBranch`.
+**commits the result back to the branch**, signed, via `createCommitOnBranch`, then dispatches `ci.yml` on that branch.
+The dispatch is not optional: a commit authored with `GITHUB_TOKEN` raises no event, so the run that would put the
+branch's required checks on the new head never starts, and the pull request sits blocked on checks that passed one
+commit earlier and can never appear on this one. The dispatched run commits nothing — the commit step is gated on
+`pull_request` — so it cannot recur.
 
 Two kinds of pull request are reported on rather than written to. A fork PR cannot be written to at all — its token is
 read-only. A **Dependabot** PR could be, but must not: Dependabot stops updating any branch carrying a commit it did

--- a/scripts/commit-sbom.sh
+++ b/scripts/commit-sbom.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Commits regenerated SBOM artifacts to a pull request branch, signed.
+# Commits regenerated SBOM artifacts to a pull request branch, signed, and asks
+# for the CI run that commit cannot start on its own.
 #
 # Uses the createCommitOnBranch GraphQL mutation rather than `git commit && git
 # push`, for two reasons: GitHub GPG-signs commits authored through the API, so
@@ -135,3 +136,21 @@ if [ $status -ne 0 ]; then
 fi
 
 echo "Committed regenerated SBOM to $branch." >&2
+
+# That commit was authored with GITHUB_TOKEN, and GitHub raises no event for
+# those — so the run that would put this branch's required checks on the new
+# head never starts. The pull request is then blocked on checks that passed on
+# the commit before it and can never appear on this one, until someone asks for
+# a run by hand. workflow_dispatch is the documented exception to that
+# suppression, the same one open-sbom-pr.sh relies on.
+#
+# This cannot recur: the dispatched run reports event_name workflow_dispatch,
+# and the step that calls this script is gated on pull_request, so it commits
+# nothing and dispatches nothing.
+#
+# Best effort, like the auto-merge in open-sbom-pr.sh. The commit is the job and
+# it succeeded; a run that has to be started by hand is a worse outcome than
+# this warning, not a reason to report the SBOM as uncommitted.
+if ! gh workflow run ci.yml --repo "$repository" --ref "$branch"; then
+  echo "::warning::Committed the SBOM to $branch but could not dispatch a run for it. Its required checks will stay on the previous commit; re-run CI on the branch to clear them."
+fi


### PR DESCRIPTION
Follow-up to #215, which spent two cycles stuck on this.

### The problem

When `sbom-sync` commits regenerated artifacts to a pull request branch, that commit becomes the head. It is authored with `GITHUB_TOKEN`, and GitHub raises no event for those — so no run starts for it. The required checks (`build-frontend`, `lint-frontend`, `lint-go`, `test`, `test-frontend`) stay on the commit *before* it, where they passed, and can never appear on the one the merge gate looks at.

The result is a pull request blocked on checks that are green somewhere it cannot see:

```
head=17d609e0  CI=startup_failure  mergeState=BLOCKED
```

Only a manual `workflow_dispatch` clears it. That is not a rare path — it fires on any PR that changes a manifest the SBOM covers.

### The fix

`commit-sbom.sh` dispatches `ci.yml` on the branch after a successful commit. This is the same escape hatch `open-sbom-pr.sh` already uses for the pull request it opens, the `workflow_dispatch` trigger was declared for exactly this suppression, and the job already holds the `actions: write` it needs — so nothing new is introduced, the existing remedy is just applied to the second write path as well.

**It cannot recur.** The dispatched run reports `event_name: workflow_dispatch`, and the step that calls this script is gated on `pull_request` — so it commits nothing and dispatches nothing. It only runs the checks and verifies the SBOM is current.

**It is best effort**, like the auto-merge in `open-sbom-pr.sh`. The commit is the job and it succeeded; a run that has to be started by hand deserves a warning, not a red check reporting an SBOM that was in fact committed.

### Verification

All four paths exercised against a stub `gh` on `PATH`:

| path | commits | dispatches |
|---|---|---|
| drift, commit succeeds | ✅ | ✅ once, for its own branch |
| `--dry-run` | — | — (calls `gh` not at all) |
| no drift | — | — |
| branch moved (`expectedHeadOid` refused) | — | — |

The last one matters: a race must still resolve by the newer commit's own run, not by a dispatch racing it. Both non-committing paths return before the dispatch and call `gh` zero times.

`shellcheck` clean; the workflow still parses and `sbom-sync` keeps its three permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
