### PR TITLE
fix(auth): decide proxy trust once, at the edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - The dashboard loads about three times less over the wire on a first visit. Built assets are now precompressed at build time and served as zstd or gzip, taking the entry set from roughly 1046 KB to 326 KB, and hashed asset filenames are cached permanently instead of being revalidated on every load. `index.html` is still checked each time, so a new release is picked up immediately
 
 ### Fixed
+- Header-based authentication works behind a reverse proxy again. Cetacean rewrites the client address out of `X-Forwarded-For` before authentication runs, and the headers provider then checked *that* address against the trusted-proxy allowlist — asking whether the visitor was the proxy, which it never is. Every request was answered with a 401, in the one authentication mode that cannot be configured without an allowlist. Whether a request arrived through a trusted proxy is now decided once, at the edge, on the address the connection actually came from, and carried forward from there
 - Documentation pages name themselves consistently. Each page's canonical URL carried a `.html` extension that no link, and no sitemap entry, ever used — nominating a second address for every page on the site
 
 ## [0.14.0] - 2026-09-10

--- a/internal/api/auth_proxy_test.go
+++ b/internal/api/auth_proxy_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+	"testing/fstest"
+
+	"github.com/radiergummi/cetacean/internal/api/sse"
+	"github.com/radiergummi/cetacean/internal/auth"
+	"github.com/radiergummi/cetacean/internal/cache"
+	"github.com/radiergummi/cetacean/internal/config"
+)
+
+// newProxyAuthRouter assembles the real router in headers auth mode, wiring
+// the same trusted-proxy set to realIP and the provider as main.go does. The
+// provider alone never sees a rewritten RemoteAddr, which is why headers mode
+// broke behind a proxy while headers_test.go stayed green.
+func newProxyAuthRouter(t *testing.T, trusted []netip.Prefix) http.Handler {
+	t.Helper()
+
+	c := cache.New(nil)
+	h := newTestHandlers(t, withCache(c))
+	b := sse.NewBroadcaster(0, noopErrorWriter, nil)
+	t.Cleanup(b.Close)
+
+	fsys := fstest.MapFS{"index.html": {Data: []byte("<html></html>")}}
+
+	return NewRouter(RouterConfig{
+		Handlers:    h,
+		Broadcaster: b,
+		SPA:         NewSPAHandler(fs.FS(fsys), ""),
+		AuthProvider: auth.NewHeadersProvider(config.HeadersConfig{
+			Subject:        "X-Auth-User",
+			TrustedProxies: trusted,
+		}),
+		TrustedProxies: trusted,
+	})
+}
+
+// proxiedRequest builds a GET /nodes carrying the identity headers a reverse
+// proxy would set, arriving from peer.
+func proxiedRequest(peer string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/nodes", nil)
+	r.Header.Set("Accept", "application/json")
+	r.Header.Set("X-Forwarded-For", "203.0.113.9")
+	r.Header.Set("X-Auth-User", "alice")
+	r.RemoteAddr = peer
+
+	return r
+}
+
+// TestHeadersAuthBehindTrustedProxy: realIP has rewritten RemoteAddr to the
+// client address by the time the provider runs, and auth still succeeds.
+func TestHeadersAuthBehindTrustedProxy(t *testing.T) {
+	router := newProxyAuthRouter(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, proxiedRequest("10.0.0.5:1234"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHeadersAuthFromUntrustedPeer: the same headers sent directly by a client
+// that is not a trusted proxy must be rejected.
+func TestHeadersAuthFromUntrustedPeer(t *testing.T) {
+	router := newProxyAuthRouter(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, proxiedRequest("203.0.113.9:1234"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d, want 401; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/realip.go
+++ b/internal/api/realip.go
@@ -6,53 +6,55 @@ import (
 	"net/netip"
 	"slices"
 	"strings"
+
+	"github.com/radiergummi/cetacean/internal/auth"
 )
 
-// realIP returns middleware that resolves the client IP from X-Forwarded-For
-// when the direct peer is a trusted proxy. It rewrites r.RemoteAddr so all
-// downstream code (logging, auth, etc.) sees the real client address.
+// realIP returns middleware that records the request's peer and — when that
+// peer is a trusted proxy — rewrites r.RemoteAddr to the client address the
+// proxy reported.
 //
-// If trusted is empty the middleware is a no-op.
+// The verdict is recorded on the original peer address, before the rewrite,
+// and recorded always, so downstream code can tell "untrusted" from "nobody
+// decided". Readers use auth.FromTrustedProxy, never RemoteAddr.
 func realIP(trusted []netip.Prefix) func(http.Handler) http.Handler {
-	if len(trusted) == 0 {
-		return func(next http.Handler) http.Handler { return next }
-	}
-
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if clientIP, ok := resolveClientIP(r, trusted); ok {
-				r.RemoteAddr = clientIP
+			peerHost, peerPort, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
 			}
+
+			peerIP, err := netip.ParseAddr(peerHost)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			peer := auth.Peer{Addr: peerIP, Trusted: isTrusted(peerIP, trusted)}
+			r = r.WithContext(auth.ContextWithPeer(r.Context(), peer))
+
+			if peer.Trusted {
+				if clientIP, ok := resolveClientIP(r, peerPort, trusted); ok {
+					r.RemoteAddr = clientIP
+				}
+			}
+
 			next.ServeHTTP(w, r)
 		})
 	}
 }
 
-// resolveClientIP walks X-Forwarded-For right-to-left, returning the
-// first (rightmost) entry that is NOT a trusted proxy. This is the
-// standard algorithm for extracting the real client IP behind a chain
-// of trusted proxies.
-func resolveClientIP(r *http.Request, trusted []netip.Prefix) (string, bool) {
-	peerHost, peerPort, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return "", false
-	}
-
-	peerIP, err := netip.ParseAddr(peerHost)
-	if err != nil {
-		return "", false
-	}
-
-	if !isTrusted(peerIP, trusted) {
-		return "", false
-	}
-
+// resolveClientIP returns the rightmost X-Forwarded-For entry that is not a
+// trusted proxy, joined with the peer's port. The caller has already
+// established that the peer itself is trusted.
+func resolveClientIP(r *http.Request, peerPort string, trusted []netip.Prefix) (string, bool) {
 	xff := r.Header.Get("X-Forwarded-For")
 	if xff == "" {
 		return "", false
 	}
 
-	// Walk right-to-left: the rightmost non-trusted entry is the client.
 	parts := strings.Split(xff, ",")
 	for _, part := range slices.Backward(parts) {
 		ip, err := netip.ParseAddr(strings.TrimSpace(part))

--- a/internal/api/realip_test.go
+++ b/internal/api/realip_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"testing"
+
+	"github.com/radiergummi/cetacean/internal/auth"
 )
 
 func TestRealIP_NoTrustedProxies(t *testing.T) {
@@ -119,4 +121,57 @@ func TestRealIP_IPv6(t *testing.T) {
 	r.RemoteAddr = "[fd00::1]:443"
 	r.Header.Set("X-Forwarded-For", "2001:db8::1")
 	handler.ServeHTTP(httptest.NewRecorder(), r)
+}
+
+// TestRealIP_RecordsVerdictOnOriginalPeer: the verdict describes the peer the
+// connection came from, not the client address the same middleware then
+// writes into RemoteAddr.
+func TestRealIP_RecordsVerdictOnOriginalPeer(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	handler := realIP(trusted)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		peer, ok := auth.PeerFromContext(r.Context())
+		if !ok {
+			t.Fatal("no peer recorded in context")
+		}
+		if peer.Addr.String() != "10.0.0.1" {
+			t.Errorf("peer address = %s, want the original peer 10.0.0.1", peer.Addr)
+		}
+		if !peer.Trusted {
+			t.Error("peer not marked trusted")
+		}
+		if r.RemoteAddr != "203.0.113.1:54321" {
+			t.Errorf("RemoteAddr = %s, want the client address", r.RemoteAddr)
+		}
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:54321"
+	r.Header.Set("X-Forwarded-For", "203.0.113.1")
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+}
+
+// TestRealIP_RecordsUntrustedVerdict: both ways of failing the check still
+// record a verdict, so downstream code can tell "untrusted" from "undecided".
+func TestRealIP_RecordsUntrustedVerdict(t *testing.T) {
+	for name, trusted := range map[string][]netip.Prefix{
+		"none configured":  nil,
+		"peer outside set": {netip.MustParsePrefix("10.0.0.0/8")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				peer, ok := auth.PeerFromContext(r.Context())
+				if !ok {
+					t.Fatal("no peer recorded in context")
+				}
+				if peer.Trusted {
+					t.Errorf("peer %s marked trusted", peer.Addr)
+				}
+			})
+
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = "203.0.113.1:12345"
+			r.Header.Set("X-Forwarded-For", "198.51.100.1")
+			realIP(trusted)(inner).ServeHTTP(httptest.NewRecorder(), r)
+		})
+	}
 }

--- a/internal/auth/headers.go
+++ b/internal/auth/headers.go
@@ -4,9 +4,7 @@ import (
 	"crypto/hmac"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"net/netip"
 	"strings"
 	"unicode"
 
@@ -34,13 +32,14 @@ func NewHeadersProvider(cfg config.HeadersConfig, extraHeaders ...string) *Heade
 }
 
 // Authenticate reads identity information from request headers set by a
-// trusted reverse proxy. If TrustedProxies is configured, the request's
-// remote address must match. If SecretHeader is configured, the proxy must
-// also send a matching secret value.
+// trusted reverse proxy, which the edge must have vouched for. If
+// SecretHeader is configured, the proxy must also send a matching secret.
 func (p *HeadersProvider) Authenticate(_ http.ResponseWriter, r *http.Request) (*Identity, error) {
-	// Check trusted proxy allowlist (always configured; enforced at startup).
-	if err := p.validateSourceIP(r.RemoteAddr); err != nil {
-		return nil, err
+	// Not re-derived from RemoteAddr: realIP has by then rewritten it to the
+	// client address the proxy reported, so the check would ask whether the
+	// *client* is a trusted proxy.
+	if !FromTrustedProxy(r.Context()) {
+		return nil, errors.New("request did not arrive through a trusted proxy")
 	}
 
 	// Check shared secret (constant-time).
@@ -101,27 +100,6 @@ func (p *HeadersProvider) Authenticate(_ http.ResponseWriter, r *http.Request) (
 }
 
 func (p *HeadersProvider) RegisterRoutes(_ *http.ServeMux) {}
-
-// validateSourceIP checks that the request originates from a trusted proxy.
-func (p *HeadersProvider) validateSourceIP(remoteAddr string) error {
-	host, _, err := net.SplitHostPort(remoteAddr)
-	if err != nil {
-		return errors.New("invalid remote address")
-	}
-
-	addr, err := netip.ParseAddr(host)
-	if err != nil {
-		return errors.New("invalid remote IP")
-	}
-
-	for _, prefix := range p.cfg.TrustedProxies {
-		if prefix.Contains(addr) {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("remote address %s is not a trusted proxy", addr)
-}
 
 // validateSubject checks the subject header value for sanity: non-empty,
 // no control characters, and within length limits.

--- a/internal/auth/headers_test.go
+++ b/internal/auth/headers_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -10,19 +11,35 @@ import (
 	"github.com/radiergummi/cetacean/internal/config"
 )
 
-// anyProxy matches all IPv4 addresses. Used in tests that aren't testing
-// proxy validation specifically, to satisfy the mandatory TrustedProxies
-// requirement without affecting test semantics.
-var anyProxy = []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")}
+// fromTrustedProxy attaches the trust verdict realIP records at the edge.
+func fromTrustedProxy(r *http.Request) *http.Request {
+	return withPeer(r, true)
+}
+
+// fromUntrustedPeer attaches the opposite verdict.
+func fromUntrustedPeer(r *http.Request) *http.Request {
+	return withPeer(r, false)
+}
+
+func withPeer(r *http.Request, trusted bool) *http.Request {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		panic("test request has no host:port RemoteAddr: " + r.RemoteAddr)
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		panic("test request has an unparseable peer address: " + host)
+	}
+	return r.WithContext(ContextWithPeer(r.Context(), Peer{Addr: addr, Trusted: trusted}))
+}
 
 func TestHeadersProvider_Authenticate(t *testing.T) {
 	t.Run("all headers", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			Name:           "X-Name",
-			Email:          "X-Email",
-			Groups:         "X-Groups",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
+			Name:    "X-Name",
+			Email:   "X-Email",
+			Groups:  "X-Groups",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -31,7 +48,7 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 		r.Header.Set("X-Email", "alice@example.com")
 		r.Header.Set("X-Groups", "admin, editors, ")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -58,13 +75,12 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("missing subject header", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for missing subject header")
 		}
@@ -72,17 +88,16 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("valid shared secret", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			SecretHeader:   "X-Proxy-Secret",
-			SecretValue:    "s3cret",
-			TrustedProxies: anyProxy,
+			Subject:      "X-User",
+			SecretHeader: "X-Proxy-Secret",
+			SecretValue:  "s3cret",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "bob")
 		r.Header.Set("X-Proxy-Secret", "s3cret")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -93,17 +108,16 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("invalid shared secret", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			SecretHeader:   "X-Proxy-Secret",
-			SecretValue:    "s3cret",
-			TrustedProxies: anyProxy,
+			Subject:      "X-User",
+			SecretHeader: "X-Proxy-Secret",
+			SecretValue:  "s3cret",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "bob")
 		r.Header.Set("X-Proxy-Secret", "wrong")
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for invalid secret")
 		}
@@ -111,17 +125,16 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("missing secret header entirely", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			SecretHeader:   "X-Proxy-Secret",
-			SecretValue:    "s3cret",
-			TrustedProxies: anyProxy,
+			Subject:      "X-User",
+			SecretHeader: "X-Proxy-Secret",
+			SecretValue:  "s3cret",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "bob")
 		// X-Proxy-Secret not set at all.
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for missing secret header")
 		}
@@ -129,14 +142,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("empty subject header value", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "")
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for empty subject header")
 		}
@@ -144,14 +156,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("subject with leading and trailing whitespace", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "  alice  ")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -163,16 +174,15 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("groups with only commas", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			Groups:         "X-Groups",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
+			Groups:  "X-Groups",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "alice")
 		r.Header.Set("X-Groups", ",,,")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -183,16 +193,15 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("groups with single value", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			Groups:         "X-Groups",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
+			Groups:  "X-Groups",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "alice")
 		r.Header.Set("X-Groups", "admin")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -203,8 +212,7 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("header name case insensitivity", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -213,7 +221,7 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 			"alice",
 		) // Go canonicalizes headers; case insensitivity is guaranteed by net/http
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -224,14 +232,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("only subject header", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-Remote-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-Remote-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-Remote-User", "charlie")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -255,14 +262,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("subject with control characters rejected", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header["X-User"] = []string{"alice\x00bob"}
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for subject with control characters")
 		}
@@ -273,14 +279,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("subject with newline rejected", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header["X-User"] = []string{"alice\nbob"}
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for subject with newline")
 		}
@@ -288,14 +293,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("subject exceeding max length rejected", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", strings.Repeat("a", maxSubjectLen+1))
 
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err == nil {
 			t.Fatal("expected error for subject exceeding max length")
 		}
@@ -306,14 +310,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("subject at max length accepted", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		})
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", strings.Repeat("a", maxSubjectLen))
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -324,15 +327,14 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("extra headers captured in Raw", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		}, "X-ACL")
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "alice")
 		r.Header.Set("X-Acl", `[{"resources":["service:*"],"permissions":["read"]}]`)
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -348,14 +350,13 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 
 	t.Run("missing extra header not stored in Raw", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: anyProxy,
+			Subject: "X-User",
 		}, "X-ACL")
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Header.Set("X-User", "alice")
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+		id, err := p.Authenticate(httptest.NewRecorder(), fromTrustedProxy(r))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -366,21 +367,23 @@ func TestHeadersProvider_Authenticate(t *testing.T) {
 	})
 }
 
-func TestHeadersProvider_TrustedProxies(t *testing.T) {
-	trustedCIDR := netip.MustParsePrefix("10.0.0.0/8")
-	trustedIP := netip.MustParsePrefix("192.168.1.1/32")
+// TestHeadersProvider_RequiresTrustedProxyVerdict: identity headers are
+// believed only when the edge recorded a trusted-proxy arrival. Which
+// addresses count as one is decided and covered in internal/api/realip.go.
+func TestHeadersProvider_RequiresTrustedProxyVerdict(t *testing.T) {
+	newProvider := func() *HeadersProvider {
+		return NewHeadersProvider(config.HeadersConfig{Subject: "X-User"})
+	}
 
-	t.Run("trusted proxy accepted", func(t *testing.T) {
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: []netip.Prefix{trustedCIDR},
-		})
-
+	newRequest := func() *http.Request {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.RemoteAddr = "10.0.0.5:12345"
 		r.Header.Set("X-User", "alice")
+		return r
+	}
 
-		id, err := p.Authenticate(httptest.NewRecorder(), r)
+	t.Run("trusted peer accepted", func(t *testing.T) {
+		id, err := newProvider().Authenticate(httptest.NewRecorder(), fromTrustedProxy(newRequest()))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -389,138 +392,40 @@ func TestHeadersProvider_TrustedProxies(t *testing.T) {
 		}
 	})
 
-	t.Run("untrusted proxy rejected", func(t *testing.T) {
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: []netip.Prefix{trustedCIDR},
-		})
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "172.16.0.1:12345"
-		r.Header.Set("X-User", "alice")
-
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+	t.Run("untrusted peer rejected", func(t *testing.T) {
+		_, err := newProvider().Authenticate(httptest.NewRecorder(), fromUntrustedPeer(newRequest()))
 		if err == nil {
-			t.Fatal("expected error for untrusted proxy")
+			t.Fatal("expected error for untrusted peer")
 		}
-		if !strings.Contains(err.Error(), "not a trusted proxy") {
+		if !strings.Contains(err.Error(), "trusted proxy") {
 			t.Errorf("error = %q, want mention of trusted proxy", err.Error())
 		}
 	})
 
-	t.Run("exact IP match", func(t *testing.T) {
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: []netip.Prefix{trustedIP},
-		})
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "192.168.1.1:443"
-		r.Header.Set("X-User", "alice")
-
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("exact IP mismatch", func(t *testing.T) {
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: []netip.Prefix{trustedIP},
-		})
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "192.168.1.2:443"
-		r.Header.Set("X-User", "alice")
-
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+	t.Run("no verdict rejected", func(t *testing.T) {
+		// The edge middleware did not run; absence is not a favourable verdict.
+		_, err := newProvider().Authenticate(httptest.NewRecorder(), newRequest())
 		if err == nil {
-			t.Fatal("expected error for non-matching IP")
+			t.Fatal("expected error when no trust verdict was recorded")
 		}
 	})
 
-	t.Run("multiple trusted prefixes", func(t *testing.T) {
+	t.Run("trust checked before secret", func(t *testing.T) {
 		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: []netip.Prefix{trustedCIDR, trustedIP},
+			Subject:      "X-User",
+			SecretHeader: "X-Secret",
+			SecretValue:  "s3cret",
 		})
 
-		// First prefix matches.
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "10.0.0.1:80"
-		r.Header.Set("X-User", "alice")
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
-		if err != nil {
-			t.Fatalf("first prefix: unexpected error: %v", err)
-		}
+		r := newRequest()
+		r.Header.Set("X-Secret", "s3cret") // correct secret, untrusted peer
 
-		// Second prefix matches.
-		r = httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "192.168.1.1:80"
-		r.Header.Set("X-User", "alice")
-		_, err = p.Authenticate(httptest.NewRecorder(), r)
-		if err != nil {
-			t.Fatalf("second prefix: unexpected error: %v", err)
-		}
-	})
-
-	t.Run("IPv6 trusted proxy", func(t *testing.T) {
-		ipv6Prefix := netip.MustParsePrefix("fd00::/8")
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			TrustedProxies: []netip.Prefix{ipv6Prefix},
-		})
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "[fd00::1]:443"
-		r.Header.Set("X-User", "alice")
-
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("trusted proxy checked before secret", func(t *testing.T) {
-		// Both configured — untrusted IP should fail before secret check.
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject:        "X-User",
-			SecretHeader:   "X-Secret",
-			SecretValue:    "s3cret",
-			TrustedProxies: []netip.Prefix{trustedCIDR},
-		})
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "172.16.0.1:12345"
-		r.Header.Set("X-User", "alice")
-		r.Header.Set("X-Secret", "s3cret") // correct secret, but untrusted IP
-
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
+		_, err := p.Authenticate(httptest.NewRecorder(), fromUntrustedPeer(r))
 		if err == nil {
-			t.Fatal("expected error for untrusted proxy despite valid secret")
+			t.Fatal("expected error for untrusted peer despite valid secret")
 		}
-		if !strings.Contains(err.Error(), "not a trusted proxy") {
+		if !strings.Contains(err.Error(), "trusted proxy") {
 			t.Errorf("error = %q, want trusted proxy error (not secret error)", err.Error())
-		}
-	})
-
-	t.Run("no trusted proxies configured rejects all", func(t *testing.T) {
-		// No TrustedProxies — proxy check always runs and rejects.
-		p := NewHeadersProvider(config.HeadersConfig{
-			Subject: "X-User",
-		})
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.RemoteAddr = "1.2.3.4:80"
-		r.Header.Set("X-User", "alice")
-
-		_, err := p.Authenticate(httptest.NewRecorder(), r)
-		if err == nil {
-			t.Fatal("expected error for missing trusted proxies")
-		}
-		if !strings.Contains(err.Error(), "not a trusted proxy") {
-			t.Errorf("error = %q, want mention of trusted proxy", err.Error())
 		}
 	})
 }

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -16,7 +16,13 @@ import (
 	"github.com/radiergummi/cetacean/internal/config"
 )
 
-var anyProxy = []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")}
+// fromTrustedProxy attaches the trust verdict realIP records at the edge.
+func fromTrustedProxy(r *http.Request) *http.Request {
+	return r.WithContext(auth.ContextWithPeer(r.Context(), auth.Peer{
+		Addr:    netip.MustParseAddr("10.0.0.5"),
+		Trusted: true,
+	}))
+}
 
 func TestIntegration_NoneMode(t *testing.T) {
 	provider := &auth.NoneProvider{}
@@ -70,11 +76,10 @@ func TestIntegration_NoneMode(t *testing.T) {
 
 func TestIntegration_HeadersMode_ValidHeaders(t *testing.T) {
 	provider := auth.NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		Name:           "X-User-Name",
-		Email:          "X-User-Email",
-		Groups:         "X-User-Groups",
-		TrustedProxies: anyProxy,
+		Subject: "X-User",
+		Name:    "X-User-Name",
+		Email:   "X-User-Email",
+		Groups:  "X-User-Groups",
 	})
 	mw := auth.Middleware(provider)
 
@@ -110,7 +115,7 @@ func TestIntegration_HeadersMode_ValidHeaders(t *testing.T) {
 	req.Header.Set("X-User-Groups", "admin, dev")
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, fromTrustedProxy(req))
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
@@ -118,8 +123,7 @@ func TestIntegration_HeadersMode_ValidHeaders(t *testing.T) {
 
 func TestIntegration_HeadersMode_MissingHeaders(t *testing.T) {
 	provider := auth.NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		TrustedProxies: anyProxy,
+		Subject: "X-User",
 	})
 	mw := auth.Middleware(provider)
 
@@ -134,7 +138,7 @@ func TestIntegration_HeadersMode_MissingHeaders(t *testing.T) {
 	// No X-User header set.
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, fromTrustedProxy(req))
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
@@ -142,10 +146,9 @@ func TestIntegration_HeadersMode_MissingHeaders(t *testing.T) {
 
 func TestIntegration_HeadersMode_ValidSecret(t *testing.T) {
 	provider := auth.NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		SecretHeader:   "X-Proxy-Secret",
-		SecretValue:    "s3cret",
-		TrustedProxies: anyProxy,
+		Subject:      "X-User",
+		SecretHeader: "X-Proxy-Secret",
+		SecretValue:  "s3cret",
 	})
 	mw := auth.Middleware(provider)
 
@@ -167,7 +170,7 @@ func TestIntegration_HeadersMode_ValidSecret(t *testing.T) {
 	req.Header.Set("X-Proxy-Secret", "s3cret")
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, fromTrustedProxy(req))
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
@@ -175,10 +178,9 @@ func TestIntegration_HeadersMode_ValidSecret(t *testing.T) {
 
 func TestIntegration_HeadersMode_InvalidSecret(t *testing.T) {
 	provider := auth.NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		SecretHeader:   "X-Proxy-Secret",
-		SecretValue:    "s3cret",
-		TrustedProxies: anyProxy,
+		Subject:      "X-User",
+		SecretHeader: "X-Proxy-Secret",
+		SecretValue:  "s3cret",
 	})
 	mw := auth.Middleware(provider)
 
@@ -193,7 +195,7 @@ func TestIntegration_HeadersMode_InvalidSecret(t *testing.T) {
 	req.Header.Set("X-Proxy-Secret", "wrong")
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, fromTrustedProxy(req))
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
@@ -201,10 +203,9 @@ func TestIntegration_HeadersMode_InvalidSecret(t *testing.T) {
 
 func TestIntegration_HeadersMode_MissingSecretHeader(t *testing.T) {
 	provider := auth.NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		SecretHeader:   "X-Proxy-Secret",
-		SecretValue:    "s3cret",
-		TrustedProxies: anyProxy,
+		Subject:      "X-User",
+		SecretHeader: "X-Proxy-Secret",
+		SecretValue:  "s3cret",
 	})
 	mw := auth.Middleware(provider)
 
@@ -219,7 +220,7 @@ func TestIntegration_HeadersMode_MissingSecretHeader(t *testing.T) {
 	// X-Proxy-Secret not set.
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, fromTrustedProxy(req))
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
@@ -227,9 +228,8 @@ func TestIntegration_HeadersMode_MissingSecretHeader(t *testing.T) {
 
 func TestIntegration_HeadersMode_GroupsParsing(t *testing.T) {
 	provider := auth.NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		Groups:         "X-Groups",
-		TrustedProxies: anyProxy,
+		Subject: "X-User",
+		Groups:  "X-Groups",
 	})
 	mw := auth.Middleware(provider)
 
@@ -278,7 +278,7 @@ func TestIntegration_HeadersMode_GroupsParsing(t *testing.T) {
 			}
 
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
+			handler.ServeHTTP(rec, fromTrustedProxy(req))
 			if rec.Code != http.StatusOK {
 				t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
 			}

--- a/internal/auth/peer.go
+++ b/internal/auth/peer.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"context"
+	"net/netip"
+)
+
+// Peer is the edge's view of where a request came from: the immediate network
+// peer's address, observed before any middleware rewrote RemoteAddr, and the
+// verdict on whether that peer is a configured trusted proxy. The decision is
+// made once, in the outermost middleware, and read from here downstream.
+type Peer struct {
+	// Addr is the address the connection actually arrived from.
+	Addr netip.Addr
+
+	// Trusted reports whether Addr falls inside the configured trusted-proxy
+	// set. False when no trusted proxies are configured.
+	Trusted bool
+}
+
+type peerCtxKey struct{}
+
+// ContextWithPeer returns a context carrying the request's peer.
+func ContextWithPeer(ctx context.Context, p Peer) context.Context {
+	return context.WithValue(ctx, peerCtxKey{}, p)
+}
+
+// PeerFromContext returns the peer recorded at the edge. The second result is
+// false when nothing recorded one, which callers must treat as untrusted.
+func PeerFromContext(ctx context.Context) (Peer, bool) {
+	p, ok := ctx.Value(peerCtxKey{}).(Peer)
+	return p, ok
+}
+
+// FromTrustedProxy reports whether the request reached us through a configured
+// trusted proxy. Credentials carried in request headers must ask this before
+// they may be believed.
+func FromTrustedProxy(ctx context.Context) bool {
+	p, ok := PeerFromContext(ctx)
+	return ok && p.Trusted
+}

--- a/internal/auth/whoami_test.go
+++ b/internal/auth/whoami_test.go
@@ -12,11 +12,10 @@ import (
 
 func TestWhoamiHandler_ReturnsIdentityJSON(t *testing.T) {
 	p := NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		Name:           "X-Name",
-		Email:          "X-Email",
-		Groups:         "X-Groups",
-		TrustedProxies: anyProxy,
+		Subject: "X-User",
+		Name:    "X-Name",
+		Email:   "X-Email",
+		Groups:  "X-Groups",
 	})
 
 	handler := WhoamiHandler(p, WriteIdentityJSON)
@@ -27,7 +26,7 @@ func TestWhoamiHandler_ReturnsIdentityJSON(t *testing.T) {
 	r.Header.Set("X-Groups", "admin, dev")
 
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(w, fromTrustedProxy(r))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
@@ -59,8 +58,7 @@ func TestWhoamiHandler_ReturnsIdentityJSON(t *testing.T) {
 
 func TestWhoamiHandler_Returns401WithoutHeaders(t *testing.T) {
 	p := NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		TrustedProxies: anyProxy,
+		Subject: "X-User",
 	})
 
 	handler := WhoamiHandler(p, WriteIdentityJSON)
@@ -68,7 +66,7 @@ func TestWhoamiHandler_Returns401WithoutHeaders(t *testing.T) {
 	// No X-User header set.
 
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(w, fromTrustedProxy(r))
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
@@ -77,10 +75,9 @@ func TestWhoamiHandler_Returns401WithoutHeaders(t *testing.T) {
 
 func TestWhoamiHandler_ValidSecret(t *testing.T) {
 	p := NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		SecretHeader:   "X-Proxy-Secret",
-		SecretValue:    "s3cret",
-		TrustedProxies: anyProxy,
+		Subject:      "X-User",
+		SecretHeader: "X-Proxy-Secret",
+		SecretValue:  "s3cret",
 	})
 
 	handler := WhoamiHandler(p, WriteIdentityJSON)
@@ -89,7 +86,7 @@ func TestWhoamiHandler_ValidSecret(t *testing.T) {
 	r.Header.Set("X-Proxy-Secret", "s3cret")
 
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(w, fromTrustedProxy(r))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
@@ -106,10 +103,9 @@ func TestWhoamiHandler_ValidSecret(t *testing.T) {
 
 func TestWhoamiHandler_InvalidSecret_Returns401(t *testing.T) {
 	p := NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		SecretHeader:   "X-Proxy-Secret",
-		SecretValue:    "s3cret",
-		TrustedProxies: anyProxy,
+		Subject:      "X-User",
+		SecretHeader: "X-Proxy-Secret",
+		SecretValue:  "s3cret",
 	})
 
 	handler := WhoamiHandler(p, WriteIdentityJSON)
@@ -118,7 +114,7 @@ func TestWhoamiHandler_InvalidSecret_Returns401(t *testing.T) {
 	r.Header.Set("X-Proxy-Secret", "wrong")
 
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(w, fromTrustedProxy(r))
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
@@ -127,8 +123,7 @@ func TestWhoamiHandler_InvalidSecret_Returns401(t *testing.T) {
 
 func TestWhoamiHandler_SetsCacheControlNoStore(t *testing.T) {
 	p := NewHeadersProvider(config.HeadersConfig{
-		Subject:        "X-User",
-		TrustedProxies: anyProxy,
+		Subject: "X-User",
 	})
 
 	handler := WhoamiHandler(p, WriteIdentityJSON)
@@ -136,7 +131,7 @@ func TestWhoamiHandler_SetsCacheControlNoStore(t *testing.T) {
 	r.Header.Set("X-User", "alice")
 
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(w, fromTrustedProxy(r))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)


### PR DESCRIPTION
Headers auth mode does not work behind a reverse proxy. It fails closed — 401 on every request — so this is denial of access to legitimate users, not a bypass.

## The bug

`realIP` (`internal/api/router.go`) wraps `auth.Middleware`, so it runs first and rewrites `r.RemoteAddr` to the *client* address whenever the peer is a trusted proxy and `X-Forwarded-For` names a non-trusted client. `HeadersProvider.validateSourceIP` then checked that rewritten value against the trusted-proxy allowlist — asking "is the client a trusted proxy?", which it never is.

Probed against the assembled middleware pair (trusted proxy `10.0.0.5:1234`, `X-Forwarded-For: 203.0.113.9`, valid `X-Auth-User`):

```
status=401 body="authentication required"
```

`main.go` copies the deprecated `auth.headers.trusted_proxies` into `server.trusted_proxies` when the recommended setting is unset, and passes that to the router — so `realIP` was active with the same list under either configuration. Headers mode required a non-empty allowlist to start at all, so there was no configuration of it that both started and worked behind a proxy setting `X-Forwarded-For`.

## The fix

Decide trust **once, at the edge, on the original peer**, and carry the verdict forward instead of re-deriving it downstream from a value another middleware built out of client-supplied headers.

- `auth.Peer` (`internal/auth/peer.go`) records the address the connection came from and whether it is inside the configured trusted-proxy set.
- `realIP` records it before it rewrites anything, and `auth.FromTrustedProxy` is the one question consumers ask.
- `HeadersProvider` reads that instead of matching prefixes itself.

`realIP` no longer short-circuits when no trusted proxies are configured: it records an untrusted verdict, so "decided, untrusted" is distinguishable from "nobody decided" and a provider can fail closed on the latter.

`HeadersConfig.TrustedProxies` stays — `config` parses the deprecated env var into it and `main.go` merges it — but nothing in the provider reads it now.

## Tests

The coverage that missed this drove the provider in isolation, where nothing upstream has rewritten `RemoteAddr` — the same shape as the `Vary: Origin` bug in #213. `internal/api/auth_proxy_test.go` drives the **assembled router** in headers mode instead: a request from a trusted proxy carrying `X-Forwarded-For` authenticates, and the same headers from an untrusted peer are rejected.

All three new tests were verified by mutation rather than by passing:

| Mutation | Fails |
|---|---|
| Delete the `FromTrustedProxy` check | `TestHeadersAuthFromUntrustedPeer` (200, want 401) |
| Record the verdict on the rewritten address | `TestRealIP_RecordsVerdictOnOriginalPeer`, `TestHeadersAuthBehindTrustedProxy` |
| Restore the `len(trusted) == 0` short-circuit | `TestRealIP_RecordsUntrustedVerdict` |

`TestHeadersProvider_TrustedProxies` was replaced rather than adapted: its subtests matched peer addresses against prefixes, which the provider no longer does. `TestHeadersProvider_RequiresTrustedProxyVerdict` covers what remains its business — trusted, untrusted, and no verdict recorded — and the prefix matching is covered where it now happens.

`go test ./... -count=1` green; `golangci-lint run ./internal/...` reports zero issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
