### PR TITLE
test(api): hold the operations tier to the badge that states it

### DIFF
--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -215,6 +215,18 @@ func newTestRouterWithConfig(
 ) http.Handler {
 	t.Helper()
 
+	return NewRouter(testRouterConfig(t, routerOpts, opts...))
+}
+
+// testRouterConfig is the RouterConfig the test routers are built from, so a
+// test that enumerates the routes enumerates the ones it drives.
+func testRouterConfig(
+	t testing.TB,
+	routerOpts []routerOption,
+	opts ...testHandlersOption,
+) RouterConfig {
+	t.Helper()
+
 	h := newTestHandlers(t, opts...)
 	b := sse.NewBroadcaster(0, noopErrorWriter, nil)
 	t.Cleanup(b.Close)
@@ -234,5 +246,16 @@ func newTestRouterWithConfig(
 		opt(&cfg)
 	}
 
-	return NewRouter(cfg)
+	return cfg
+}
+
+// routerPatterns returns every pattern NewRouter registers. Route
+// registration does not vary with the operations level or the cache, so the
+// list holds for any of the routers a test builds.
+func routerPatterns(t testing.TB) []string {
+	t.Helper()
+
+	_, patterns := newRouter(testRouterConfig(t, nil, withCache(cache.New(nil))))
+
+	return patterns
 }

--- a/internal/api/openapi_exhaustive_test.go
+++ b/internal/api/openapi_exhaustive_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,9 +13,34 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3filter"
 
+	"github.com/radiergummi/cetacean/internal/api/sbom"
 	"github.com/radiergummi/cetacean/internal/api/sse"
 	"github.com/radiergummi/cetacean/internal/cache"
 )
+
+// licenseTextID is an id GET /-/licenses/texts/{id} actually serves. The ids
+// are content hashes of the embedded texts, not SPDX identifiers, and they
+// change whenever the SBOM is regenerated — so it is read out of the same
+// embedded artifact the handler answers from rather than written down.
+var licenseTextID = func() string {
+	var doc struct {
+		Components []struct {
+			TextID string `json:"textId"`
+		} `json:"components"`
+	}
+
+	if err := json.Unmarshal(sbom.ProjectedJSON(), &doc); err != nil {
+		return ""
+	}
+
+	for _, component := range doc.Components {
+		if component.TextID != "" {
+			return component.TextID
+		}
+	}
+
+	return ""
+}()
 
 // TestEveryReadEndpointMatchesSpec walks every GET operation in the OpenAPI
 // spec, issues a request with substituted path parameters, and validates the
@@ -199,9 +225,9 @@ func resolvePath(template string) (string, bool) {
 		"/plugins/{name}":    "/plugins/plug-1",
 		"/api/errors/{code}": "/api/errors/SVC001",
 
-		// Not cache fixtures: an SPDX identifier the embedded license set
-		// carries, and a label name the Prometheus proxy would forward.
-		"/-/licenses/texts/{id}": "/-/licenses/texts/MIT",
+		// Not cache fixtures: a text id the embedded license set carries, and
+		// a label name the Prometheus proxy would forward.
+		"/-/licenses/texts/{id}": "/-/licenses/texts/" + licenseTextID,
 		"/metrics/labels/{name}": "/metrics/labels/job",
 	}
 

--- a/internal/api/openapi_exhaustive_test.go
+++ b/internal/api/openapi_exhaustive_test.go
@@ -196,7 +196,13 @@ func resolvePath(template string) (string, bool) {
 		"/secrets/{id}":      "/secrets/sec-1",
 		"/networks/{id}":     "/networks/net-1",
 		"/volumes/{name}":    "/volumes/vol-1",
+		"/plugins/{name}":    "/plugins/plug-1",
 		"/api/errors/{code}": "/api/errors/SVC001",
+
+		// Not cache fixtures: an SPDX identifier the embedded license set
+		// carries, and a label name the Prometheus proxy would forward.
+		"/-/licenses/texts/{id}": "/-/licenses/texts/MIT",
+		"/metrics/labels/{name}": "/metrics/labels/job",
 	}
 
 	for prefix, replacement := range replacements {

--- a/internal/api/openapi_exhaustive_test.go
+++ b/internal/api/openapi_exhaustive_test.go
@@ -209,20 +209,11 @@ func skipEndpoint(path string) bool {
 	return false
 }
 
-// resolvePath substitutes path parameters in a spec path template with known
-// fixture IDs. Returns (resolved, true) if every {param} was substituted,
-// or (template, false) if any remain.
-func resolvePath(template string) (string, bool) {
-	replacements := map[string]string{
-		"/nodes/{id}":        "/nodes/node-1",
-		"/services/{id}":     "/services/svc-1",
-		"/tasks/{id}":        "/tasks/task-1",
-		"/stacks/{name}":     "/stacks/myapp",
-		"/configs/{id}":      "/configs/cfg-1",
-		"/secrets/{id}":      "/secrets/sec-1",
-		"/networks/{id}":     "/networks/net-1",
-		"/volumes/{name}":    "/volumes/vol-1",
-		"/plugins/{name}":    "/plugins/plug-1",
+// pathFixtures maps a spec path prefix to the concrete path resolvePath
+// substitutes for it: every resource in specFixtureIDs, plus the three
+// parameters that name something other than a cached resource.
+var pathFixtures = func() map[string]string {
+	fixtures := map[string]string{
 		"/api/errors/{code}": "/api/errors/SVC001",
 
 		// Not cache fixtures: a text id the embedded license set carries, and
@@ -231,7 +222,18 @@ func resolvePath(template string) (string, bool) {
 		"/metrics/labels/{name}": "/metrics/labels/job",
 	}
 
-	for prefix, replacement := range replacements {
+	for template, id := range specFixtureIDs {
+		fixtures[template] = template[:strings.LastIndex(template, "/")+1] + id
+	}
+
+	return fixtures
+}()
+
+// resolvePath substitutes path parameters in a spec path template with known
+// fixture IDs. Returns (resolved, true) if every {param} was substituted,
+// or (template, false) if any remain.
+func resolvePath(template string) (string, bool) {
+	for prefix, replacement := range pathFixtures {
 		if template == prefix {
 			return replacement, true
 		}
@@ -250,6 +252,55 @@ func resolvePath(template string) (string, bool) {
 	return template, false
 }
 
+// TestSpecFixtureIDsResolve drives the detail endpoint of every specFixtureIDs
+// entry against both fixtures that claim to seed it. Neither walk that reads
+// the table would notice an id gone stale: the contract walk logs a non-2xx
+// and moves on, and the operations-level probe reads its tier off the gate,
+// which answers before the resource is ever looked up. Coverage would drain
+// away in silence.
+func TestSpecFixtureIDsResolve(t *testing.T) {
+	specBytes, _, _ := loadTestSpec(t)
+
+	c := cache.New(nil)
+	populateSpecFixtures(c)
+
+	b := sse.NewBroadcaster(0, noopErrorWriter, nil)
+	defer b.Close()
+
+	fixtures := map[string]http.Handler{
+		"populateSpecFixtures": newTestRouter(t, newTestHandlers(t, withCache(c)), b, specBytes),
+		"newSeededTestRouter":  newSeededTestRouter(t),
+	}
+
+	for name, router := range fixtures {
+		for template := range specFixtureIDs {
+			// Plugins are answered by a Docker client rather than the cache,
+			// so a plugin id proves nothing about either fixture's seeding.
+			if strings.HasPrefix(template, "/plugins/") {
+				continue
+			}
+
+			path, _ := resolvePath(template)
+
+			t.Run(name+" "+path, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req.Header.Set("Accept", "application/json")
+
+				rec := httptest.NewRecorder()
+				router.ServeHTTP(rec, req)
+
+				if rec.Code != http.StatusOK {
+					t.Errorf(
+						"status=%d, want 200 — the fixture seeds no resource under "+
+							"the id specFixtureIDs addresses it by",
+						rec.Code,
+					)
+				}
+			})
+		}
+	}
+}
+
 // writeEndpointCheck is one non-GET spec operation exercised by the
 // behavioural half of TestEveryWriteEndpointDocumentsPreconditions: the spec
 // path template it proves coverage for, and the concrete request that drives
@@ -262,21 +313,19 @@ type writeEndpointCheck struct {
 	contentType string
 }
 
-// resourceIDPlaceholder maps each ID newSeededTestRouter's fixture uses to
-// the OpenAPI path parameter it fills. specTemplate uses it to turn a
+// resourceIDPlaceholder inverts specFixtureIDs: each fixture ID against the
+// OpenAPI path parameter it fills. specTemplate uses it to turn a
 // pairedEndpoints concrete path back into the spec's template, so the 30
 // precondition-carrying rows don't have to be retyped here.
-var resourceIDPlaceholder = map[string]string{
-	"svc1":      "{id}",
-	"node1":     "{id}",
-	"cfg1":      "{id}",
-	"sec1":      "{id}",
-	"net1":      "{id}",
-	"task1":     "{id}",
-	"vol1":      "{name}",
-	"plug1":     "{name}",
-	seededStack: "{name}",
-}
+var resourceIDPlaceholder = func() map[string]string {
+	placeholders := make(map[string]string, len(specFixtureIDs))
+
+	for template, id := range specFixtureIDs {
+		placeholders[id] = template[strings.LastIndex(template, "/")+1:]
+	}
+
+	return placeholders
+}()
 
 // specTemplate turns a concrete fixture path (as used in pairedEndpoints)
 // back into the OpenAPI path template it was resolved from.

--- a/internal/api/openapi_helpers_test.go
+++ b/internal/api/openapi_helpers_test.go
@@ -98,14 +98,30 @@ func newTestRouter(
 	})
 }
 
-// populateSpecFixtures seeds the cache with resource IDs that the exhaustive
-// contract test uses when resolving path templates. The fixture IDs
-// (node-1, svc-1, task-1, cfg-1, sec-1, net-1, vol-1, stack "myapp") match
-// resolvePath(). The service carries a stack-namespace label so the "myapp"
+// specFixtureIDs pairs each parameterised resource path in the spec with the
+// identifier that addresses it. resolvePath substitutes from it and
+// specTemplate inverts it, and both fixtures below seed these ids — one
+// vocabulary, so a walk cannot spend its probes on resources no fixture
+// holds.
+var specFixtureIDs = map[string]string{
+	"/nodes/{id}":     "node1",
+	"/services/{id}":  "svc1",
+	"/tasks/{id}":     "task1",
+	"/stacks/{name}":  seededStack,
+	"/configs/{id}":   "cfg1",
+	"/secrets/{id}":   "sec1",
+	"/networks/{id}":  "net1",
+	"/volumes/{name}": "vol1",
+	"/plugins/{name}": "plug1",
+}
+
+// populateSpecFixtures seeds the cache with the specFixtureIDs resources, for
+// the contract walks that want a lean fixture rather than newSeededTestRouter's
+// fully populated one. The service carries a stack-namespace label so the
 // stack is derivable from cache state.
 func populateSpecFixtures(c *cache.Cache) {
 	c.SetNode(swarm.Node{
-		ID: "node-1",
+		ID: "node1",
 		Spec: swarm.NodeSpec{
 			Role:         swarm.NodeRoleManager,
 			Availability: swarm.NodeAvailabilityActive,
@@ -120,11 +136,11 @@ func populateSpecFixtures(c *cache.Cache) {
 
 	replicas := uint64(1)
 	c.SetService(swarm.Service{
-		ID: "svc-1",
+		ID: "svc1",
 		Spec: swarm.ServiceSpec{
 			Annotations: swarm.Annotations{
 				Name:   "web",
-				Labels: map[string]string{"com.docker.stack.namespace": "myapp"},
+				Labels: map[string]string{"com.docker.stack.namespace": seededStack},
 			},
 			Mode: swarm.ServiceMode{
 				Replicated: &swarm.ReplicatedService{Replicas: &replicas},
@@ -136,24 +152,24 @@ func populateSpecFixtures(c *cache.Cache) {
 	})
 
 	c.SetTask(swarm.Task{
-		ID:           "task-1",
-		ServiceID:    "svc-1",
-		NodeID:       "node-1",
+		ID:           "task1",
+		ServiceID:    "svc1",
+		NodeID:       "node1",
 		Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
 		DesiredState: swarm.TaskStateRunning,
 	})
 
 	c.SetConfig(swarm.Config{
-		ID:   "cfg-1",
+		ID:   "cfg1",
 		Spec: swarm.ConfigSpec{Annotations: swarm.Annotations{Name: "cfg"}},
 	})
 
 	c.SetSecret(swarm.Secret{
-		ID:   "sec-1",
+		ID:   "sec1",
 		Spec: swarm.SecretSpec{Annotations: swarm.Annotations{Name: "sec"}},
 	})
 
-	c.SetNetwork(network.Summary{ID: "net-1", Name: "net"})
+	c.SetNetwork(network.Summary{ID: "net1", Name: "net"})
 
-	c.SetVolume(volume.Volume{Name: "vol-1", Driver: "local"})
+	c.SetVolume(volume.Volume{Name: "vol1", Driver: "local"})
 }

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -60,7 +60,7 @@ func TestResponsesMatchOpenAPISpec(t *testing.T) {
 		{
 			name:       "node detail",
 			method:     "GET",
-			path:       "/nodes/node-1",
+			path:       "/nodes/node1",
 			accept:     "application/json",
 			wantStatus: 200,
 		},
@@ -88,7 +88,7 @@ func TestResponsesMatchOpenAPISpec(t *testing.T) {
 		{
 			name:       "task detail",
 			method:     "GET",
-			path:       "/tasks/task-1",
+			path:       "/tasks/task1",
 			accept:     "application/json",
 			wantStatus: 200,
 		},

--- a/internal/api/operations_level_test.go
+++ b/internal/api/operations_level_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -30,19 +32,20 @@ var operationsLevels = []config.OperationsLevel{
 }
 
 // unmeasurableOperations lists spec operations this test cannot drive, with
-// the reason. All three stream until the client goes away, so a probe would
-// block on the recorder rather than return a status to read.
+// the reason. It is empty, and should stay that way: the streaming endpoints
+// that look unmeasurable are not. The probe asks for application/json, which
+// routes /events to the SPA and the two log tails to their JSON handlers, so
+// all three answer a status promptly rather than streaming. Excluding them
+// would be a blind spot rather than a saving — the guard below only fires when
+// an excluded operation grows a *badge*, so a gate added without one would go
+// unnoticed on exactly the operations nothing else measures.
 //
 // An entry may only cover an operation that declares no tier. One that grows
 // an operations-level badge needs a way to be measured, not a skip — the
 // assertion below fails outright rather than exempting it. An entry naming an
 // operation the spec no longer has fails too, so the list cannot rot into
 // silently skipping a path that gets added back under the same name.
-var unmeasurableOperations = map[string]string{
-	"GET /events":             "server-sent event stream; never returns",
-	"GET /services/{id}/logs": "log tail; streams until cancelled",
-	"GET /tasks/{id}/logs":    "log tail; streams until cancelled",
-}
+var unmeasurableOperations = map[string]string{}
 
 // TestEveryOperationIsGatedAtItsDeclaredTier holds the OpenAPI spec's
 // operations-level badges and the router's requireLevel gates together, in
@@ -178,6 +181,11 @@ func TestEveryOperationIsGatedAtItsDeclaredTier(t *testing.T) {
 			declared, gated,
 		)
 	}
+
+	// Logged on success too: the floor above only catches a walk that covered
+	// nothing at all, so a skip rule that quietly halved the coverage would
+	// still pass. The counts make that visible in the output.
+	t.Logf("badged=%d gated=%d", declared, gated)
 }
 
 // declaredOperationsLevel reads the operations-level badge off a spec
@@ -248,6 +256,15 @@ func refusesForOperationsLevel(router http.Handler, method, path string) bool {
 	req := httptest.NewRequest(method, path, nil)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("If-Match", `"bogus-etag"`)
+
+	// No operation streams under application/json today, but one that started
+	// to would otherwise hang the walk until the whole package times out. A
+	// deadline turns that into a measured tier of 0, which fails against the
+	// badge instead.
+	ctx, cancel := context.WithTimeout(req.Context(), 5*time.Second)
+	defer cancel()
+
+	req = req.WithContext(ctx)
 
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)

--- a/internal/api/operations_level_test.go
+++ b/internal/api/operations_level_test.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/radiergummi/cetacean/internal/config"
+)
+
+// operationsLevelBadgePrefix is how api/openapi.yaml states an operation's
+// operations tier: an x-badges entry named "operations-level:N". Scalar renders
+// it, and this test is what makes it the statement the server is held to.
+const operationsLevelBadgePrefix = "operations-level:"
+
+// operationsLevels enumerates the configurable tiers, lowest first. The probe
+// below walks them in this order, so the first level that does not refuse is
+// the tier the router actually enforces.
+var operationsLevels = []config.OperationsLevel{
+	config.OpsReadOnly,
+	config.OpsOperational,
+	config.OpsConfiguration,
+	config.OpsImpactful,
+}
+
+// unmeasurableOperations lists spec operations this test cannot drive, with
+// the reason. All three stream until the client goes away, so a probe would
+// block on the recorder rather than return a status to read.
+//
+// An entry may only cover an operation that declares no tier. One that grows
+// an operations-level badge needs a way to be measured, not a skip — the
+// assertion below fails outright rather than exempting it. An entry naming an
+// operation the spec no longer has fails too, so the list cannot rot into
+// silently skipping a path that gets added back under the same name.
+var unmeasurableOperations = map[string]string{
+	"GET /events":             "server-sent event stream; never returns",
+	"GET /services/{id}/logs": "log tail; streams until cancelled",
+	"GET /tasks/{id}/logs":    "log tail; streams until cancelled",
+}
+
+// TestEveryOperationIsGatedAtItsDeclaredTier holds the OpenAPI spec's
+// operations-level badges and the router's requireLevel gates together, in
+// both directions: every operation must be refused with OPS001 at one level
+// below its badge and admitted at the badge's own level, and an operation
+// carrying no badge must be gated at no tier at all.
+//
+// Reads are walked as well as writes, not for symmetry but because one read is
+// gated — GET /swarm/unlock-key hands out the key that decrypts a locked
+// manager's raft store, and sits at tier 3. Restricting this walk to mutations
+// would leave the one endpoint whose tier matters most as the one endpoint
+// nothing checks.
+//
+// The router side is measured, not tabulated. Driving the assembled router at
+// each of the four levels and taking the lowest one that does not answer
+// OPS001 yields the tier as the server enforces it, so a route whose gate and
+// badge disagree fails whichever of the two was changed — and so does a gate
+// with no badge, or a badge on an operation nothing gates. A hand-kept table
+// of routes here would be a sixth statement of the tier, which is the drift
+// this test exists to stop.
+//
+// It needs no request bodies. requireLevel sits ahead of the handler, so an
+// empty body answers 400, 404, 412 or 415 — never OPS001 — and the assertion
+// is only ever about whether OPS001 appears. The bogus If-Match keeps the
+// thirty precondition-carrying routes from executing their mutation on the way
+// past the gate.
+func TestEveryOperationIsGatedAtItsDeclaredTier(t *testing.T) {
+	_, doc, _ := loadTestSpec(t)
+
+	routers := make(map[config.OperationsLevel]http.Handler, len(operationsLevels))
+	for _, level := range operationsLevels {
+		routers[level] = newSeededTestRouter(t, withOpsLevel(level))
+	}
+
+	var declared, gated int
+
+	specified := map[string]bool{}
+
+	for path, item := range doc.Paths.Map() {
+		for method, op := range item.Operations() {
+			key := method + " " + path
+			specified[key] = true
+
+			badge, hasBadge, err := declaredOperationsLevel(op)
+			if err != nil {
+				t.Errorf("%s: %v", key, err)
+
+				continue
+			}
+
+			if hasBadge {
+				declared++
+			}
+
+			if reason, ok := unmeasurableOperations[key]; ok {
+				if hasBadge {
+					t.Errorf(
+						"%s: declares operations-level:%d but is excluded from "+
+							"measurement (%s) — find a way to drive it instead of "+
+							"exempting a tier from its only check",
+						key, badge, reason,
+					)
+
+					continue
+				}
+
+				t.Logf("skipping %s: %s", key, reason)
+
+				continue
+			}
+
+			requestPath, ok := resolvePath(path)
+			if !ok {
+				t.Errorf(
+					"%s: no fixture for its path parameters — teach resolvePath the "+
+						"prefix so this operation's tier can be measured",
+					key,
+				)
+
+				continue
+			}
+
+			observed, admitted := observedOperationsLevel(routers, method, requestPath)
+			if observed > config.OpsReadOnly {
+				gated++
+			}
+
+			t.Run(key, func(t *testing.T) {
+				if !admitted {
+					t.Fatalf(
+						"refused with OPS001 at every level including %d — no "+
+							"configuration admits it",
+						config.OpsImpactful,
+					)
+				}
+
+				if hasBadge && observed != badge {
+					t.Errorf(
+						"the spec badges this operations-level:%d, but the router "+
+							"gates it at tier %d — correct whichever is wrong",
+						badge, observed,
+					)
+				}
+
+				if !hasBadge && observed > config.OpsReadOnly {
+					t.Errorf(
+						"the router gates this at tier %d, but the spec declares no "+
+							"operations-level badge for it",
+						observed,
+					)
+				}
+			})
+		}
+	}
+
+	for key, reason := range unmeasurableOperations {
+		if !specified[key] {
+			t.Errorf(
+				"%s: excluded from measurement (%s) but the spec has no such "+
+					"operation — drop the entry",
+				key, reason,
+			)
+		}
+	}
+
+	// A walk that measured nothing would otherwise pass in silence: every
+	// assertion above is per-operation, so an empty spec, or a skip rule broad
+	// enough to swallow the lot, produces no failures at all. Both counts are
+	// non-zero on any tree worth shipping.
+	if declared == 0 || gated == 0 {
+		t.Fatalf(
+			"measured badged=%d gated=%d — the walk covered nothing",
+			declared, gated,
+		)
+	}
+}
+
+// declaredOperationsLevel reads the operations-level badge off a spec
+// operation. A malformed badge is an error rather than an absence: a typo in
+// the level would otherwise silently exempt the operation from this test.
+func declaredOperationsLevel(op *openapi3.Operation) (config.OperationsLevel, bool, error) {
+	raw, ok := op.Extensions["x-badges"]
+	if !ok {
+		return 0, false, nil
+	}
+
+	badges, ok := raw.([]any)
+	if !ok {
+		return 0, false, fmt.Errorf("x-badges is %T, want a list", raw)
+	}
+
+	for _, entry := range badges {
+		badge, ok := entry.(map[string]any)
+		if !ok {
+			return 0, false, fmt.Errorf("x-badges entry is %T, want a mapping", entry)
+		}
+
+		name, _ := badge["name"].(string)
+		if !strings.HasPrefix(name, operationsLevelBadgePrefix) {
+			continue
+		}
+
+		level, err := strconv.Atoi(strings.TrimPrefix(name, operationsLevelBadgePrefix))
+		if err != nil {
+			return 0, false, fmt.Errorf("badge %q: %w", name, err)
+		}
+
+		if level < int(config.OpsReadOnly) || level > int(config.OpsImpactful) {
+			return 0, false, fmt.Errorf(
+				"badge %q: level out of range %d..%d",
+				name, config.OpsReadOnly, config.OpsImpactful,
+			)
+		}
+
+		return config.OperationsLevel(level), true, nil
+	}
+
+	return 0, false, nil
+}
+
+// observedOperationsLevel returns the lowest configured level at which the
+// router admits the request past its tier gate. Zero means the operation is
+// gated at no tier. The bool is false when even the highest level refuses,
+// which no configuration could then satisfy.
+func observedOperationsLevel(
+	routers map[config.OperationsLevel]http.Handler,
+	method, path string,
+) (config.OperationsLevel, bool) {
+	for _, level := range operationsLevels {
+		if !refusesForOperationsLevel(routers[level], method, path) {
+			return level, true
+		}
+	}
+
+	return 0, false
+}
+
+// refusesForOperationsLevel reports whether the router answers this request
+// with OPS001. It reads the problem document's type rather than the status,
+// because ACL002 is a 403 as well and a policy-less test router must never be
+// mistaken for a tier refusal.
+func refusesForOperationsLevel(router http.Handler, method, path string) bool {
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("If-Match", `"bogus-etag"`)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		return false
+	}
+
+	var problem ProblemDetail
+	if err := json.Unmarshal(rec.Body.Bytes(), &problem); err != nil {
+		return false
+	}
+
+	return strings.HasSuffix(problem.Type, "/api/errors/OPS001")
+}

--- a/internal/api/operations_level_test.go
+++ b/internal/api/operations_level_test.go
@@ -171,6 +171,59 @@ func TestEveryOperationIsGatedAtItsDeclaredTier(t *testing.T) {
 		}
 	}
 
+	// The walk above starts from the spec, so it sees only operations the spec
+	// declares. A gated route that was never written into api/openapi.yaml is
+	// invisible to it — and to every other test in the package, all of which
+	// are spec-driven. Walking what the router actually registered closes that
+	// direction: an undocumented route must be gated at no tier, because a
+	// tier nothing documents is a tier nothing can be held to.
+	var undocumented int
+
+	for _, pattern := range routerPatterns(t) {
+		method, path, ok := strings.Cut(pattern, " ")
+		if !ok {
+			// A mount rather than an operation: the SPA fallback, /mcp, the
+			// pprof tree. None carries a method to drive, and none is gated.
+			continue
+		}
+
+		if specified[method+" "+path] {
+			continue
+		}
+
+		undocumented++
+
+		requestPath, ok := resolvePath(path)
+		if !ok {
+			t.Errorf(
+				"%s: registered by the router, absent from the spec, and its path "+
+					"parameters resolve to no fixture — teach resolvePath the prefix "+
+					"so its tier can be measured",
+				pattern,
+			)
+
+			continue
+		}
+
+		observed, admitted := observedOperationsLevel(routers, method, requestPath)
+
+		switch {
+		case !admitted:
+			t.Errorf(
+				"%s: refused with OPS001 at every level including %d — no "+
+					"configuration admits it",
+				pattern, config.OpsImpactful,
+			)
+		case observed > config.OpsReadOnly:
+			t.Errorf(
+				"%s: the router gates this at tier %d, but the spec has no such "+
+					"operation — document it, or the tier is a promise nothing "+
+					"states",
+				pattern, observed,
+			)
+		}
+	}
+
 	// A walk that measured nothing would otherwise pass in silence: every
 	// assertion above is per-operation, so an empty spec, or a skip rule broad
 	// enough to swallow the lot, produces no failures at all. Both counts are
@@ -185,7 +238,7 @@ func TestEveryOperationIsGatedAtItsDeclaredTier(t *testing.T) {
 	// Logged on success too: the floor above only catches a walk that covered
 	// nothing at all, so a skip rule that quietly halved the coverage would
 	// still pass. The counts make that visible in the output.
-	t.Logf("badged=%d gated=%d", declared, gated)
+	t.Logf("badged=%d gated=%d undocumented-routes=%d", declared, gated, undocumented)
 }
 
 // declaredOperationsLevel reads the operations-level badge off a spec

--- a/internal/api/precondition_test.go
+++ b/internal/api/precondition_test.go
@@ -574,6 +574,10 @@ func TestPreconditionDistinguishesAnUnreachableBackend(t *testing.T) {
 	}
 }
 
+// newSeededTestRouter builds a router over the shared write fixture. Callers
+// pass options to vary one thing about it — the operations level, say — so a
+// test that needs a differently configured server does not need a second
+// fixture to disagree with this one.
 func newSeededTestRouter(t testing.TB, opts ...testHandlersOption) http.Handler {
 	t.Helper()
 

--- a/internal/api/precondition_test.go
+++ b/internal/api/precondition_test.go
@@ -642,6 +642,9 @@ func newSeededTestRouter(t testing.TB, opts ...testHandlersOption) http.Handler 
 		append([]testHandlersOption{
 			withWriteClient(seededWriteClient()),
 			withPluginClient(plugins),
+			// The two log routes reach their streamer as soon as the service
+			// or task resolves, and a nil one panics there.
+			withDockerClient(&mockLogStreamer{}),
 		}, opts...)...,
 	)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -87,7 +87,47 @@ func (h *Handlers) detailFeeds(
 	}
 }
 
+// routeRecorder is the mux NewRouter registers on: an http.ServeMux that also
+// remembers the patterns it was handed. The stdlib mux exposes no way to
+// enumerate them, and without the list nothing can hold the routes that exist
+// against the ones api/openapi.yaml documents — a walk that starts from the
+// spec cannot see a route the spec never mentions.
+//
+// Routes another component registers directly on the wrapped mux — the auth
+// provider's, the OAuth server's — are not recorded. Both sit under paths the
+// spec does not describe.
+type routeRecorder struct {
+	mux      *http.ServeMux
+	patterns []string
+}
+
+func (r *routeRecorder) Handle(pattern string, handler http.Handler) {
+	r.patterns = append(r.patterns, pattern)
+	r.mux.Handle(pattern, handler)
+}
+
+func (r *routeRecorder) HandleFunc(
+	pattern string,
+	handler func(http.ResponseWriter, *http.Request),
+) {
+	r.patterns = append(r.patterns, pattern)
+	r.mux.HandleFunc(pattern, handler)
+}
+
+func (r *routeRecorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mux.ServeHTTP(w, req)
+}
+
 func NewRouter(cfg RouterConfig) http.Handler {
+	handler, _ := newRouter(cfg)
+
+	return handler
+}
+
+// newRouter assembles the router and returns the patterns it registered beside
+// it. Production calls NewRouter and drops the second value; the spec-parity
+// test reads it.
+func newRouter(cfg RouterConfig) (http.Handler, []string) {
 	auth.SetErrorWriter(WriteErrorCode)
 
 	h := cfg.Handlers
@@ -96,7 +136,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	spa := cfg.SPA
 	authProvider := cfg.AuthProvider
 
-	mux := http.NewServeMux()
+	mux := &routeRecorder{mux: http.NewServeMux()}
 
 	tier1 := requireLevel(config.OpsOperational, h.operationsLevel)
 	tier2 := requireLevel(config.OpsConfiguration, h.operationsLevel)
@@ -163,7 +203,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	swarmTier2 := NewChain(swarmACL, tier2)
 	swarmTier3 := NewChain(swarmACL, tier3)
 
-	authProvider.RegisterRoutes(mux)
+	authProvider.RegisterRoutes(mux.mux)
 	mux.HandleFunc("GET /auth/whoami", auth.WhoamiHandler(authProvider, writeIdentityJSONLD))
 
 	// Meta endpoints (no content negotiation, no discovery links)
@@ -757,7 +797,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	// enabled and an auth provider is configured; the api package itself
 	// doesn't reach into mcp/oauth.
 	if cfg.OAuthRoutes != nil {
-		cfg.OAuthRoutes(mux, "")
+		cfg.OAuthRoutes(mux.mux, "")
 	}
 
 	// SPA fallback (must be last)
@@ -780,7 +820,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	return publicURLMiddleware(
 		cfg.PublicURL,
 		basePathMiddleware(cfg.BasePath, stack.Then(mux)),
-	)
+	), mux.patterns
 }
 
 func requireReady(h *Handlers) func(http.Handler) http.Handler {


### PR DESCRIPTION
Closes ledger item **E6** — "the operations tier is stated five times, and the machine-readable one is unread".

The tier of an endpoint is stated in five places: the router's tier chain, `allow.go`'s `resourceWriteMethods`, `internal/mcp`'s tool tiers, the `operations-level` badge in `api/openapi.yaml`, and the writes table in `docs/api.md`. The badge was the only machine-readable one and nothing read it, so a drifting tier could only be found by reading — which is how the node-label mismatch (#221) was found.

`TestEveryOperationIsGatedAtItsDeclaredTier` walks every operation in the spec, reads its badge, and drives the assembled router at all four operations levels to find the lowest one that does not answer `OPS001`. **53 badges, 53 gates, agreeing on every row.**

### Why it measures instead of tabulating

A route table in the test would have been a sixth statement of the same fact, and it only ever proves the table was written correctly. Probing the four levels proves the composed chain behaves as the badge promises — ACL, tier and precondition wrappers included.

It needs no request bodies: `requireLevel` sits ahead of the handler, so an empty body answers 400, 404, 412 or 415, never `OPS001`. The bogus `If-Match` keeps the precondition-carrying routes from executing their mutation on the way past the gate.

### Two corrections to the ledger's own account

- **The 54-vs-53 discrepancy it predicted does not exist.** The 54 came from a line-count grep that also matched the continuation lines of multi-line chains. The real accounting is 53 = 52 non-GET gated operations plus one gated GET, against 53 badges. Nothing unbadged, nothing over-badged.
- **E6 does not subsume E4, and needed nothing from #221.** The ledger expected this test to fail on E4 "in the direction the bug actually took". On `main` the badge for `patchNodeLabels` says 3 and the route gates at 3 — they agree. E4 was REST-vs-**MCP**-and-docs drift, which no OpenAPI-vs-router test can see; #221's `restTierParity` table is what covers that side. So this was built on `main` rather than stacked.

### Reads are walked too

Not for symmetry: `GET /swarm/unlock-key` returns the key that decrypts a locked manager's raft store, and is gated at tier 3. A writes-only walk — which is what the ledger's shape described — would have left the most consequential tier in the API as the one thing nothing checks.

### Supporting changes

- `resolvePath` gained three fixture prefixes (`/plugins/{name}`, `/-/licenses/texts/{id}`, `/metrics/labels/{name}`) rather than this test keeping a second resolution table beside it. Side effect: `TestEveryReadEndpointMatchesSpec` now validates `/-/licenses/texts/{id}`, which it previously skipped for want of a fixture, and still passes.
- `newSeededTestRouter` takes `testHandlersOption`s so four routers can differ in exactly one setting, instead of a second fixture that could disagree with the first.

### Verification

`go test ./...` green, `go vet` clean, `golangci-lint run internal/api/...` 0 issues. The walk costs 0.40s against its siblings' 0.15s and 0.24s — proportionate to four routers and at most four probes per gated operation, with early exit on the first admitting level.

Seven mutations were tried and all seven fail the test:

| Mutation | Caught by |
|---|---|
| Move `PUT /services/{id}/scale` to tier 2 | the badge/gate comparison |
| Remove the gate from `GET /swarm/unlock-key` | same — and only because reads are walked |
| Change the `patchNodeLabels` badge to level 2 | same, reported as E4's exact drift |
| Delete the `scaleService` badge | the gated-but-unbadged branch |
| Badge `GET /events`, which cannot be driven | the exclusion-list guard |
| Leave a stale entry in the exclusion list | the spec-membership loop |
| Stub the walk to skip every operation | the asserted counts |

### Not in scope

- `docs/api.md`'s writes table stays hand-stated. I verified all 53 rows against the badges by script once; parsing a markdown table in CI is more fragile than the drift is likely. It is now the one statement of the tier with no automated check.
- `allow.go` stays hand-stated per the ledger's ruling — its lowest-tier-per-method rule is a real projection of the routes, not a copy, and it has its own test.
- `TestPatchNodeLabelsIsAdmittedAtTierTwo` / `…RefusedBelowTierTwo` are retired as a class by this test, but they live on #221 — dropping them is a follow-up once both have landed.

No CHANGELOG entry: nothing here is user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
