### PR TITLE
refactor(config): move the headers-mode proxy rule out of main

### DIFF
--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -409,3 +409,37 @@ func ValidateCertMode(tlsEnabled bool, certCA string, trustedProxies []netip.Pre
 			"or server.trusted_proxies, to accept a Client-Cert header from a proxy that terminates it",
 	)
 }
+
+// ResolveTrustedProxies settles which list headers mode authenticates against.
+// Headers mode cannot authenticate anyone without one: every claim arrives in a
+// header that any client could have sent, so the list is what separates a proxy
+// Cetacean believes from one it does not.
+//
+// auth.headers.trusted_proxies is the older spelling and applies only where
+// server.trusted_proxies is unset, since that one also governs realIP and a
+// deployment setting both means the two to agree.
+func ResolveTrustedProxies(
+	current, deprecated []netip.Prefix,
+) (resolved []netip.Prefix, warnings []string, err error) {
+	switch {
+	case len(current) > 0 && len(deprecated) > 0:
+		return current, []string{
+			"auth.headers.trusted_proxies is deprecated and ignored when " +
+				"server.trusted_proxies is set; remove the old setting",
+		}, nil
+
+	case len(current) > 0:
+		return current, nil, nil
+
+	case len(deprecated) > 0:
+		return deprecated, []string{
+			"auth.headers.trusted_proxies is deprecated; use server.trusted_proxies instead",
+		}, nil
+
+	default:
+		return nil, nil, fmt.Errorf(
+			"headers auth mode requires server.trusted_proxies; " +
+				"set it to the CIDR of your reverse proxy",
+		)
+	}
+}

--- a/internal/config/auth_test.go
+++ b/internal/config/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -683,5 +684,91 @@ func TestValidateCertMode(t *testing.T) {
 					tt.tlsEnabled, tt.certCA, tt.trustedProxies, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestResolveTrustedProxies(t *testing.T) {
+	current := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	deprecated := []netip.Prefix{netip.MustParsePrefix("192.168.0.0/16")}
+
+	tests := []struct {
+		name         string
+		current      []netip.Prefix
+		deprecated   []netip.Prefix
+		want         []netip.Prefix
+		wantWarnings int
+		wantErr      bool
+	}{
+		{"only the current setting", current, nil, current, 0, false},
+		{"only the deprecated setting", nil, deprecated, deprecated, 1, false},
+		{"both, so the current one wins", current, deprecated, current, 1, false},
+		{"neither, so no request could authenticate", nil, nil, nil, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, warnings, err := ResolveTrustedProxies(tt.current, tt.deprecated)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("resolved = %v, want %v", got, tt.want)
+			}
+
+			if len(warnings) != tt.wantWarnings {
+				t.Errorf("warnings = %v, want %d", warnings, tt.wantWarnings)
+			}
+		})
+	}
+}
+
+// A warning an operator cannot act on is noise, so each names both spellings:
+// the one to remove and the one to keep.
+func TestResolveTrustedProxiesWarningsNameBothSettings(t *testing.T) {
+	current := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	deprecated := []netip.Prefix{netip.MustParsePrefix("192.168.0.0/16")}
+
+	cases := []struct {
+		name       string
+		current    []netip.Prefix
+		deprecated []netip.Prefix
+	}{
+		{"superseded", current, deprecated},
+		{"still in use", nil, deprecated},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, warnings, err := ResolveTrustedProxies(tt.current, tt.deprecated)
+			if err != nil {
+				t.Fatalf("ResolveTrustedProxies: %v", err)
+			}
+
+			if len(warnings) != 1 {
+				t.Fatalf("warnings = %v, want exactly one", warnings)
+			}
+
+			for _, setting := range []string{
+				"auth.headers.trusted_proxies",
+				"server.trusted_proxies",
+			} {
+				if !strings.Contains(warnings[0], setting) {
+					t.Errorf("warning %q does not name %s", warnings[0], setting)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveTrustedProxiesErrorNamesTheSetting(t *testing.T) {
+	_, _, err := ResolveTrustedProxies(nil, nil)
+	if err == nil {
+		t.Fatal("want an error when neither setting is configured")
+	}
+
+	if !strings.Contains(err.Error(), "server.trusted_proxies") {
+		t.Errorf("error %q does not name server.trusted_proxies", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -137,29 +137,23 @@ func main() {
 		}
 	}
 
-	// Resolve trusted proxies for headers auth: the deprecated
-	// CETACEAN_AUTH_HEADERS_TRUSTED_PROXIES falls back to the general setting.
 	if authCfg.Mode == "headers" {
-		if len(authCfg.Headers.TrustedProxies) > 0 {
-			if len(cfg.TrustedProxies) > 0 {
-				slog.Warn(
-					"auth.headers.trusted_proxies is deprecated and ignored when server.trusted_proxies is set; please remove the old setting",
-				)
-			} else {
-				slog.Warn(
-					"auth.headers.trusted_proxies is deprecated; use server.trusted_proxies instead",
-				)
-				cfg.TrustedProxies = authCfg.Headers.TrustedProxies
-			}
-		}
-		if len(cfg.TrustedProxies) == 0 {
-			fmt.Fprintf(
-				os.Stderr,
-				"headers auth mode requires server.trusted_proxies; set to the CIDR of your reverse proxy\n",
-			)
+		proxies, warnings, err := config.ResolveTrustedProxies(
+			cfg.TrustedProxies,
+			authCfg.Headers.TrustedProxies,
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
-		authCfg.Headers.TrustedProxies = cfg.TrustedProxies
+
+		for _, warning := range warnings {
+			slog.Warn(warning)
+		}
+
+		// realIP reads the one, the provider the other; they must agree.
+		cfg.TrustedProxies = proxies
+		authCfg.Headers.TrustedProxies = proxies
 	}
 
 	aclCfg := config.LoadACL(flags, fc)


### PR DESCRIPTION
`main.go` had grown one genuine piece of config validation. For headers auth mode it resolved the precedence between `server.trusted_proxies` and the deprecated `auth.headers.trusted_proxies`, picked between two different deprecation warnings depending on which combination was set, failed startup when neither was, and then wrote the result back into `authCfg.Headers.TrustedProxies` — finishing the construction of a config `LoadAuth` had returned incomplete.

None of that was testable. The failure path is an `os.Exit`, so no package test could reach it, and the precedence rule had no coverage at all despite deciding which reverse proxy Cetacean believes.

`config.ResolveTrustedProxies` now decides, and hands back warnings for `main` to log. That is the shape `ValidateCertMode` already has ten lines above the call site — same kind of rule (a mode requires one of two things), same package, same signature style.

Behaviour is unchanged. The four combinations are covered, and so is the wording of both warnings and the error, since a deprecation notice that doesn't name the setting to change is noise.

## Not changed

`main`'s `default: unknown auth mode` branch stays. It looks like misplaced validation, but `LoadAuth` already rejects unknown modes against `validModes`, so that branch is unreachable from configuration — it guards against a mode being added to the map without a provider, which is a different thing worth keeping.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fa6mhgBPXVAqrUtW3BpzzQ
