### PR TITLE
feat(api): describe the SSE streams as an AsyncAPI document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- `GET /api/asyncapi` describes every SSE stream as an AsyncAPI 3.0 document — the channels, the messages each carries, and which cursor dialect its `id:` uses. Sixteen streams were previously described nowhere
+- Both API descriptions are served as YAML as well as JSON, at `/api/openapi.yaml` and `/api/asyncapi.yaml` or by negotiating on `Accept`
 - Any list can be downloaded as CSV — add `.csv` to the URL or ask for `text/csv`. Search, filters and sorting apply; a download that asks for no page gets every row
 - The dashboard is installable as an app, with icons and a theme colour that follows its own background
 - The cluster can be searched from the browser's address bar, via the OpenSearch description at `/opensearch.xml`
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - The documentation site is navigable by an agent: every page has a Markdown version, `/llms.txt` lists the site, and `/openapi.json` describes what it serves
 
 ### Changed
+- **Upgrade note:** `X-Forwarded-Proto` and `X-Forwarded-Host` are honoured only from an address in `server.trusted_proxies`. Behind a proxy without it set, absolute URLs now name the internal address — set `server.public_url` or list the proxy
 - The dashboard's first load is about a third of its former size, and hashed assets are cached permanently
 - The API reference at `/api` is six months newer, and now follows Scalar releases automatically
 - MCP access tokens follow the RFC 9068 `at+jwt` profile. Clients holding an older token refresh automatically
@@ -32,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Everything that does not describe the cluster keeps working while the Docker daemon is unreachable — the dashboard's own icons and manifest, the API catalogue, the OpenSearch description and `/profile`
+- The CSV alternate a filtered listing advertises downloads the rows you are looking at; it dropped the query, so following the link returned everything
+- A browser-based MCP client can complete its OAuth flow again — cross-origin protection covered the endpoints that authenticate from the request body, where there is no ambient credential to defend
+- The dashboard can be installed as an app under OIDC authentication; the browser's manifest request was made without credentials and rejected
+- A recommendation that measured zero no longer reads as one that measured nothing — a service using essentially no CPU reported an empty `current`
 - Header-based authentication works behind a reverse proxy again; it was answering 401 to every request
 - Asking an endpoint for a format it does not serve now says so, instead of answering with JSON
 - Relabelling a node needs operations level 2 over the API, matching MCP. It was gated with draining and demoting

--- a/api/asyncapi.yaml
+++ b/api/asyncapi.yaml
@@ -482,7 +482,6 @@ components:
       name: node
       title: Node event
       summary: A node appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -490,7 +489,6 @@ components:
       name: service
       title: Service event
       summary: A service appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -498,7 +496,6 @@ components:
       name: task
       title: Task event
       summary: A task appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -506,7 +503,6 @@ components:
       name: stack
       title: Stack event
       summary: A stack appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -514,7 +510,6 @@ components:
       name: config
       title: Config event
       summary: A config appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -523,7 +518,6 @@ components:
       title: Secret event
       summary: A secret appeared, changed or is gone.
       description: The `resource` never carries secret data.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -531,7 +525,6 @@ components:
       name: network
       title: Network event
       summary: A network appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -539,7 +532,6 @@ components:
       name: volume
       title: Volume event
       summary: A volume appeared, changed or is gone.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/SSEEvent"
 
@@ -551,7 +543,6 @@ components:
         The payload is an **array** of envelopes, not one envelope. A single
         event is written under its own type name instead; a client must handle
         both. The frame's `id` is the highest history id in the array.
-      contentType: application/json
       payload:
         type: array
         items:
@@ -567,7 +558,6 @@ components:
         channel, which is ineligible for replay. The frame's `id` is the
         current history count, so the next reconnect resumes from there. The
         payload carries no `@id`, no `@type`, an empty `id` and no `resource`.
-      contentType: application/json
       payload:
         type: object
         properties:
@@ -595,7 +585,6 @@ components:
         Log frames are unnamed: they carry `data:` and, when the line has a
         timestamp newer than the cursor, `id:`. An EventSource client receives
         them as `message`.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/LogLine"
 
@@ -603,7 +592,6 @@ components:
       name: initial
       title: Initial range
       summary: The full window, queried once when the stream opens.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/PrometheusResponse"
 
@@ -612,7 +600,6 @@ components:
       title: Instant value
       summary: One instant query result, appended at each tick.
       description: Append these to the window `initial` delivered.
-      contentType: application/json
       payload:
         $ref: "#/components/schemas/PrometheusResponse"
 
@@ -620,7 +607,6 @@ components:
       name: query_error
       title: Query failed
       summary: A query failed. The stream stays open and keeps ticking.
-      contentType: application/json
       payload:
         type: object
         required: [error, errorType]

--- a/api/asyncapi.yaml
+++ b/api/asyncapi.yaml
@@ -1,0 +1,734 @@
+asyncapi: 3.0.0
+
+info:
+  title: Cetacean streams
+  version: 1.0.0
+  description: |
+    Every Server-Sent Events stream Cetacean serves.
+
+    A stream is opened by sending `Accept: text/event-stream` to the channel's
+    address; the same address answers JSON, HTML and the feed formats under a
+    different `Accept`, which is what `/api` describes. This document describes
+    only the streaming representation.
+
+    Three cursor dialects appear below, and all three reach a client as
+    `Last-Event-ID`:
+
+    - The sixteen resource channels and `/events` write a monotonic history id.
+      Reconnecting with one replays the events in between from a 10,000-entry
+      ring. A cursor the ring no longer holds gets a `sync` message instead,
+      and so does every detail channel, always — they are ineligible for replay
+      because a cross-resource matcher cannot be reconstructed from history.
+    - The two log channels write an RFC 3339 timestamp, and only ever move it
+      forward: Docker interleaves a service's tasks, so a line can arrive
+      carrying an older timestamp than one already sent, and a cursor that
+      followed arrival order would discard everything in between on the next
+      resume. The cursor narrows the backlog Docker replays on connect; it
+      never filters live output.
+    - `/metrics` writes no id at all. There is nothing to resume.
+
+    A replayed event carries no `resource`: replay reads the change history,
+    which stores identity and not payload. A client that assumes `resource` is
+    present breaks only after a reconnection.
+  license:
+    name: MIT
+    url: https://github.com/Radiergummi/cetacean/blob/main/LICENSE
+  externalDocs:
+    description: REST API reference
+    url: https://cetacean.mazetti.me/api
+
+defaultContentType: application/json
+
+servers:
+  self:
+    host: localhost:9000
+    protocol: https
+    description: |
+      This deployment. The served document names the origin the request
+      arrived on; the file in the repository names a placeholder.
+
+channels:
+  nodes:
+    address: /nodes
+    title: Node list stream
+    description: Every node event in the cluster.
+    messages:
+      node:
+        $ref: "#/components/messages/node"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  nodeDetail:
+    address: /nodes/{id}
+    title: Node detail stream
+    description: One node, plus the tasks placed on it.
+    parameters:
+      id:
+        description: Node ID.
+    messages:
+      node:
+        $ref: "#/components/messages/node"
+      task:
+        $ref: "#/components/messages/task"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  services:
+    address: /services
+    title: Service list stream
+    description: Every service event in the cluster.
+    messages:
+      service:
+        $ref: "#/components/messages/service"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  serviceDetail:
+    address: /services/{id}
+    title: Service detail stream
+    description: One service, plus its tasks.
+    parameters:
+      id:
+        description: Service ID.
+    messages:
+      service:
+        $ref: "#/components/messages/service"
+      task:
+        $ref: "#/components/messages/task"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  tasks:
+    address: /tasks
+    title: Task list stream
+    description: Every task event in the cluster.
+    messages:
+      task:
+        $ref: "#/components/messages/task"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  taskDetail:
+    address: /tasks/{id}
+    title: Task detail stream
+    description: One task.
+    parameters:
+      id:
+        description: Task ID.
+    messages:
+      task:
+        $ref: "#/components/messages/task"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  stacks:
+    address: /stacks
+    title: Stack list stream
+    description: Every stack event in the cluster.
+    messages:
+      stack:
+        $ref: "#/components/messages/stack"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  stackDetail:
+    address: /stacks/{name}
+    title: Stack detail stream
+    description: |
+      The members of one stack: its services, their tasks, and the configs,
+      secrets, networks and volumes they use. The stack itself is a derived
+      concept with no events of its own, so no `stack` message appears here.
+    parameters:
+      name:
+        description: Stack namespace, from the com.docker.stack.namespace label.
+    messages:
+      service:
+        $ref: "#/components/messages/service"
+      task:
+        $ref: "#/components/messages/task"
+      config:
+        $ref: "#/components/messages/config"
+      secret:
+        $ref: "#/components/messages/secret"
+      network:
+        $ref: "#/components/messages/network"
+      volume:
+        $ref: "#/components/messages/volume"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  configs:
+    address: /configs
+    title: Config list stream
+    description: Every config event in the cluster.
+    messages:
+      config:
+        $ref: "#/components/messages/config"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  configDetail:
+    address: /configs/{id}
+    title: Config detail stream
+    description: One config.
+    parameters:
+      id:
+        description: Config ID.
+    messages:
+      config:
+        $ref: "#/components/messages/config"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  secrets:
+    address: /secrets
+    title: Secret list stream
+    description: |
+      Every secret event in the cluster. Secret data is cleared before
+      serialization and never appears on this channel.
+    messages:
+      secret:
+        $ref: "#/components/messages/secret"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  secretDetail:
+    address: /secrets/{id}
+    title: Secret detail stream
+    description: One secret, without its data.
+    parameters:
+      id:
+        description: Secret ID.
+    messages:
+      secret:
+        $ref: "#/components/messages/secret"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  networks:
+    address: /networks
+    title: Network list stream
+    description: Every network event in the cluster.
+    messages:
+      network:
+        $ref: "#/components/messages/network"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  networkDetail:
+    address: /networks/{id}
+    title: Network detail stream
+    description: One network.
+    parameters:
+      id:
+        description: Network ID.
+    messages:
+      network:
+        $ref: "#/components/messages/network"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  volumes:
+    address: /volumes
+    title: Volume list stream
+    description: Every volume event in the cluster.
+    messages:
+      volume:
+        $ref: "#/components/messages/volume"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  volumeDetail:
+    address: /volumes/{name}
+    title: Volume detail stream
+    description: One volume. Volumes are keyed by name, not by ID.
+    parameters:
+      name:
+        description: Volume name.
+    messages:
+      volume:
+        $ref: "#/components/messages/volume"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: sync-only
+
+  events:
+    address: /events
+    title: Global event stream
+    description: |
+      Every resource change in one stream. `?types=` narrows it to a
+      comma-separated list of event type names; `sync` always passes the
+      filter.
+    messages:
+      node:
+        $ref: "#/components/messages/node"
+      service:
+        $ref: "#/components/messages/service"
+      task:
+        $ref: "#/components/messages/task"
+      stack:
+        $ref: "#/components/messages/stack"
+      config:
+        $ref: "#/components/messages/config"
+      secret:
+        $ref: "#/components/messages/secret"
+      network:
+        $ref: "#/components/messages/network"
+      volume:
+        $ref: "#/components/messages/volume"
+      batch:
+        $ref: "#/components/messages/batch"
+      sync:
+        $ref: "#/components/messages/sync"
+    x-cetacean-cursor: history-id
+    x-cetacean-replay: ring
+
+  serviceLogs:
+    address: /services/{id}/logs
+    title: Service log tail
+    description: |
+      Live log output for every task of one service. Frames are unnamed — an
+      EventSource client receives them as `message`.
+    parameters:
+      id:
+        description: Service ID.
+    messages:
+      logLine:
+        $ref: "#/components/messages/logLine"
+    x-cetacean-cursor: rfc3339-forward-only
+    x-cetacean-replay: backlog
+
+  taskLogs:
+    address: /tasks/{id}/logs
+    title: Task log tail
+    description: |
+      Live log output for one task. Frames are unnamed — an EventSource client
+      receives them as `message`.
+    parameters:
+      id:
+        description: Task ID.
+    messages:
+      logLine:
+        $ref: "#/components/messages/logLine"
+    x-cetacean-cursor: rfc3339-forward-only
+    x-cetacean-replay: backlog
+
+  metrics:
+    address: /metrics
+    title: Metrics stream
+    description: |
+      A Prometheus query, re-run on a timer. `query` is required; `step`
+      (5-300 seconds, default 15) sets the tick interval and `range` (seconds,
+      default 3600) the width of the initial window. No `id` is written, so
+      there is nothing to resume.
+    messages:
+      initial:
+        $ref: "#/components/messages/initial"
+      point:
+        $ref: "#/components/messages/point"
+      queryError:
+        $ref: "#/components/messages/queryError"
+    x-cetacean-cursor: none
+    x-cetacean-replay: none
+
+operations:
+  sendNodes:
+    action: send
+    channel:
+      $ref: "#/channels/nodes"
+  sendNodeDetail:
+    action: send
+    channel:
+      $ref: "#/channels/nodeDetail"
+  sendServices:
+    action: send
+    channel:
+      $ref: "#/channels/services"
+  sendServiceDetail:
+    action: send
+    channel:
+      $ref: "#/channels/serviceDetail"
+  sendTasks:
+    action: send
+    channel:
+      $ref: "#/channels/tasks"
+  sendTaskDetail:
+    action: send
+    channel:
+      $ref: "#/channels/taskDetail"
+  sendStacks:
+    action: send
+    channel:
+      $ref: "#/channels/stacks"
+  sendStackDetail:
+    action: send
+    channel:
+      $ref: "#/channels/stackDetail"
+  sendConfigs:
+    action: send
+    channel:
+      $ref: "#/channels/configs"
+  sendConfigDetail:
+    action: send
+    channel:
+      $ref: "#/channels/configDetail"
+  sendSecrets:
+    action: send
+    channel:
+      $ref: "#/channels/secrets"
+  sendSecretDetail:
+    action: send
+    channel:
+      $ref: "#/channels/secretDetail"
+  sendNetworks:
+    action: send
+    channel:
+      $ref: "#/channels/networks"
+  sendNetworkDetail:
+    action: send
+    channel:
+      $ref: "#/channels/networkDetail"
+  sendVolumes:
+    action: send
+    channel:
+      $ref: "#/channels/volumes"
+  sendVolumeDetail:
+    action: send
+    channel:
+      $ref: "#/channels/volumeDetail"
+  sendEvents:
+    action: send
+    channel:
+      $ref: "#/channels/events"
+  sendServiceLogs:
+    action: send
+    channel:
+      $ref: "#/channels/serviceLogs"
+  sendTaskLogs:
+    action: send
+    channel:
+      $ref: "#/channels/taskLogs"
+  sendMetrics:
+    action: send
+    channel:
+      $ref: "#/channels/metrics"
+
+components:
+  messages:
+    node:
+      name: node
+      title: Node event
+      summary: A node appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    service:
+      name: service
+      title: Service event
+      summary: A service appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    task:
+      name: task
+      title: Task event
+      summary: A task appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    stack:
+      name: stack
+      title: Stack event
+      summary: A stack appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    config:
+      name: config
+      title: Config event
+      summary: A config appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    secret:
+      name: secret
+      title: Secret event
+      summary: A secret appeared, changed or is gone.
+      description: The `resource` never carries secret data.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    network:
+      name: network
+      title: Network event
+      summary: A network appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    volume:
+      name: volume
+      title: Volume event
+      summary: A volume appeared, changed or is gone.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/SSEEvent"
+
+    batch:
+      name: batch
+      title: Batched events
+      summary: Two or more events that fell inside one batch interval.
+      description: |
+        The payload is an **array** of envelopes, not one envelope. A single
+        event is written under its own type name instead; a client must handle
+        both. The frame's `id` is the highest history id in the array.
+      contentType: application/json
+      payload:
+        type: array
+        items:
+          $ref: "#/components/schemas/SSEEvent"
+
+    sync:
+      name: sync
+      title: Resynchronize
+      summary: The stream could not be replayed from your cursor. Refetch.
+      description: |
+        Sent when a reconnecting client's `Last-Event-ID` is older than the
+        change-history ring still holds, and unconditionally on every detail
+        channel, which is ineligible for replay. The frame's `id` is the
+        current history count, so the next reconnect resumes from there. The
+        payload carries no `@id`, no `@type`, an empty `id` and no `resource`.
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          type:
+            type: string
+            const: sync
+          action:
+            type: string
+            const: full_sync
+          id:
+            type: string
+            const: ""
+      examples:
+        - name: afterAnAgedOutCursor
+          payload:
+            type: sync
+            action: full_sync
+            id: ""
+
+    logLine:
+      name: logLine
+      title: Log line
+      summary: One line of container output.
+      description: |
+        Log frames are unnamed: they carry `data:` and, when the line has a
+        timestamp newer than the cursor, `id:`. An EventSource client receives
+        them as `message`.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/LogLine"
+
+    initial:
+      name: initial
+      title: Initial range
+      summary: The full window, queried once when the stream opens.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/PrometheusResponse"
+
+    point:
+      name: point
+      title: Instant value
+      summary: One instant query result, appended at each tick.
+      description: Append these to the window `initial` delivered.
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/PrometheusResponse"
+
+    queryError:
+      name: query_error
+      title: Query failed
+      summary: A query failed. The stream stays open and keeps ticking.
+      contentType: application/json
+      payload:
+        type: object
+        required: [error, errorType]
+        properties:
+          error:
+            type: string
+            description: The failure, as reported by the Prometheus client.
+          errorType:
+            type: string
+            const: server_error
+      examples:
+        - name: prometheusUnreachable
+          payload:
+            error: "prometheus request failed: connection refused"
+            errorType: server_error
+
+  schemas:
+    # Copied from api/openapi.yaml#/components/schemas/SSEEvent and held to it
+    # by TestAsyncAPISchemasMatchOpenAPI. A $ref cannot be used: the correct
+    # spelling differs between the file and the served document.
+    SSEEvent:
+      type: object
+      description: |
+        JSON payload of an SSE event. Single events have `event: <type>`,
+        batched events have `event: batch` with an array of these objects.
+      properties:
+        "@id":
+          type: string
+          description: Canonical resource path
+        "@type":
+          type: string
+          description: Resource type (Node, Service, Task, etc.)
+        type:
+          type: string
+          description: Event type string (node, service, task, etc.)
+        action:
+          type: string
+          enum: [create, update, remove, ref_changed, full_sync]
+          description: >-
+            Event action. `create` means the resource appeared, `update` that
+            an existing one changed, `remove` that it is gone, and
+            `ref_changed` that a resource this one cross-references changed.
+            `full_sync` accompanies a `sync` event and asks the client to
+            refetch, because the stream could not be replayed from its cursor.
+        id:
+          type: string
+          description: Resource ID
+        resource:
+          type: object
+          description: The full resource object (type varies by event type)
+      example:
+        "@id": /services/r8m2x5nk3p7q
+        "@type": Service
+        type: service
+        action: update
+        id: r8m2x5nk3p7q
+        resource:
+          ID: r8m2x5nk3p7q
+          Version: { Index: 157 }
+          Spec:
+            Name: webapp
+            TaskTemplate:
+              ContainerSpec: { Image: "nginx:1.28@sha256:def456..." }
+
+    # Copied from api/openapi.yaml#/components/schemas/LogLine.
+    LogLine:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: RFC 3339 Nano timestamp
+        message:
+          type: string
+        stream:
+          type: string
+          enum: [stdout, stderr]
+        attrs:
+          type: object
+          additionalProperties:
+            type: string
+          description: Docker log attributes (e.g. task ID)
+      example:
+        timestamp: "2026-04-13T08:12:34.123456789Z"
+        message: "172.18.0.1 - - [13/Apr/2026:08:12:34 +0000] \"GET / HTTP/1.1\" 200 612"
+        stream: stdout
+        attrs: { "com.docker.swarm.task.id": tsk_abc123def456 }
+
+    # The /metrics stream forwards Prometheus' own response bodies unchanged.
+    # This is the first schema for them anywhere; OpenAPI describes the proxy
+    # at /metrics as an opaque object.
+    PrometheusResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [success, error]
+        data:
+          type: object
+          properties:
+            resultType:
+              type: string
+              enum: [matrix, vector, scalar, string]
+            result:
+              type: array
+              items:
+                type: object
+        errorType:
+          type: string
+        error:
+          type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -15,6 +15,8 @@ info:
 
     Every response (except `/-/` meta endpoints) includes:
     - `Link: </api>; rel="service-desc"` — pointer to this spec
+    - `Link: </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0"` —
+      the AsyncAPI description of the SSE streams
     - `Link: </api/context.jsonld>; rel="describedby"` — JSON-LD context
     - `Vary: Accept` — content negotiation indicator
 
@@ -774,6 +776,9 @@ paths:
                       - href: "https://cetacean.example.com/api"
                         type: "application/json"
                         title: "OpenAPI description"
+                      - href: "https://cetacean.example.com/api/asyncapi"
+                        type: "application/vnd.aai.asyncapi+json"
+                        title: "AsyncAPI description of the event streams"
                     describedby:
                       - href: "https://cetacean.example.com/api/context.jsonld"
                         type: "application/ld+json"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,6 +13,11 @@ info:
     Detail responses include `@context`, `@id`, and `@type`.
     Error responses follow RFC 9457 (Problem Details).
 
+    Both descriptions are served as JSON and as YAML. `/api` and `/api/asyncapi` negotiate on `Accept`
+    (`application/yaml`, `text/yaml`, or the registered `application/vnd.oai.openapi` and
+    `application/vnd.aai.asyncapi+yaml`), and `/api/openapi.yaml` and `/api/asyncapi.yaml` address the
+    YAML form directly.
+
     Every response (except `/-/` meta endpoints) includes:
     - `Link: </api>; rel="service-desc"; type="application/json"` — pointer to this spec
     - `Link: </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0"` —
@@ -655,8 +660,9 @@ paths:
       tags: [Documentation]
       summary: API documentation
       description: |
-        Content-negotiated. HTML requests get the Scalar API playground;
-        all other requests get this OpenAPI spec as JSON.
+        Content-negotiated. HTML requests get the Scalar API playground, a
+        request naming a YAML type gets this document as YAML, and all others
+        get it as JSON.
       security: []
       responses:
         "200":
@@ -666,6 +672,69 @@ paths:
               schema:
                 type: object
             text/html:
+              schema:
+                type: string
+            application/vnd.oai.openapi:
+              schema:
+                type: string
+
+  /api/openapi.yaml:
+    get:
+      operationId: getApiDocYaml
+      tags: [Documentation]
+      summary: OpenAPI description as YAML
+      description: |
+        This document as YAML, at the address the documentation site publishes
+        it under. The source file is served verbatim, so its comments and key
+        order are intact.
+      security: []
+      responses:
+        "200":
+          description: OpenAPI description
+          content:
+            application/vnd.oai.openapi:
+              schema:
+                type: string
+
+  /api/asyncapi:
+    get:
+      operationId: getAsyncApiDoc
+      tags: [Documentation]
+      summary: AsyncAPI description of the event streams
+      description: |
+        Describes every Server-Sent Events stream this server serves — what
+        each channel sends, the shape of its payloads, and which cursor dialect
+        its `id:` belongs to. A request naming a YAML type gets YAML; everything
+        else gets JSON.
+
+        The document names this deployment's own origin in its `servers` block,
+        so it is built per origin rather than served as a fixed file.
+      security: []
+      responses:
+        "200":
+          description: AsyncAPI description
+          content:
+            application/vnd.aai.asyncapi+json:
+              schema:
+                type: object
+            application/vnd.aai.asyncapi+yaml:
+              schema:
+                type: string
+
+  /api/asyncapi.yaml:
+    get:
+      operationId: getAsyncApiDocYaml
+      tags: [Documentation]
+      summary: AsyncAPI description as YAML
+      description: |
+        The same document as `/api/asyncapi`, always as YAML, keeping the
+        source's comments and key order.
+      security: []
+      responses:
+        "200":
+          description: AsyncAPI description
+          content:
+            application/vnd.aai.asyncapi+yaml:
               schema:
                 type: string
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6758,8 +6758,14 @@ components:
           type: string
         current:
           type: number
+          description: >-
+            The measured value. Absent when nothing was measured; present and
+            zero when the measurement was zero.
         configured:
           type: number
+          description: >-
+            The configured value. Absent when the finding is that nothing is
+            configured.
         suggested:
           type: number
         fixAction:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -14,7 +14,7 @@ info:
     Error responses follow RFC 9457 (Problem Details).
 
     Every response (except `/-/` meta endpoints) includes:
-    - `Link: </api>; rel="service-desc"` — pointer to this spec
+    - `Link: </api>; rel="service-desc"; type="application/json"` — pointer to this spec
     - `Link: </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0"` —
       the AsyncAPI description of the SSE streams
     - `Link: </api/context.jsonld>; rel="describedby"` — JSON-LD context

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,11 +13,6 @@ info:
     Detail responses include `@context`, `@id`, and `@type`.
     Error responses follow RFC 9457 (Problem Details).
 
-    Both descriptions are served as JSON and as YAML. `/api` and `/api/asyncapi` negotiate on `Accept`
-    (`application/yaml`, `text/yaml`, or the registered `application/vnd.oai.openapi` and
-    `application/vnd.aai.asyncapi+yaml`), and `/api/openapi.yaml` and `/api/asyncapi.yaml` address the
-    YAML form directly.
-
     Every response (except `/-/` meta endpoints) includes:
     - `Link: </api>; rel="service-desc"; type="application/json"` — pointer to this spec
     - `Link: </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0"` —

--- a/docs/api.md
+++ b/docs/api.md
@@ -542,7 +542,8 @@ Append `point` events to the data you already hold to build a rolling window.
 ### Stream contract
 
 `GET /api/asyncapi` describes every stream above as an [AsyncAPI 3.0](https://www.asyncapi.com/) document —
-`/api/asyncapi.json` serves the same thing. It names all twenty channels, the messages each can carry, and which of
+`/api/asyncapi.json` serves the same thing, and `/api/asyncapi.yaml` (or an `Accept` naming a YAML type)
+serves it as YAML. It names all twenty channels, the messages each can carry, and which of
 three cursor dialects its `id:` belongs to: a monotonic history id on the resource streams, an RFC 3339 timestamp that
 only moves forward on the log tails, and no id at all on `/metrics`. Paste it into
 [AsyncAPI Studio](https://studio.asyncapi.com/) to browse it; Cetacean ships no renderer of its own.

--- a/docs/api.md
+++ b/docs/api.md
@@ -699,7 +699,7 @@ Every response outside the `/-/` meta endpoints carries [RFC 8631](https://www.r
 headers:
 
 ```http
-Link: </api>; rel="service-desc", </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0", </api/context.jsonld>; rel="describedby", </.well-known/api-catalog>; rel="api-catalog"
+Link: </api>; rel="service-desc"; type="application/json", </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0", </api/context.jsonld>; rel="describedby", </.well-known/api-catalog>; rel="api-catalog"
 ```
 
 There are two `service-desc` links because there are two descriptions: the OpenAPI document at `/api` describes the

--- a/docs/api.md
+++ b/docs/api.md
@@ -541,16 +541,12 @@ Append `point` events to the data you already hold to build a rolling window.
 
 ### Stream contract
 
-`GET /api/asyncapi` describes every stream above as an [AsyncAPI 3.0](https://www.asyncapi.com/) document —
-`/api/asyncapi.json` serves the same thing, and `/api/asyncapi.yaml` (or an `Accept` naming a YAML type)
-serves it as YAML. It names all twenty channels, the messages each can carry, and which of
-three cursor dialects its `id:` belongs to: a monotonic history id on the resource streams, an RFC 3339 timestamp that
-only moves forward on the log tails, and no id at all on `/metrics`. Paste it into
-[AsyncAPI Studio](https://studio.asyncapi.com/) to browse it; Cetacean ships no renderer of its own.
+`GET /api/asyncapi` describes all twenty streams as an [AsyncAPI 3.0](https://www.asyncapi.com/) document: their
+channels, messages and cursor semantics. Add `.json` or `.yaml`, or negotiate on `Accept`. Browse it in
+[AsyncAPI Studio](https://studio.asyncapi.com/).
 
-Two things the document states that are easy to get wrong from the examples alone: a `batch` frame's payload is an
-**array** of envelopes rather than one, and a **replayed** event has no `resource` — replay reads the change history,
-which stores identity and not payload.
+Two details the examples above don't show: a `batch` payload is an **array** of envelopes, and a **replayed** event
+carries no `resource`.
 
 ## Connection limits
 
@@ -703,9 +699,8 @@ headers:
 Link: </api>; rel="service-desc"; type="application/json", </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0", </api/context.jsonld>; rel="describedby", </.well-known/api-catalog>; rel="api-catalog"
 ```
 
-There are two `service-desc` links because there are two descriptions: the OpenAPI document at `/api` describes the
-request/response API, and the AsyncAPI document at `/api/asyncapi` describes the event streams. The `type` parameter
-tells them apart. `describedby` points at the JSON-LD context document, and `api-catalog` at the
+The two `service-desc` links are told apart by `type`: `/api` describes the request/response API, `/api/asyncapi`
+the event streams. `describedby` points at the JSON-LD context document, and `api-catalog` at the
 [API catalogue](#api-catalogue).
 
 ### Browser search

--- a/docs/api.md
+++ b/docs/api.md
@@ -539,6 +539,18 @@ curl -H "Accept: text/event-stream" "http://localhost:9000/metrics?query=up&step
 
 Append `point` events to the data you already hold to build a rolling window.
 
+### Stream contract
+
+`GET /api/asyncapi` describes every stream above as an [AsyncAPI 3.0](https://www.asyncapi.com/) document —
+`/api/asyncapi.json` serves the same thing. It names all twenty channels, the messages each can carry, and which of
+three cursor dialects its `id:` belongs to: a monotonic history id on the resource streams, an RFC 3339 timestamp that
+only moves forward on the log tails, and no id at all on `/metrics`. Paste it into
+[AsyncAPI Studio](https://studio.asyncapi.com/) to browse it; Cetacean ships no renderer of its own.
+
+Two things the document states that are easy to get wrong from the examples alone: a `batch` frame's payload is an
+**array** of envelopes rather than one, and a **replayed** event has no `resource` — replay reads the change history,
+which stores identity and not payload.
+
 ## Connection limits
 
 There is no general rate limiting. Concurrent streams are capped, and a request over the cap returns
@@ -687,10 +699,12 @@ Every response outside the `/-/` meta endpoints carries [RFC 8631](https://www.r
 headers:
 
 ```http
-Link: </api>; rel="service-desc", </api/context.jsonld>; rel="describedby", </.well-known/api-catalog>; rel="api-catalog"
+Link: </api>; rel="service-desc", </api/asyncapi>; rel="service-desc"; type="application/vnd.aai.asyncapi+json;version=3.0.0", </api/context.jsonld>; rel="describedby", </.well-known/api-catalog>; rel="api-catalog"
 ```
 
-`service-desc` points at the OpenAPI spec, `describedby` at the JSON-LD context document, and `api-catalog` at the
+There are two `service-desc` links because there are two descriptions: the OpenAPI document at `/api` describes the
+request/response API, and the AsyncAPI document at `/api/asyncapi` describes the event streams. The `type` parameter
+tells them apart. `describedby` points at the JSON-LD context document, and `api-catalog` at the
 [API catalogue](#api-catalogue).
 
 ### Browser search

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -81,7 +81,7 @@ the config file.
 </ConfigParam>
 
 <ConfigParam name="server.trusted_proxies" flag="-trusted-proxies" env="CETACEAN_TRUSTED_PROXIES">
-  Comma-separated IP addresses or [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges of reverse proxies whose forwarding headers are trusted, e.g. `10.0.0.0/8,172.16.0.0/12`. Both [`Forwarded`][rfc7239] and `X-Forwarded-For` are read for the real client IP, the standard header first. Required for [header-based authentication][trusted-proxy-headers], and for `cert` mode behind a [TLS-terminating proxy][cert-behind-proxy]. When unset, every request counts as a direct connection, and `X-Forwarded-Proto`/`X-Forwarded-Host` are ignored — so absolute URLs (feed links and identifiers, OpenSearch templates, the API catalogue) name the address Cetacean was reached on inside the cluster. Set [`server.public_url`][server.public_url] instead if you would rather pin those URLs outright.
+  Comma-separated IP addresses or [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges of reverse proxies whose forwarding headers are trusted, e.g. `10.0.0.0/8,172.16.0.0/12`. Both [`Forwarded`][rfc7239] and `X-Forwarded-For` are read for the real client IP, the standard header first. Required for [header-based authentication][trusted-proxy-headers], and for `cert` mode behind a [TLS-terminating proxy][cert-behind-proxy]. When unset, every request counts as a direct connection.
 </ConfigParam>
 
 <ConfigParam name="storage.snapshot" flag="-snapshot" env="CETACEAN_SNAPSHOT" default="true">

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -81,7 +81,7 @@ the config file.
 </ConfigParam>
 
 <ConfigParam name="server.trusted_proxies" flag="-trusted-proxies" env="CETACEAN_TRUSTED_PROXIES">
-  Comma-separated IP addresses or [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges of reverse proxies whose forwarding headers are trusted, e.g. `10.0.0.0/8,172.16.0.0/12`. Both [`Forwarded`][rfc7239] and `X-Forwarded-For` are read for the real client IP, the standard header first. Required for [header-based authentication][trusted-proxy-headers], and for `cert` mode behind a [TLS-terminating proxy][cert-behind-proxy]. When unset, every request counts as a direct connection.
+  Comma-separated IP addresses or [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges of reverse proxies whose forwarding headers are trusted, e.g. `10.0.0.0/8,172.16.0.0/12`. Both [`Forwarded`][rfc7239] and `X-Forwarded-For` are read for the real client IP, the standard header first. Required for [header-based authentication][trusted-proxy-headers], and for `cert` mode behind a [TLS-terminating proxy][cert-behind-proxy]. When unset, every request counts as a direct connection, and `X-Forwarded-Proto`/`X-Forwarded-Host` are ignored — so absolute URLs (feed links and identifiers, OpenSearch templates, the API catalogue) name the address Cetacean was reached on inside the cluster. Set [`server.public_url`][server.public_url] instead if you would rather pin those URLs outright.
 </ConfigParam>
 
 <ConfigParam name="storage.snapshot" flag="-snapshot" env="CETACEAN_SNAPSHOT" default="true">

--- a/docs/specs/2026-09-12-asyncapi-stream-contract-design.md
+++ b/docs/specs/2026-09-12-asyncapi-stream-contract-design.md
@@ -1,0 +1,308 @@
+# AsyncAPI: a machine-readable contract for the SSE streams — design
+
+## Problem
+
+Cetacean serves **20 SSE streams**. OpenAPI describes four of them, and three of
+those four only partially.
+
+`api/openapi.yaml` carries exactly four `text/event-stream` content blocks:
+
+| Line | Endpoint | What it says |
+|---|---|---|
+| 495 | `GET /metrics` | `schema: {type: object}` and a sentence: *"SSE stream with `initial` (full range) and `point` (single value) events"* |
+| 902 | `GET /events` | `$ref: SSEEvent`, plus prose giving the frame shape |
+| 2633 | `GET /services/{id}/logs` | `$ref: LogLine` |
+| 4392 | `GET /tasks/{id}/logs` | `$ref: LogLine` |
+
+Every other stream is undocumented as a stream. The eight list endpoints and
+eight detail endpoints are registered with `contentNegotiatedWithSSE`
+(`internal/api/router.go:318`, `:327`, and fourteen more), so `GET /services`
+with `Accept: text/event-stream` opens a live stream — and nothing in the
+OpenAPI document mentions that the endpoint has a streaming representation at
+all. **Sixteen of twenty streams are invisible to a client reading the API
+description.**
+
+What the document cannot express even where it tries is the rest of it. OpenAPI
+describes a *response body*; an SSE stream is a sequence of named frames with a
+cursor, and the parts that matter have no slot to go in:
+
+**The event-name vocabulary.** `event: batch` and `event: sync` exist only
+inside the `SSEEvent` schema's prose (`api/openapi.yaml:7089`). The per-type
+names appear as *"(node, service, task, etc.)"* — an `etc.` standing in for an
+enumeration the code knows exactly (`internal/api/sse/broadcaster.go:440-457`).
+
+**Resumability, which differs per channel.** `Last-Event-ID` drives real replay
+from a ring buffer (`broadcaster.go:243`). A cursor too old for the ring gets a
+`sync` / `full_sync` event instead, asking the client to refetch. And detail
+streams are *ineligible for replay entirely* — `replayType == ""` takes the
+`writeSync()` branch unconditionally (`broadcaster.go:258`). So `/services` and
+`/services/{id}` are not one channel with a different filter; they make
+different promises about what happens when a client reconnects.
+
+**A replayed frame has a different shape from a live one.** Replay converts
+entries "to `cache.Event` (no Resource payload)" (`broadcaster.go:274`), so
+`resource` — `omitempty` on the wire (`broadcaster.go:399`) — is simply absent.
+A client that assumes it is present breaks only after a reconnection, which is
+the worst time to find out.
+
+**Three incompatible cursor dialects.** Resource streams write a monotonic
+`HistoryID` (`broadcaster.go:471`); log tails write an RFC3339 timestamp, and
+deliberately only advance it forward, because Docker interleaves tasks and a
+backwards-moving id would discard lines on the next resume
+(`internal/api/log_handlers.go:245-267`); the metrics stream writes no `id:` at
+all. All three are `Last-Event-ID` to a client, and mean three different things.
+
+**`query_error`.** `internal/api/metricsstream.go:79` emits it. Nothing
+documents it.
+
+This is the last item on the 2026-09-09 web-standards ledger's deferred list
+that closes a hole rather than adding a surface.
+
+## Scope
+
+One document, one route, two discovery entries, six tests.
+
+**In scope:** an AsyncAPI 3.0.0 document describing all 20 channels, served at
+`GET /api/asyncapi`, discoverable from the `Link` header and the API catalog,
+and held true by tests that drive the real router.
+
+**Not in scope:** changing any stream's behaviour. This describes what exists.
+Where the description is awkward to write, that is evidence about the design,
+recorded as a follow-up rather than fixed here.
+
+## The document
+
+`api/asyncapi.yaml`, hand-written, `//go:embed`-ed beside `api/openapi.yaml`.
+
+Hand-written rather than assembled in Go — the opposite of
+`internal/api/apicatalog.go`, which is built from runtime facts because its
+content depends on what the router mounted. An AsyncAPI document is mostly
+prose, examples and JSON Schema; expressing three dialects' worth of that as Go
+struct literals fights both the authoring and every off-the-shelf AsyncAPI tool.
+The drift that hand-writing invites is answered by tests, which is the answer
+this repo already reaches for — `TestCSVColumnsMatchTheWidget` holds a Go column
+map to a TypeScript one, and `TestTypeGrantsAgreesWithCan` holds two ACL
+implementations of one rule together.
+
+### Channels
+
+Twenty channels, one per address, each `$ref`-ing messages from a shared pool:
+
+| Channels | Messages | `id:` | On reconnect with a cursor |
+|---|---|---|---|
+| 8 list streams — `/nodes`, `/services`, `/tasks`, `/stacks`, `/configs`, `/secrets`, `/networks`, `/volumes` | `<type>`, `batch`, `sync` | monotonic `HistoryID` | replay from the ring; `sync` if the cursor has aged out |
+| 8 detail streams — `/nodes/{id}` … `/volumes/{name}` | `<type>`, `batch`, `sync` | monotonic `HistoryID` | always `sync` — replay is not offered |
+| `/events` (legacy, `?types=`) | all eight type messages, `batch`, `sync` | monotonic `HistoryID` | replay from the ring |
+| `/services/{id}/logs`, `/tasks/{id}/logs` | `logLine` (unnamed frames) | RFC3339 timestamp, forward-only | `Last-Event-ID` narrows a `logResumeTail` backlog |
+| `/metrics` | `initial`, `point`, `query_error` | none | nothing to resume |
+
+One channel per address rather than parameterising `/{type}` and `/{type}/{id}`
+over an eight-value enum. The collapsed form is a smaller file and a single edit
+to add a ninth type, but it costs the two things the document exists for: the
+payload's `resource` becomes a union across eight schemas instead of a named one
+per channel, and the drift test has to expand the enum itself — re-deriving what
+the document says rather than reading it. The list/detail split is not
+cosmetic either, as the reconnect column above shows.
+
+### Messages and the three dialects
+
+Fourteen messages in `components.messages`: eight per-type resource events
+(`node`, `service`, `task`, `stack`, `config`, `secret`, `network`, `volume`),
+plus `batch`, `sync`, `logLine`, `initial`, `point` and `queryError`.
+
+Two payload facts the schemas must carry that no prose currently does:
+
+- **A `batch` frame's payload is an array** of envelopes, not one envelope.
+  `WriteBatch` writes `event: <type>` for a single event and `event: batch` with
+  a JSON array for more (`broadcaster.go:469-478`).
+- **A replayed event omits `resource`.** The `sync` message and the replay path
+  both produce envelopes without it.
+
+The `/metrics` messages are the first schemas anywhere for that stream:
+`initial` carries a full range query result, `point` a single value,
+`query_error` the shape `marshalErrorEvent` produces.
+
+### Schemas, and why they are copies
+
+`components.schemas.SSEEvent` and `components.schemas.LogLine` are copies of the
+OpenAPI originals (`api/openapi.yaml:7086` and the `LogLine` entry), held to
+them by `TestAsyncAPISchemasMatchOpenAPI`, which parses both files and fails on
+any difference.
+
+Copies rather than `$ref`s because the correct `$ref` differs between the file
+and the served document. `$ref: "/api#/components/schemas/SSEEvent"` genuinely
+resolves once served — `/api` returns the OpenAPI spec as JSON — but is
+meaningless in the repo, where `./openapi.yaml#/...` is correct instead. One
+reference with two correct spellings depending on where it is read is the same
+class of trap as the `.json` suffix that `/.well-known/jwks.json` fell into
+(PR #233): a path that is right in the place you wrote it and wrong in the place
+it is used.
+
+The duplication is two schemas. The per-type `resource` payloads are not
+duplicated because they do not exist on either side — Docker's `swarm.Node`,
+`swarm.Service` and friends were never schematised in OpenAPI, and `resource`
+stays `type: object` in both documents.
+
+## Serving and discovery
+
+`GET /api/asyncapi`, via `HandleAsyncAPI` in `internal/api/asyncapi.go`.
+
+**Single representation, served unconditionally**, the way `HandleContext` does
+for `/api/context.jsonld` (`internal/api/context.go:39`) — no content
+negotiation branch, no SPA fallback, no 406 table entry. That is E7's
+conclusion about documents that have exactly one form, and this is one.
+
+- `Content-Type: application/vnd.aai.asyncapi+json;version=3.0.0`
+- `Cache-Control: public, max-age=3600`, matching `HandleAPIDoc`
+- YAML→JSON once at startup via the existing `convertYAMLToJSON`
+- Body written with `writeRawWithETag`, not `newStaticBody` — see below
+
+**No renderer.** `/api` gets the Scalar playground; `/api/asyncapi` gets the
+document. A browser-side AsyncAPI viewer means `@asyncapi/react-component` as a
+production frontend dependency, with a `postbuild` copy-out, an SBOM entry, a
+`THIRD_PARTY_LICENSES` entry, a CSP allowance and a Dependabot group — the exact
+freight `CLAUDE.md` records Scalar's vendored bundle costing when nothing
+watched it. Consumers have AsyncAPI Studio.
+
+**`servers` is per-request**, which is why the body is not a `newStaticBody`.
+AsyncAPI 3.0 requires `host` on a server object, so the document names the
+deployment's own origin — and that must come from the validated origin
+(`originOf`, `absPath`), never from raw `X-Forwarded-*`. That is ledger item
+B5's rule, and B5 exists because C1 and C2 each added a consumer for `absURL`
+before anyone checked what it was built from. `writeRawWithETag` is the pattern
+`HandleAPICatalog` already uses for exactly this.
+
+**`/api/asyncapi.json` works for free** — `.json` is a stripped extension
+(`internal/api/negotiate.go:121`), so the suffixed path routes to the same
+handler. It gets an explicit test, because this mechanism has bitten once
+already from the other direction.
+
+**Discovery** in two places:
+
+```
+Link: </api>; rel="service-desc"
+Link: </api/asyncapi>; rel="service-desc";
+      type="application/vnd.aai.asyncapi+json;version=3.0.0"
+Link: </api/context.jsonld>; rel="describedby"
+Link: </.well-known/api-catalog>; rel="api-catalog"
+```
+
+RFC 8631 does not limit `service-desc` to one link, and the `type` parameter is
+what tells a client which description it is being offered. The catalog gains a
+matching `service-desc` target on the REST API's context, which is what C1 built
+the catalog for.
+
+## Testing
+
+Six claims. Each is confirmed load-bearing by making the mutation it exists to
+catch and watching it fail first — #229's note records that habit as the only
+reason the catalog walk was worth writing.
+
+**1. Every channel address is a stream.** `TestAsyncAPIChannelsAnswerAsStreams`
+walks the channels, substitutes path parameters from the fixture cache, requests
+each with `Accept: text/event-stream`, and asserts `200` with
+`Content-Type: text/event-stream`.
+
+This one is immune to the failure that nearly defeated C1's catalog walk, where
+"every published URI answers non-404" passed under a renamed endpoint because
+the SPA fallback answers `200` for anything unrouted. Here a bogus address still
+reaches the SPA — and the SPA answers `text/html`, so the assertion fails on the
+content type. The trap is closed by construction rather than by remembering it.
+
+**2. Every stream is a channel.** `TestEveryStreamRouteIsAChannel` walks
+`mux.patterns`, probes each `GET` with `Accept: text/event-stream`, and requires
+anything that streams to appear as a channel address. This is the direction that
+catches a stream route added later, and it is the reason the document can be
+trusted six months from now.
+
+**3. The document is valid AsyncAPI 3.0.** The official AsyncAPI 3.0.0 JSON
+Schema is vendored to `internal/api/testdata/asyncapi-3.0.0.json` and embedded
+*from a `_test.go` file*, so it is never linked into the binary. Validation runs
+through `santhosh-tekuri/jsonschema/v6`, already in the module graph. No JS
+toolchain and no `@asyncapi/cli` step in `make check`.
+
+**4. The copied schemas match OpenAPI.** `TestAsyncAPISchemasMatchOpenAPI`
+parses both YAML files and deep-equals `SSEEvent` and `LogLine`.
+
+**5. The declared event names are the names emitted** — one exemplar per code
+path, not per channel:
+
+| Driven | Asserts |
+|---|---|
+| `/services` (list) | one mutation → `event: service`; two inside the SSE batch interval → `event: batch` with an array payload; reconnect with an aged-out `Last-Event-ID` → `event: sync`; a replayed frame omits `resource` |
+| `/services/{id}` (detail) | reconnect with any cursor → `event: sync`, never a replay |
+| both log tails | unnamed frames, `id:` is RFC3339 and never moves backwards |
+| `/metrics` | `initial` then `point`; `query_error` against a failing Prometheus stub |
+
+The sixteen resource channels run through two functions — `streamList` and
+`streamResource` — so driving all sixteen exercises the same code eight times
+each, for sixteen chances to flake. What actually varies per channel is a `type`
+string, and that is pinned better structurally: **the set of per-type messages
+declared in the document must equal the set of `cache.EventType` constants.** A
+ninth resource type fails that comparison without anyone opening a ninth stream.
+
+**6. Captured frames validate against their declared schemas.** Every payload
+claim 5 captures is validated against the channel's message schema — the
+AsyncAPI counterpart of what `openapi_exhaustive_test.go` does for responses.
+
+## Sequencing
+
+1. The document, with channels and messages but no serving — claims 3 and 4
+   pass against the file alone.
+2. The route, the `Link` header and the catalog target — claim 1, plus the
+   `.json` suffix test.
+3. Claim 2, which is where a missing channel surfaces.
+4. Claims 5 and 6, the behavioural pair.
+
+Steps 1–2 are independently useful: a valid, served, discoverable document that
+is merely *not yet proven* to match behaviour.
+
+## Files
+
+| File | Change |
+|---|---|
+| `api/asyncapi.yaml` | new — the document |
+| `internal/api/asyncapi.go` | new — `HandleAsyncAPI` |
+| `internal/api/asyncapi_test.go` | new — the six claims |
+| `internal/api/testdata/asyncapi-3.0.0.json` | new — vendored schema, test-only |
+| `internal/api/router.go` | one route |
+| `internal/api/middleware.go` | one `Link` in `discoveryLinks` |
+| `internal/api/apicatalog.go` | one `service-desc` target |
+| `main.go` | one `//go:embed`, passed through `Config` |
+| `docs/api.md` | the new endpoint and what it describes |
+| `CHANGELOG.md` | user-facing entry |
+
+`santhosh-tekuri/jsonschema/v6` moves from indirect to direct, so `go.mod`
+changes and the pre-commit hook regenerates the SBOM and
+`THIRD_PARTY_LICENSES`.
+
+## Rejected alternatives
+
+| Alternative | Why not |
+|---|---|
+| Assemble the document in Go, like `apicatalog.go` | Cannot drift, but AsyncAPI is prose, examples and JSON Schema; as Go literals that fights both authoring and every AsyncAPI tool. Drift is a test's job here |
+| Hybrid — hand-written messages, channels injected from the router | The file in the repo would stop being the document that is served, so the file alone is no longer reviewable |
+| Parameterised channels over a type enum | Collapses `resource` into an eight-way union and makes the drift test expand the enum itself; also erases the list/detail resumability difference |
+| `$ref` into the served OpenAPI document | Resolves when served, meaningless in the repo. One reference, two correct spellings — the `.json` trap again |
+| Thin messages pointing at OpenAPI in prose | A consumer cannot validate a frame against it, which is most of the point |
+| An embedded AsyncAPI renderer | A second vendored viewer with an SBOM, licence, CSP and Dependabot tail |
+| Render the channels as a dashboard page | No new dependency, but frontend work in service of a document aimed at machines |
+| Driving all 20 channels behaviourally | Sixteen of them are two functions; the enum comparison pins what varies, for a fifth of the streams |
+| Extending OpenAPI instead | OpenAPI describes a response body. Frame names, cursor semantics and per-channel resumability have no slot in it — which is why four blocks of `text/event-stream` say so little |
+| A `Link` header on each SSE response naming its channel | A fourth mapping to keep in step, for discoverability a client already has two routes to |
+
+## Follow-ups, not in scope
+
+- **The 16 resource endpoints should also declare `text/event-stream` in
+  OpenAPI**, now that there is somewhere to point. A one-line
+  `$ref: SSEEvent` content block per endpoint, plus a link to the channel.
+- **Three cursor dialects is a design observation, not just a documentation
+  problem.** Writing them down side by side makes the case for the log tail's
+  timestamp cursor (Docker interleaves; ids must not move backwards) and against
+  the metrics stream having no cursor at all. Worth a look once documented.
+- **Detail-stream replay ineligibility** is a real limitation a client now
+  learns about explicitly. Whether the ring should be queryable by type+id is a
+  separate question this document only makes visible.
+- **CloudEvents** (ledger, deferred) becomes tractable once channels and
+  messages are named: the envelope mapping would be per-message, and this
+  document is where it would be declared.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,9 +16,15 @@
       rel="apple-touch-icon"
       href="./apple-touch-icon.png"
     />
+    <!--
+      use-credentials: a manifest is fetched with credentials omitted by
+      default, and /manifest.webmanifest is not exempt from authentication, so
+      without this the browser never gets one to install under auth.mode=oidc.
+    -->
     <link
       rel="manifest"
       href="./manifest.webmanifest"
+      crossorigin="use-credentials"
     />
     <link
       rel="search"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,11 +16,6 @@
       rel="apple-touch-icon"
       href="./apple-touch-icon.png"
     />
-    <!--
-      use-credentials: a manifest is fetched with credentials omitted by
-      default, and /manifest.webmanifest is not exempt from authentication, so
-      without this the browser never gets one to install under auth.mode=oidc.
-    -->
     <link
       rel="manifest"
       href="./manifest.webmanifest"

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -732,8 +732,8 @@ export interface Recommendation {
   targetName: string;
   resource: string;
   message: string;
-  current: number;
-  configured: number;
+  current?: number | undefined;
+  configured?: number | undefined;
   suggested?: number | undefined;
   fixAction?: string | undefined;
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mark3labs/mcp-go v1.0.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.3
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.46.0
 	go.opentelemetry.io/otel/sdk v1.46.0
@@ -100,7 +101,6 @@ require (
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/safchain/ethtool v0.3.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shogo82148/go-shuffle v0.0.0-20170808115208-59829097ff3b // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/internal/api/apicatalog.go
+++ b/internal/api/apicatalog.go
@@ -86,10 +86,6 @@ func HandleAPICatalog(mounts catalogMounts) http.HandlerFunc {
 						Type:  "application/json",
 						Title: "OpenAPI description",
 					}, {
-						// The base type, without the version parameter:
-						// TestAPICatalogTargetsAnswerAsAdvertised compares a
-						// target's type against the response's, cut at the
-						// first ";".
 						Href:  link(asyncAPIPath),
 						Type:  asyncAPIMediaTypeBase,
 						Title: "AsyncAPI description of the event streams",

--- a/internal/api/apicatalog.go
+++ b/internal/api/apicatalog.go
@@ -85,6 +85,14 @@ func HandleAPICatalog(mounts catalogMounts) http.HandlerFunc {
 						Href:  link("/api"),
 						Type:  "application/json",
 						Title: "OpenAPI description",
+					}, {
+						// The base type, without the version parameter:
+						// TestAPICatalogTargetsAnswerAsAdvertised compares a
+						// target's type against the response's, cut at the
+						// first ";".
+						Href:  link(asyncAPIPath),
+						Type:  asyncAPIMediaTypeBase,
+						Title: "AsyncAPI description of the event streams",
 					}},
 					"service-doc": {{
 						Href:  link("/api"),

--- a/internal/api/apidoc.go
+++ b/internal/api/apidoc.go
@@ -18,10 +18,23 @@ const apiPlaygroundHTML = `<!DOCTYPE html>
 </body>
 </html>`
 
-// HandleAPIDoc serves the API documentation. HTML requests get the Scalar
-// playground; JSON requests (including default */* negotiation) get the spec
-// as JSON; explicit application/yaml requests get YAML.
-func HandleAPIDoc(specYAML []byte) http.HandlerFunc {
+// openAPIYAMLMediaType is the type OAI registered for an OpenAPI document in
+// YAML; the +json suffix names the JSON form.
+const (
+	openAPIYAMLPath = "/api/openapi.yaml"
+
+	openAPIYAMLMediaType = "application/vnd.oai.openapi"
+)
+
+// HandleAPIDoc serves the API documentation, and HandleOpenAPIYAML the same
+// document at the .yaml address the documentation site publishes it under.
+//
+// HTML requests get the Scalar playground, JSON requests (including default
+// */* negotiation) get the spec as JSON, and a request naming a YAML type gets
+// the source file — bytes rather than a re-encoding, so the comments and the
+// authored key order survive. Both handlers come from one call because they
+// share the bodies, each hashed once and compressed at most once per coding.
+func HandleAPIDoc(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 	// Convert YAML to JSON once at startup.
 	var parsed any
 	if err := yaml.Unmarshal(specYAML, &parsed); err != nil {
@@ -36,8 +49,14 @@ func HandleAPIDoc(specYAML []byte) http.HandlerFunc {
 	// once and compressed at most once per coding.
 	playground := newStaticBody([]byte(apiPlaygroundHTML))
 	spec := newStaticBody(specJSON)
+	source := newStaticBody(specYAML)
 
-	return func(w http.ResponseWriter, r *http.Request) {
+	serveYAML := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", openAPIYAMLMediaType)
+		source.serve(w, r)
+	}
+
+	negotiated = func(w http.ResponseWriter, r *http.Request) {
 		ct := ContentTypeFromContext(r.Context())
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		switch ct {
@@ -50,10 +69,22 @@ func HandleAPIDoc(specYAML []byte) http.HandlerFunc {
 			// The default for content negotiation, including */*.
 			w.Header().Set("Content-Type", "application/json")
 			spec.serve(w, r)
+		case ContentTypeYAML:
+			serveYAML(w, r)
 		default:
-			notAcceptable(w, r, "application/json, text/html")
+			notAcceptable(
+				w, r,
+				"application/json, text/html, "+openAPIYAMLMediaType,
+			)
 		}
 	}
+
+	yamlOnly = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		serveYAML(w, r)
+	}
+
+	return negotiated, yamlOnly
 }
 
 // HandleScalarJS serves the embedded Scalar API reference JavaScript bundle.

--- a/internal/api/apidoc.go
+++ b/internal/api/apidoc.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"gopkg.in/yaml.v3"
@@ -63,6 +65,22 @@ func HandleScalarJS(js []byte) http.HandlerFunc {
 		w.Header().Set("Cache-Control", "public, max-age=86400")
 		bundle.serve(w, r)
 	}
+}
+
+// yamlDocument parses a spec into the JSON-shaped object both descriptions
+// are served from.
+func yamlDocument(raw []byte) (map[string]any, error) {
+	var parsed any
+	if err := yaml.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("not valid YAML: %w", err)
+	}
+
+	doc, ok := convertYAMLToJSON(parsed).(map[string]any)
+	if !ok {
+		return nil, errors.New("does not parse to an object")
+	}
+
+	return doc, nil
 }
 
 // convertYAMLToJSON recursively converts yaml.v3 map[string]any types to

--- a/internal/api/apidoc.go
+++ b/internal/api/apidoc.go
@@ -26,14 +26,10 @@ const (
 	openAPIYAMLMediaType = "application/vnd.oai.openapi"
 )
 
-// HandleAPIDoc serves the API documentation, and HandleOpenAPIYAML the same
-// document at the .yaml address the documentation site publishes it under.
-//
-// HTML requests get the Scalar playground, JSON requests (including default
-// */* negotiation) get the spec as JSON, and a request naming a YAML type gets
-// the source file — bytes rather than a re-encoding, so the comments and the
-// authored key order survive. Both handlers come from one call because they
-// share the bodies, each hashed once and compressed at most once per coding.
+// HandleAPIDoc returns the negotiated handler and the one behind the .yaml
+// address. HTML gets the Scalar playground, */* and JSON get the spec as JSON,
+// and a YAML type gets the source file verbatim. Both come from one call so
+// they share the bodies, each hashed and compressed once.
 func HandleAPIDoc(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 	// Convert YAML to JSON once at startup.
 	var parsed any

--- a/internal/api/asyncapi.go
+++ b/internal/api/asyncapi.go
@@ -24,11 +24,11 @@ const (
 	asyncAPIYAMLMediaType = "application/vnd.aai.asyncapi+yaml;version=3.0.0"
 )
 
-// asyncAPIRendering is the document as one origin sees it.
+// asyncAPIRendering is one representation of the document as one origin sees
+// it.
 type asyncAPIRendering struct {
 	key  string
-	json *staticBody
-	yaml *staticBody
+	body *staticBody
 }
 
 // HandleAsyncAPI returns the negotiated handler and the one behind the .yaml
@@ -36,9 +36,11 @@ type asyncAPIRendering struct {
 // there is no SPA route here.
 //
 // AsyncAPI 3.0 requires host on a server object, so the body varies by scheme,
-// host and base path and is retained under that key. One slot, not a map:
-// origin falls back to r.Host, so the key is caller-controlled and a map would
-// grow without bound.
+// host and base path and is retained under that key. One slot per
+// representation, not a map: origin falls back to r.Host, so the key is
+// caller-controlled and a map would grow without bound. A miss is what every
+// request with an unseen Host costs, so it renders only the representation
+// being served rather than both.
 func HandleAsyncAPI(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 	doc, err := yamlDocument(specYAML)
 	if err != nil {
@@ -50,41 +52,47 @@ func HandleAsyncAPI(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 		panic("asyncapi spec " + err.Error())
 	}
 
-	var current atomic.Pointer[asyncAPIRendering]
+	var currentJSON, currentYAML atomic.Pointer[asyncAPIRendering]
 
-	render := func(r *http.Request) (*asyncAPIRendering, error) {
+	render := func(r *http.Request, asYAML bool) (*staticBody, error) {
+		slot := &currentJSON
+		if asYAML {
+			slot = &currentYAML
+		}
+
 		scheme, host := origin(r)
 		base := BasePathFromContext(r.Context())
 		key := scheme + "\x00" + host + "\x00" + base
 
-		if rendering := current.Load(); rendering != nil && rendering.key == key {
-			return rendering, nil
+		if rendering := slot.Load(); rendering != nil && rendering.key == key {
+			return rendering.body, nil
 		}
 
 		fields := asyncAPIServerFields(scheme, host, base)
 
-		asJSON, err := renderAsyncAPIJSON(doc, fields)
+		var (
+			raw []byte
+			err error
+		)
+
+		if asYAML {
+			raw, err = source.render(fields)
+		} else {
+			raw, err = renderAsyncAPIJSON(doc, fields)
+		}
+
 		if err != nil {
 			return nil, err
 		}
 
-		asYAML, err := source.render(fields)
-		if err != nil {
-			return nil, err
-		}
+		body := newStaticBody(raw)
+		slot.Store(&asyncAPIRendering{key: key, body: body})
 
-		rendering := &asyncAPIRendering{
-			key:  key,
-			json: newStaticBody(asJSON),
-			yaml: newStaticBody(asYAML),
-		}
-		current.Store(rendering)
-
-		return rendering, nil
+		return body, nil
 	}
 
 	serve := func(w http.ResponseWriter, r *http.Request, asYAML bool) {
-		rendering, err := render(r)
+		body, err := render(r, asYAML)
 		if err != nil {
 			writeErrorCode(w, r, "API009", "failed to serialize response")
 
@@ -95,13 +103,11 @@ func HandleAsyncAPI(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 
 		if asYAML {
 			w.Header().Set("Content-Type", asyncAPIYAMLMediaType)
-			rendering.yaml.serve(w, r)
-
-			return
+		} else {
+			w.Header().Set("Content-Type", asyncAPIMediaType)
 		}
 
-		w.Header().Set("Content-Type", asyncAPIMediaType)
-		rendering.json.serve(w, r)
+		body.serve(w, r)
 	}
 
 	negotiated = func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/asyncapi.go
+++ b/internal/api/asyncapi.go
@@ -24,29 +24,21 @@ const (
 	asyncAPIYAMLMediaType = "application/vnd.aai.asyncapi+yaml;version=3.0.0"
 )
 
-// asyncAPIRendering is the document as one origin sees it, in both
-// representations, under the key that produced them.
+// asyncAPIRendering is the document as one origin sees it.
 type asyncAPIRendering struct {
 	key  string
 	json *staticBody
 	yaml *staticBody
 }
 
-// HandleAsyncAPI serves the AsyncAPI description of the SSE streams, and
-// HandleAsyncAPIYAML the same document at its .yaml address.
+// HandleAsyncAPI returns the negotiated handler and the one behind the .yaml
+// address. Anything that is not a YAML request gets JSON, text/html included:
+// there is no SPA route here.
 //
-// AsyncAPI 3.0 requires host on a server object, so the document names the
-// deployment's own origin — from the validated origin, never from a raw
-// forwarding header. The body is therefore a pure function of scheme, host and
-// base path, and one rendering is retained under that key so this document is
-// hashed and compressed once like every other served document. A single slot
-// rather than a map: origin falls back to r.Host when server.public_url is
-// unset, so a hostile client can vary the key without bound — a map would
-// grow, a slot degrades to rebuilding per request and no worse.
-//
-// Anything that is not a YAML request gets JSON, text/html included: there is
-// no SPA route here, so a browser pointed at the URL should see the document
-// rather than a refusal.
+// AsyncAPI 3.0 requires host on a server object, so the body varies by scheme,
+// host and base path and is retained under that key. One slot, not a map:
+// origin falls back to r.Host, so the key is caller-controlled and a map would
+// grow without bound.
 func HandleAsyncAPI(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 	doc, err := yamlDocument(specYAML)
 	if err != nil {
@@ -123,9 +115,8 @@ func HandleAsyncAPI(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 	return negotiated, yamlOnly
 }
 
-// asyncAPIServerFields is the server object both representations inject, in
-// the order they write it. Named once so the two cannot disagree about what
-// the deployment is called.
+// asyncAPIServerFields is the server object both representations inject, named
+// once so they cannot disagree.
 func asyncAPIServerFields(scheme, host, base string) [][2]string {
 	fields := [][2]string{
 		{"host", host},
@@ -147,8 +138,7 @@ func renderAsyncAPIJSON(doc map[string]any, fields [][2]string) ([]byte, error) 
 		server[field[0]] = field[1]
 	}
 
-	// Copied shallowly so a concurrent render cannot see this server block;
-	// nothing below servers is written.
+	// Shallow copy: nothing below servers is written.
 	described := make(map[string]any, len(doc))
 	maps.Copy(described, doc)
 
@@ -157,16 +147,13 @@ func renderAsyncAPIJSON(doc map[string]any, fields [][2]string) ([]byte, error) 
 	return json.Marshal(described)
 }
 
-// asyncAPISource is the authored document as a node tree. The YAML
-// representation is spliced rather than re-encoded from the map the JSON is
-// built from, because marshalling a map loses every comment and the authored
-// key order — and the point of serving YAML is that a person reads it.
+// asyncAPISource is the authored document as a node tree. The YAML is spliced
+// rather than re-encoded from a map, which would lose the comments and key
+// order a reader came for.
 type asyncAPISource struct {
 	root *yaml.Node
 
-	// serversAt indexes the servers *value* in root.Content, or -1 when the
-	// document declares none. The key node is left in place, so a comment
-	// attached to it survives the splice.
+	// serversAt indexes the servers *value*, or -1 if there is none.
 	serversAt int
 }
 
@@ -193,8 +180,8 @@ func newAsyncAPISource(specYAML []byte) (*asyncAPISource, error) {
 	return source, nil
 }
 
-// render writes the document with the server object one origin gets. The root
-// mapping is copied so concurrent renders never share the slice they write.
+// render writes the document for one origin. The root mapping is copied so
+// concurrent renders never share the slice they write.
 func (s *asyncAPISource) render(fields [][2]string) ([]byte, error) {
 	servers := &yaml.Node{
 		Kind:    yaml.MappingNode,
@@ -210,8 +197,7 @@ func (s *asyncAPISource) render(fields [][2]string) ([]byte, error) {
 		root.Content = append(root.Content, yamlScalar("servers"), servers)
 	}
 
-	// yaml.Marshal would indent by four. The authored file indents by two, and
-	// this is meant to read as that file.
+	// yaml.Marshal indents by four; the authored file uses two.
 	var out bytes.Buffer
 
 	encoder := yaml.NewEncoder(&out)

--- a/internal/api/asyncapi.go
+++ b/internal/api/asyncapi.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"maps"
+	"net/http"
+
+	json "github.com/goccy/go-json"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	asyncAPIPath = "/api/asyncapi"
+
+	// asyncAPIMediaTypeBase is the type without its version parameter, for
+	// the places that compare types rather than state them.
+	asyncAPIMediaTypeBase = "application/vnd.aai.asyncapi+json"
+	asyncAPIMediaType     = asyncAPIMediaTypeBase + ";version=3.0.0"
+)
+
+// HandleAsyncAPI serves the AsyncAPI description of the SSE streams.
+//
+// One representation, served unconditionally, as HandleContext does for the
+// JSON-LD context: this document has exactly one form, so there is nothing to
+// negotiate and no SPA fallback to reach.
+//
+// The body is rebuilt per request because AsyncAPI 3.0 requires host on a
+// server object, so the document names the deployment's own origin. That
+// value comes from the validated origin, never from a raw forwarding header.
+func HandleAsyncAPI(specYAML []byte) http.HandlerFunc {
+	var parsed any
+	if err := yaml.Unmarshal(specYAML, &parsed); err != nil {
+		panic("asyncapi spec is not valid YAML: " + err.Error())
+	}
+
+	doc, ok := convertYAMLToJSON(parsed).(map[string]any)
+	if !ok {
+		panic("asyncapi spec does not parse to an object")
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		scheme, host := origin(r)
+
+		server := map[string]any{
+			"host":        host,
+			"protocol":    scheme,
+			"description": "This deployment.",
+		}
+
+		if base := BasePathFromContext(r.Context()); base != "" {
+			server["pathname"] = base
+		}
+
+		// Copied shallowly so concurrent requests cannot see each other's
+		// server block; nothing below servers is written.
+		described := make(map[string]any, len(doc))
+		maps.Copy(described, doc)
+
+		described["servers"] = map[string]any{"self": server}
+
+		body, err := json.Marshal(described)
+		if err != nil {
+			writeErrorCode(w, r, "API009", "failed to serialize response")
+
+			return
+		}
+
+		w.Header().Set("Content-Type", asyncAPIMediaType)
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		writeRawWithETag(w, r, body)
+	}
+}

--- a/internal/api/asyncapi.go
+++ b/internal/api/asyncapi.go
@@ -3,9 +3,9 @@ package api
 import (
 	"maps"
 	"net/http"
+	"sync/atomic"
 
 	json "github.com/goccy/go-json"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -17,55 +17,78 @@ const (
 	asyncAPIMediaType     = asyncAPIMediaTypeBase + ";version=3.0.0"
 )
 
+// asyncAPIRendering is the document as one origin sees it, under the key that
+// produced it.
+type asyncAPIRendering struct {
+	key  string
+	body *staticBody
+}
+
 // HandleAsyncAPI serves the AsyncAPI description of the SSE streams.
 //
 // One representation, served unconditionally, as HandleContext does for the
 // JSON-LD context: this document has exactly one form, so there is nothing to
 // negotiate and no SPA fallback to reach.
 //
-// The body is rebuilt per request because AsyncAPI 3.0 requires host on a
-// server object, so the document names the deployment's own origin. That
-// value comes from the validated origin, never from a raw forwarding header.
+// AsyncAPI 3.0 requires host on a server object, so the document names the
+// deployment's own origin — from the validated origin, never from a raw
+// forwarding header. The body is therefore a pure function of scheme, host and
+// base path, and one rendering is retained under that key so this document is
+// hashed and compressed once like every other served document. A single slot
+// rather than a map: origin falls back to r.Host when server.public_url is
+// unset, so a hostile client can vary the key without bound — a map would
+// grow, a slot degrades to rebuilding per request and no worse.
 func HandleAsyncAPI(specYAML []byte) http.HandlerFunc {
-	var parsed any
-	if err := yaml.Unmarshal(specYAML, &parsed); err != nil {
-		panic("asyncapi spec is not valid YAML: " + err.Error())
+	doc, err := yamlDocument(specYAML)
+	if err != nil {
+		panic("asyncapi spec " + err.Error())
 	}
 
-	doc, ok := convertYAMLToJSON(parsed).(map[string]any)
-	if !ok {
-		panic("asyncapi spec does not parse to an object")
-	}
+	var current atomic.Pointer[asyncAPIRendering]
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		scheme, host := origin(r)
+		base := BasePathFromContext(r.Context())
+		key := scheme + "\x00" + host + "\x00" + base
 
-		server := map[string]any{
-			"host":        host,
-			"protocol":    scheme,
-			"description": "This deployment.",
-		}
+		rendering := current.Load()
 
-		if base := BasePathFromContext(r.Context()); base != "" {
-			server["pathname"] = base
-		}
+		if rendering == nil || rendering.key != key {
+			body, err := renderAsyncAPI(doc, scheme, host, base)
+			if err != nil {
+				writeErrorCode(w, r, "API009", "failed to serialize response")
 
-		// Copied shallowly so concurrent requests cannot see each other's
-		// server block; nothing below servers is written.
-		described := make(map[string]any, len(doc))
-		maps.Copy(described, doc)
+				return
+			}
 
-		described["servers"] = map[string]any{"self": server}
-
-		body, err := json.Marshal(described)
-		if err != nil {
-			writeErrorCode(w, r, "API009", "failed to serialize response")
-
-			return
+			rendering = &asyncAPIRendering{key: key, body: newStaticBody(body)}
+			current.Store(rendering)
 		}
 
 		w.Header().Set("Content-Type", asyncAPIMediaType)
 		w.Header().Set("Cache-Control", "public, max-age=3600")
-		writeRawWithETag(w, r, body)
+		rendering.body.serve(w, r)
 	}
+}
+
+// renderAsyncAPI marshals doc with the server block one origin gets.
+func renderAsyncAPI(doc map[string]any, scheme, host, base string) ([]byte, error) {
+	server := map[string]any{
+		"host":        host,
+		"protocol":    scheme,
+		"description": "This deployment.",
+	}
+
+	if base != "" {
+		server["pathname"] = base
+	}
+
+	// Copied shallowly so a concurrent render cannot see this server block;
+	// nothing below servers is written.
+	described := make(map[string]any, len(doc))
+	maps.Copy(described, doc)
+
+	described["servers"] = map[string]any{"self": server}
+
+	return json.Marshal(described)
 }

--- a/internal/api/asyncapi.go
+++ b/internal/api/asyncapi.go
@@ -1,34 +1,39 @@
 package api
 
 import (
+	"bytes"
+	"errors"
 	"maps"
 	"net/http"
+	"slices"
 	"sync/atomic"
 
 	json "github.com/goccy/go-json"
+	"gopkg.in/yaml.v3"
 )
 
 const (
-	asyncAPIPath = "/api/asyncapi"
+	asyncAPIPath     = "/api/asyncapi"
+	asyncAPIYAMLPath = asyncAPIPath + ".yaml"
 
 	// asyncAPIMediaTypeBase is the type without its version parameter, for
 	// the places that compare types rather than state them.
 	asyncAPIMediaTypeBase = "application/vnd.aai.asyncapi+json"
 	asyncAPIMediaType     = asyncAPIMediaTypeBase + ";version=3.0.0"
+
+	asyncAPIYAMLMediaType = "application/vnd.aai.asyncapi+yaml;version=3.0.0"
 )
 
-// asyncAPIRendering is the document as one origin sees it, under the key that
-// produced it.
+// asyncAPIRendering is the document as one origin sees it, in both
+// representations, under the key that produced them.
 type asyncAPIRendering struct {
 	key  string
-	body *staticBody
+	json *staticBody
+	yaml *staticBody
 }
 
-// HandleAsyncAPI serves the AsyncAPI description of the SSE streams.
-//
-// One representation, served unconditionally, as HandleContext does for the
-// JSON-LD context: this document has exactly one form, so there is nothing to
-// negotiate and no SPA fallback to reach.
+// HandleAsyncAPI serves the AsyncAPI description of the SSE streams, and
+// HandleAsyncAPIYAML the same document at its .yaml address.
 //
 // AsyncAPI 3.0 requires host on a server object, so the document names the
 // deployment's own origin — from the validated origin, never from a raw
@@ -38,49 +43,108 @@ type asyncAPIRendering struct {
 // rather than a map: origin falls back to r.Host when server.public_url is
 // unset, so a hostile client can vary the key without bound — a map would
 // grow, a slot degrades to rebuilding per request and no worse.
-func HandleAsyncAPI(specYAML []byte) http.HandlerFunc {
+//
+// Anything that is not a YAML request gets JSON, text/html included: there is
+// no SPA route here, so a browser pointed at the URL should see the document
+// rather than a refusal.
+func HandleAsyncAPI(specYAML []byte) (negotiated, yamlOnly http.HandlerFunc) {
 	doc, err := yamlDocument(specYAML)
+	if err != nil {
+		panic("asyncapi spec " + err.Error())
+	}
+
+	source, err := newAsyncAPISource(specYAML)
 	if err != nil {
 		panic("asyncapi spec " + err.Error())
 	}
 
 	var current atomic.Pointer[asyncAPIRendering]
 
-	return func(w http.ResponseWriter, r *http.Request) {
+	render := func(r *http.Request) (*asyncAPIRendering, error) {
 		scheme, host := origin(r)
 		base := BasePathFromContext(r.Context())
 		key := scheme + "\x00" + host + "\x00" + base
 
-		rendering := current.Load()
+		if rendering := current.Load(); rendering != nil && rendering.key == key {
+			return rendering, nil
+		}
 
-		if rendering == nil || rendering.key != key {
-			body, err := renderAsyncAPI(doc, scheme, host, base)
-			if err != nil {
-				writeErrorCode(w, r, "API009", "failed to serialize response")
+		fields := asyncAPIServerFields(scheme, host, base)
 
-				return
-			}
+		asJSON, err := renderAsyncAPIJSON(doc, fields)
+		if err != nil {
+			return nil, err
+		}
 
-			rendering = &asyncAPIRendering{key: key, body: newStaticBody(body)}
-			current.Store(rendering)
+		asYAML, err := source.render(fields)
+		if err != nil {
+			return nil, err
+		}
+
+		rendering := &asyncAPIRendering{
+			key:  key,
+			json: newStaticBody(asJSON),
+			yaml: newStaticBody(asYAML),
+		}
+		current.Store(rendering)
+
+		return rendering, nil
+	}
+
+	serve := func(w http.ResponseWriter, r *http.Request, asYAML bool) {
+		rendering, err := render(r)
+		if err != nil {
+			writeErrorCode(w, r, "API009", "failed to serialize response")
+
+			return
+		}
+
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+
+		if asYAML {
+			w.Header().Set("Content-Type", asyncAPIYAMLMediaType)
+			rendering.yaml.serve(w, r)
+
+			return
 		}
 
 		w.Header().Set("Content-Type", asyncAPIMediaType)
-		w.Header().Set("Cache-Control", "public, max-age=3600")
-		rendering.body.serve(w, r)
+		rendering.json.serve(w, r)
 	}
+
+	negotiated = func(w http.ResponseWriter, r *http.Request) {
+		serve(w, r, ContentTypeFromContext(r.Context()) == ContentTypeYAML)
+	}
+
+	yamlOnly = func(w http.ResponseWriter, r *http.Request) {
+		serve(w, r, true)
+	}
+
+	return negotiated, yamlOnly
 }
 
-// renderAsyncAPI marshals doc with the server block one origin gets.
-func renderAsyncAPI(doc map[string]any, scheme, host, base string) ([]byte, error) {
-	server := map[string]any{
-		"host":        host,
-		"protocol":    scheme,
-		"description": "This deployment.",
+// asyncAPIServerFields is the server object both representations inject, in
+// the order they write it. Named once so the two cannot disagree about what
+// the deployment is called.
+func asyncAPIServerFields(scheme, host, base string) [][2]string {
+	fields := [][2]string{
+		{"host", host},
+		{"protocol", scheme},
+		{"description", "This deployment."},
 	}
 
 	if base != "" {
-		server["pathname"] = base
+		fields = append(fields, [2]string{"pathname", base})
+	}
+
+	return fields
+}
+
+// renderAsyncAPIJSON marshals doc with the server block one origin gets.
+func renderAsyncAPIJSON(doc map[string]any, fields [][2]string) ([]byte, error) {
+	server := make(map[string]any, len(fields))
+	for _, field := range fields {
+		server[field[0]] = field[1]
 	}
 
 	// Copied shallowly so a concurrent render cannot see this server block;
@@ -91,4 +155,95 @@ func renderAsyncAPI(doc map[string]any, scheme, host, base string) ([]byte, erro
 	described["servers"] = map[string]any{"self": server}
 
 	return json.Marshal(described)
+}
+
+// asyncAPISource is the authored document as a node tree. The YAML
+// representation is spliced rather than re-encoded from the map the JSON is
+// built from, because marshalling a map loses every comment and the authored
+// key order — and the point of serving YAML is that a person reads it.
+type asyncAPISource struct {
+	root *yaml.Node
+
+	// serversAt indexes the servers *value* in root.Content, or -1 when the
+	// document declares none. The key node is left in place, so a comment
+	// attached to it survives the splice.
+	serversAt int
+}
+
+func newAsyncAPISource(specYAML []byte) (*asyncAPISource, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(specYAML, &document); err != nil {
+		return nil, errors.New("is not valid YAML: " + err.Error())
+	}
+
+	if len(document.Content) == 0 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("does not parse to an object")
+	}
+
+	source := &asyncAPISource{root: document.Content[0], serversAt: -1}
+
+	for i := 0; i+1 < len(source.root.Content); i += 2 {
+		if source.root.Content[i].Value == "servers" {
+			source.serversAt = i + 1
+
+			break
+		}
+	}
+
+	return source, nil
+}
+
+// render writes the document with the server object one origin gets. The root
+// mapping is copied so concurrent renders never share the slice they write.
+func (s *asyncAPISource) render(fields [][2]string) ([]byte, error) {
+	servers := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{yamlScalar("self"), yamlMapping(fields)},
+	}
+
+	root := *s.root
+	root.Content = slices.Clone(s.root.Content)
+
+	if s.serversAt >= 0 {
+		root.Content[s.serversAt] = servers
+	} else {
+		root.Content = append(root.Content, yamlScalar("servers"), servers)
+	}
+
+	// yaml.Marshal would indent by four. The authored file indents by two, and
+	// this is meant to read as that file.
+	var out bytes.Buffer
+
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(&yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{&root},
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+
+	return out.Bytes(), nil
+}
+
+func yamlMapping(fields [][2]string) *yaml.Node {
+	node := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: make([]*yaml.Node, 0, len(fields)*2),
+	}
+
+	for _, field := range fields {
+		node.Content = append(node.Content, yamlScalar(field[0]), yamlScalar(field[1]))
+	}
+
+	return node
+}
+
+func yamlScalar(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
 }

--- a/internal/api/asyncapi_drift_test.go
+++ b/internal/api/asyncapi_drift_test.go
@@ -1,20 +1,16 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/radiergummi/cetacean/internal/api/sse"
-	"github.com/radiergummi/cetacean/internal/cache"
 )
 
 // TestEveryStreamRouteIsAChannel probes every registered GET route with
@@ -30,20 +26,7 @@ import (
 // channel declaration is covered by TestAsyncAPIChannelsAnswerAsStreams,
 // which probes addresses rather than routes and supplies the query.
 func TestEveryStreamRouteIsAChannel(t *testing.T) {
-	c := cache.New(nil)
-	populateSpecFixtures(c)
-
-	broadcaster := sse.NewBroadcaster(0, noopErrorWriter, c.History())
-	t.Cleanup(broadcaster.Close)
-
-	var frames bytes.Buffer
-	frames.Write(buildFrame(1, "2026-01-01T00:00:00.000000000Z hello\n"))
-
-	router := newTestRouterWithCache(
-		t, c,
-		withBroadcaster(broadcaster),
-		withDockerClient(&mockLogStreamer{data: frames.Bytes()}),
-	)
+	router, _, _ := streamTestRouter(t, 0)
 
 	declared := make(map[string]bool)
 	for _, address := range asyncAPIAddresses(t) {
@@ -70,6 +53,8 @@ func TestEveryStreamRouteIsAChannel(t *testing.T) {
 		}
 
 		t.Run(template, func(t *testing.T) {
+			t.Parallel()
+
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			req.Header.Set("Accept", "text/event-stream")
 
@@ -111,18 +96,18 @@ func TestEveryStreamRouteIsAChannel(t *testing.T) {
 func TestAsyncAPIPerTypeMessagesMatchEventTypes(t *testing.T) {
 	want := eventTypeConstants(t)
 
-	messages, ok := loadAsyncAPIDoc(t)["components"].(map[string]any)
+	components, ok := loadAsyncAPIDoc(t)["components"].(map[string]any)
 	if !ok {
 		t.Fatal("the document declares no components")
 	}
 
-	declared, ok := messages["messages"].(map[string]any)
+	declared, ok := components["messages"].(map[string]any)
 	if !ok {
 		t.Fatal("the document declares no components.messages")
 	}
 
-	// The four messages that are not a resource type: a batch of them, the
-	// resync signal, and the three metrics frames plus the log line.
+	// The six messages that are not a resource type: a batch of them, the
+	// resync signal, the log line, and the three metrics frames.
 	notATypeName := map[string]bool{
 		"batch": true, "sync": true, "logLine": true,
 		"initial": true, "point": true, "queryError": true,
@@ -138,8 +123,8 @@ func TestAsyncAPIPerTypeMessagesMatchEventTypes(t *testing.T) {
 		got = append(got, name)
 	}
 
-	sort.Strings(got)
-	sort.Strings(want)
+	slices.Sort(got)
+	slices.Sort(want)
 
 	if !slices.Equal(got, want) {
 		t.Errorf(
@@ -151,23 +136,35 @@ func TestAsyncAPIPerTypeMessagesMatchEventTypes(t *testing.T) {
 	}
 }
 
-// eventTypeConstants reads the cache.EventType constant block out of
-// internal/cache/cache.go. EventSync is excluded: it is the resync signal,
-// not a resource type, and the document declares it as its own message.
+// eventTypeConstants reads the cache.EventType constants out of every file in
+// internal/cache, so a constant that moves between files is still found.
+// EventSync is excluded: it is the resync signal, not a resource type, and the
+// document declares it as its own message.
 func eventTypeConstants(t *testing.T) []string {
 	t.Helper()
 
-	const source = "../cache/cache.go"
+	const source = "../cache"
 
-	raw, err := os.ReadFile(source)
-	if err != nil {
-		t.Fatalf("read %s: %v", source, err)
+	sources, err := filepath.Glob(filepath.Join(source, "*.go"))
+	if err != nil || len(sources) == 0 {
+		t.Fatalf("glob %s: %v", source, err)
+	}
+
+	var declarations []byte
+
+	for _, name := range sources {
+		raw, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+
+		declarations = append(declarations, raw...)
 	}
 
 	// EventNode    EventType = "node"
 	pattern := regexp.MustCompile(`(?m)^\s*Event(\w+)\s+EventType\s*=\s*"([^"]+)"`)
 
-	matches := pattern.FindAllStringSubmatch(string(raw), -1)
+	matches := pattern.FindAllStringSubmatch(string(declarations), -1)
 	if len(matches) == 0 {
 		t.Fatalf(
 			"found no EventType constants in %s — the declaration moved and "+

--- a/internal/api/asyncapi_drift_test.go
+++ b/internal/api/asyncapi_drift_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/radiergummi/cetacean/internal/api/sse"
+	"github.com/radiergummi/cetacean/internal/cache"
+)
+
+// TestEveryStreamRouteIsAChannel probes every registered GET route with
+// Accept: text/event-stream and requires anything that streams to appear in
+// the document.
+//
+// Task 2's walk runs the other way: it proves every channel is a stream. Only
+// this direction catches a stream route added after the document was written,
+// which is what makes the document worth trusting later.
+//
+// /metrics is walked but never asserted: it answers 400 for a missing query
+// parameter before setting a content type, so it cannot stream here. Its
+// channel declaration is covered by TestAsyncAPIChannelsAnswerAsStreams,
+// which probes addresses rather than routes and supplies the query.
+func TestEveryStreamRouteIsAChannel(t *testing.T) {
+	c := cache.New(nil)
+	populateSpecFixtures(c)
+
+	broadcaster := sse.NewBroadcaster(0, noopErrorWriter, c.History())
+	t.Cleanup(broadcaster.Close)
+
+	var frames bytes.Buffer
+	frames.Write(buildFrame(1, "2026-01-01T00:00:00.000000000Z hello\n"))
+
+	router := newTestRouterWithCache(
+		t, c,
+		withBroadcaster(broadcaster),
+		withDockerClient(&mockLogStreamer{data: frames.Bytes()}),
+	)
+
+	declared := make(map[string]bool)
+	for _, address := range asyncAPIAddresses(t) {
+		declared[address] = true
+	}
+
+	for _, pattern := range routerPatterns(t) {
+		method, template, ok := strings.Cut(pattern, " ")
+		if !ok || method != http.MethodGet {
+			continue
+		}
+
+		// The SPA fallback matches everything; probing it proves nothing.
+		if template == "/" {
+			continue
+		}
+
+		// A template pathFixtures cannot resolve is skipped, as it is in
+		// openapi_exhaustive_test.go. Adding the prefix there is what brings a
+		// new parameterised route into both walks at once.
+		path, ok := resolvePath(template)
+		if !ok {
+			continue
+		}
+
+		t.Run(template, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Accept", "text/event-stream")
+
+			ctx, cancel := context.WithTimeout(req.Context(), 150*time.Millisecond)
+			defer cancel()
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req.WithContext(ctx))
+
+			if rec.Header().Get("Content-Type") != "text/event-stream" {
+				return
+			}
+
+			if !declared[template] {
+				t.Errorf(
+					"%s streams but api/asyncapi.yaml declares no channel with "+
+						"address %q — every stream this process serves has to be "+
+						"described, or the document is a partial map again",
+					template, template,
+				)
+			}
+		})
+	}
+}
+
+// TestAsyncAPIPerTypeMessagesMatchEventTypes pins what actually varies across
+// the sixteen resource channels.
+//
+// Driving all sixteen behaviourally would run streamList and streamResource
+// eight times each for sixteen chances to flake, while the only thing that
+// differs between them is a type string. Comparing the declared per-type
+// messages against the cache.EventType constants pins that string for all of
+// them, and fails when a ninth resource type is added without anyone opening
+// a ninth stream.
+//
+// The constants are read out of the source rather than from a Go slice: a
+// slice would have to be kept in step by the same person who forgot the
+// document, which is the drift this is meant to catch.
+func TestAsyncAPIPerTypeMessagesMatchEventTypes(t *testing.T) {
+	want := eventTypeConstants(t)
+
+	messages, ok := loadAsyncAPIDoc(t)["components"].(map[string]any)
+	if !ok {
+		t.Fatal("the document declares no components")
+	}
+
+	declared, ok := messages["messages"].(map[string]any)
+	if !ok {
+		t.Fatal("the document declares no components.messages")
+	}
+
+	// The four messages that are not a resource type: a batch of them, the
+	// resync signal, and the three metrics frames plus the log line.
+	notATypeName := map[string]bool{
+		"batch": true, "sync": true, "logLine": true,
+		"initial": true, "point": true, "queryError": true,
+	}
+
+	var got []string
+
+	for name := range declared {
+		if notATypeName[name] {
+			continue
+		}
+
+		got = append(got, name)
+	}
+
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if !slices.Equal(got, want) {
+		t.Errorf(
+			"the document's per-type messages are %v but cache.EventType "+
+				"declares %v — a resource type gained or lost an event without "+
+				"the stream contract following",
+			got, want,
+		)
+	}
+}
+
+// eventTypeConstants reads the cache.EventType constant block out of
+// internal/cache/cache.go. EventSync is excluded: it is the resync signal,
+// not a resource type, and the document declares it as its own message.
+func eventTypeConstants(t *testing.T) []string {
+	t.Helper()
+
+	const source = "../cache/cache.go"
+
+	raw, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read %s: %v", source, err)
+	}
+
+	// EventNode    EventType = "node"
+	pattern := regexp.MustCompile(`(?m)^\s*Event(\w+)\s+EventType\s*=\s*"([^"]+)"`)
+
+	matches := pattern.FindAllStringSubmatch(string(raw), -1)
+	if len(matches) == 0 {
+		t.Fatalf(
+			"found no EventType constants in %s — the declaration moved and "+
+				"this test is now asserting nothing",
+			source,
+		)
+	}
+
+	var types []string
+
+	for _, match := range matches {
+		if match[2] == "sync" {
+			continue
+		}
+
+		types = append(types, match[2])
+	}
+
+	return types
+}

--- a/internal/api/asyncapi_frames_test.go
+++ b/internal/api/asyncapi_frames_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/radiergummi/cetacean/internal/api/sse"
 	"github.com/radiergummi/cetacean/internal/cache"
-	promapi "github.com/radiergummi/cetacean/internal/prometheus"
 )
 
 // sseFrame is one parsed `event:`/`id:`/`data:` group. Comment lines (the
@@ -95,27 +94,53 @@ func streamUntilIdle(
 	return readSSEFrames(t, rec.Body.String())
 }
 
-// resourceStreamRouter is a router whose broadcaster has a real history ring,
-// so Last-Event-ID reaches the replay path rather than being ignored.
-func resourceStreamRouter(t *testing.T) (http.Handler, *cache.Cache, *sse.Broadcaster) {
+// streamTestRouter is a router over the spec fixtures whose broadcaster has a
+// real history ring, so Last-Event-ID reaches the replay path rather than
+// being ignored, and whose Docker client serves one log frame.
+//
+// batch is the broadcaster's batching interval; zero sends each event on its
+// own.
+func streamTestRouter(
+	t *testing.T,
+	batch time.Duration,
+	opts ...testHandlersOption,
+) (http.Handler, *cache.Cache, *sse.Broadcaster) {
 	t.Helper()
 
 	c := cache.New(nil)
 	populateSpecFixtures(c)
 
-	broadcaster := sse.NewBroadcaster(50*time.Millisecond, noopErrorWriter, c.History())
+	broadcaster := sse.NewBroadcaster(batch, noopErrorWriter, c.History())
 	t.Cleanup(broadcaster.Close)
 
-	router := newTestRouterWithCache(t, c, withBroadcaster(broadcaster))
+	var frames bytes.Buffer
+	frames.Write(buildFrame(1, "2026-01-01T00:00:00.000000000Z hello\n"))
 
-	return router, c, broadcaster
+	opts = append([]testHandlersOption{
+		withBroadcaster(broadcaster),
+		withDockerClient(&mockLogStreamer{data: frames.Bytes()}),
+	}, opts...)
+
+	return newTestRouterWithCache(t, c, opts...), c, broadcaster
+}
+
+// resourceStreamRouter is streamTestRouter at the batching interval the
+// resource streams are driven at here.
+func resourceStreamRouter(t *testing.T) (http.Handler, *cache.Cache, *sse.Broadcaster) {
+	t.Helper()
+
+	return streamTestRouter(t, 50*time.Millisecond)
 }
 
 // TestListStreamEmitsTheDeclaredNames drives /services, the exemplar for
 // streamList: one mutation is named for its type, two inside a batch interval
 // become `batch` with an array payload.
 func TestListStreamEmitsTheDeclaredNames(t *testing.T) {
+	t.Parallel()
+
 	t.Run("a single event is named for its type", func(t *testing.T) {
+		t.Parallel()
+
 		router, _, broadcaster := resourceStreamRouter(t)
 
 		frames := streamUntilIdle(t, router, "/services", "", func() {
@@ -148,6 +173,8 @@ func TestListStreamEmitsTheDeclaredNames(t *testing.T) {
 	})
 
 	t.Run("two events inside the interval become a batch array", func(t *testing.T) {
+		t.Parallel()
+
 		router, _, broadcaster := resourceStreamRouter(t)
 
 		frames := streamUntilIdle(t, router, "/services", "", func() {
@@ -193,6 +220,8 @@ func TestListStreamEmitsTheDeclaredNames(t *testing.T) {
 // `sync` message the document declares, with action full_sync and no
 // resource.
 func TestAgedOutCursorEmitsSync(t *testing.T) {
+	t.Parallel()
+
 	router, _, _ := resourceStreamRouter(t)
 
 	frames := streamUntilIdle(t, router, "/services", "999999", nil)
@@ -223,6 +252,8 @@ func TestAgedOutCursorEmitsSync(t *testing.T) {
 // stores identity and not payload, so a replayed envelope has no resource.
 // A client that assumes it is present breaks only after a reconnection.
 func TestReplayedFrameOmitsResource(t *testing.T) {
+	t.Parallel()
+
 	router, c, _ := resourceStreamRouter(t)
 
 	c.History().Append(cache.HistoryEntry{
@@ -262,6 +293,8 @@ func TestReplayedFrameOmitsResource(t *testing.T) {
 // TestDetailStreamNeverReplays: a detail channel is ineligible for replay, so
 // any cursor gets sync — not only an aged-out one.
 func TestDetailStreamNeverReplays(t *testing.T) {
+	t.Parallel()
+
 	router, c, _ := resourceStreamRouter(t)
 
 	c.History().Append(cache.HistoryEntry{
@@ -292,6 +325,8 @@ func TestDetailStreamNeverReplays(t *testing.T) {
 // interleaves a service's tasks and a backwards cursor would discard the
 // lines in between on the next resume.
 func TestLogTailFramesAreUnnamedAndTheCursorOnlyMovesForward(t *testing.T) {
+	t.Parallel()
+
 	c := cache.New(nil)
 	populateSpecFixtures(c)
 
@@ -307,6 +342,8 @@ func TestLogTailFramesAreUnnamedAndTheCursorOnlyMovesForward(t *testing.T) {
 
 	for _, path := range []string{"/services/svc1/logs", "/tasks/task1/logs"} {
 		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
 			frames := streamUntilIdle(t, router, path, "", nil)
 
 			if len(frames) == 0 {
@@ -340,99 +377,4 @@ func TestLogTailFramesAreUnnamedAndTheCursorOnlyMovesForward(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestMetricsStreamEmitsTheDeclaredNames covers the third dialect: initial,
-// point and query_error, and no id at all.
-func TestMetricsStreamEmitsTheDeclaredNames(t *testing.T) {
-	t.Run("initial then point, with no id", func(t *testing.T) {
-		prometheus := httptest.NewServer(http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-
-				if strings.HasSuffix(r.URL.Path, "/query_range") {
-					w.Write([]byte(
-						`{"status":"success","data":{"resultType":"matrix","result":[]}}`,
-					))
-
-					return
-				}
-
-				w.Write([]byte(
-					`{"status":"success","data":{"resultType":"vector","result":[]}}`,
-				))
-			},
-		))
-		t.Cleanup(prometheus.Close)
-
-		router := newTestRouterWithCache(
-			t, cache.New(nil),
-			withPromClient(promapi.NewClient(prometheus.URL)),
-			withTickerInterval(10*time.Millisecond),
-		)
-
-		frames := streamUntilIdle(t, router, "/metrics?query=up&step=5", "", nil)
-
-		if len(frames) == 0 {
-			t.Fatal("no frames")
-		}
-
-		if frames[0].Event != "initial" {
-			t.Errorf("first event = %q, want initial", frames[0].Event)
-		}
-
-		var points int
-
-		for _, frame := range frames {
-			if frame.Event == "point" {
-				points++
-			}
-
-			if frame.ID != "" {
-				t.Errorf("metrics frame carries id %q; this stream writes none", frame.ID)
-			}
-		}
-
-		if points == 0 {
-			t.Error("no point event; the stream declares one per tick")
-		}
-	})
-
-	t.Run("a failing query is named query_error", func(t *testing.T) {
-		prometheus := httptest.NewServer(http.HandlerFunc(
-			func(w http.ResponseWriter, _ *http.Request) {
-				http.Error(w, "boom", http.StatusInternalServerError)
-			},
-		))
-		t.Cleanup(prometheus.Close)
-
-		router := newTestRouterWithCache(
-			t, cache.New(nil),
-			withPromClient(promapi.NewClient(prometheus.URL)),
-			withTickerInterval(10*time.Millisecond),
-		)
-
-		frames := streamUntilIdle(t, router, "/metrics?query=up&step=5", "", nil)
-
-		if len(frames) == 0 {
-			t.Fatal("no frames")
-		}
-
-		if frames[0].Event != "query_error" {
-			t.Fatalf("first event = %q, want query_error", frames[0].Event)
-		}
-
-		var payload struct {
-			Error     string `json:"error"`
-			ErrorType string `json:"errorType"`
-		}
-
-		if err := json.Unmarshal([]byte(frames[0].Data), &payload); err != nil {
-			t.Fatalf("payload is not an object: %v", err)
-		}
-
-		if payload.ErrorType != "server_error" {
-			t.Errorf("errorType = %q, want server_error", payload.ErrorType)
-		}
-	})
 }

--- a/internal/api/asyncapi_frames_test.go
+++ b/internal/api/asyncapi_frames_test.go
@@ -1,0 +1,438 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+
+	"github.com/radiergummi/cetacean/internal/api/sse"
+	"github.com/radiergummi/cetacean/internal/cache"
+	promapi "github.com/radiergummi/cetacean/internal/prometheus"
+)
+
+// sseFrame is one parsed `event:`/`id:`/`data:` group. Comment lines (the
+// keepalive) carry none of the three and are dropped.
+type sseFrame struct {
+	Event string
+	ID    string
+	Data  string
+}
+
+func readSSEFrames(t *testing.T, body string) []sseFrame {
+	t.Helper()
+
+	var frames []sseFrame
+
+	for block := range strings.SplitSeq(body, "\n\n") {
+		var frame sseFrame
+		var seen bool
+
+		for line := range strings.SplitSeq(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				frame.Event = strings.TrimPrefix(line, "event: ")
+				seen = true
+			case strings.HasPrefix(line, "id: "):
+				frame.ID = strings.TrimPrefix(line, "id: ")
+				seen = true
+			case strings.HasPrefix(line, "data: "):
+				frame.Data = strings.TrimPrefix(line, "data: ")
+				seen = true
+			}
+		}
+
+		if seen {
+			frames = append(frames, frame)
+		}
+	}
+
+	return frames
+}
+
+// streamUntilIdle opens path as a stream, runs drive once the handler is
+// serving, and returns the frames written before the context expires.
+func streamUntilIdle(
+	t *testing.T,
+	router http.Handler,
+	path string,
+	lastEventID string,
+	drive func(),
+) []sseFrame {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Accept", "text/event-stream")
+
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), 400*time.Millisecond)
+	defer cancel()
+
+	rec := httptest.NewRecorder()
+
+	if drive != nil {
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			drive()
+		}()
+	}
+
+	router.ServeHTTP(rec, req.WithContext(ctx))
+
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	return readSSEFrames(t, rec.Body.String())
+}
+
+// resourceStreamRouter is a router whose broadcaster has a real history ring,
+// so Last-Event-ID reaches the replay path rather than being ignored.
+func resourceStreamRouter(t *testing.T) (http.Handler, *cache.Cache, *sse.Broadcaster) {
+	t.Helper()
+
+	c := cache.New(nil)
+	populateSpecFixtures(c)
+
+	broadcaster := sse.NewBroadcaster(50*time.Millisecond, noopErrorWriter, c.History())
+	t.Cleanup(broadcaster.Close)
+
+	router := newTestRouterWithCache(t, c, withBroadcaster(broadcaster))
+
+	return router, c, broadcaster
+}
+
+// TestListStreamEmitsTheDeclaredNames drives /services, the exemplar for
+// streamList: one mutation is named for its type, two inside a batch interval
+// become `batch` with an array payload.
+func TestListStreamEmitsTheDeclaredNames(t *testing.T) {
+	t.Run("a single event is named for its type", func(t *testing.T) {
+		router, _, broadcaster := resourceStreamRouter(t)
+
+		frames := streamUntilIdle(t, router, "/services", "", func() {
+			broadcaster.Broadcast(cache.Event{
+				Type:      cache.EventService,
+				Action:    "update",
+				ID:        "svc1",
+				Name:      "web",
+				HistoryID: 1,
+				Resource:  swarm.Service{ID: "svc1"},
+			})
+		})
+
+		if len(frames) == 0 {
+			t.Fatal("no frames")
+		}
+
+		if frames[0].Event != "service" {
+			t.Errorf("event = %q, want service", frames[0].Event)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(frames[0].Data), &payload); err != nil {
+			t.Fatalf("payload is not an object: %v", err)
+		}
+
+		if payload["resource"] == nil {
+			t.Error("a live event must carry resource")
+		}
+	})
+
+	t.Run("two events inside the interval become a batch array", func(t *testing.T) {
+		router, _, broadcaster := resourceStreamRouter(t)
+
+		frames := streamUntilIdle(t, router, "/services", "", func() {
+			for _, id := range []string{"svc1", "svc2"} {
+				broadcaster.Broadcast(cache.Event{
+					Type:      cache.EventService,
+					Action:    "update",
+					ID:        id,
+					Name:      "web",
+					HistoryID: 1,
+					Resource:  swarm.Service{ID: id},
+				})
+			}
+		})
+
+		var batch *sseFrame
+
+		for i := range frames {
+			if frames[i].Event == "batch" {
+				batch = &frames[i]
+			}
+		}
+
+		if batch == nil {
+			t.Fatalf("no batch frame; got %+v", frames)
+		}
+
+		var payload []map[string]any
+		if err := json.Unmarshal([]byte(batch.Data), &payload); err != nil {
+			t.Fatalf(
+				"a batch payload must be an array of envelopes, not one envelope: %v",
+				err,
+			)
+		}
+
+		if len(payload) != 2 {
+			t.Errorf("batch carries %d envelopes, want 2", len(payload))
+		}
+	})
+}
+
+// TestAgedOutCursorEmitsSync: a cursor the ring no longer holds gets the
+// `sync` message the document declares, with action full_sync and no
+// resource.
+func TestAgedOutCursorEmitsSync(t *testing.T) {
+	router, _, _ := resourceStreamRouter(t)
+
+	frames := streamUntilIdle(t, router, "/services", "999999", nil)
+
+	if len(frames) == 0 {
+		t.Fatal("no frames — an aged-out cursor must be answered, not ignored")
+	}
+
+	if frames[0].Event != "sync" {
+		t.Fatalf("event = %q, want sync", frames[0].Event)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(frames[0].Data), &payload); err != nil {
+		t.Fatalf("payload is not an object: %v", err)
+	}
+
+	if payload["action"] != "full_sync" {
+		t.Errorf("action = %v, want full_sync", payload["action"])
+	}
+
+	if _, present := payload["resource"]; present {
+		t.Error("a sync payload must not carry resource")
+	}
+}
+
+// TestReplayedFrameOmitsResource: replay reads the change history, which
+// stores identity and not payload, so a replayed envelope has no resource.
+// A client that assumes it is present breaks only after a reconnection.
+func TestReplayedFrameOmitsResource(t *testing.T) {
+	router, c, _ := resourceStreamRouter(t)
+
+	c.History().Append(cache.HistoryEntry{
+		Type:       cache.EventService,
+		Action:     "update",
+		ResourceID: "svc1",
+		Name:       "web",
+		Timestamp:  time.Now(),
+	})
+
+	frames := streamUntilIdle(t, router, "/services", "0", nil)
+
+	if len(frames) == 0 {
+		t.Fatal("no frames — a replayable cursor must replay")
+	}
+
+	if frames[0].Event == "sync" {
+		t.Fatal("the cursor was replayable but the stream answered sync")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(frames[0].Data), &payload); err != nil {
+		// A batch frame: unwrap and take the first envelope.
+		var batched []map[string]any
+		if err := json.Unmarshal([]byte(frames[0].Data), &batched); err != nil {
+			t.Fatalf("payload is neither an object nor an array: %v", err)
+		}
+
+		payload = batched[0]
+	}
+
+	if _, present := payload["resource"]; present {
+		t.Error("a replayed envelope must not carry resource")
+	}
+}
+
+// TestDetailStreamNeverReplays: a detail channel is ineligible for replay, so
+// any cursor gets sync — not only an aged-out one.
+func TestDetailStreamNeverReplays(t *testing.T) {
+	router, c, _ := resourceStreamRouter(t)
+
+	c.History().Append(cache.HistoryEntry{
+		Type:       cache.EventService,
+		Action:     "update",
+		ResourceID: "svc1",
+		Name:       "web",
+		Timestamp:  time.Now(),
+	})
+
+	frames := streamUntilIdle(t, router, "/services/svc1", "0", nil)
+
+	if len(frames) == 0 {
+		t.Fatal("no frames")
+	}
+
+	if frames[0].Event != "sync" {
+		t.Errorf(
+			"event = %q, want sync — a detail stream offers no replay even for a "+
+				"cursor the ring still holds",
+			frames[0].Event,
+		)
+	}
+}
+
+// TestLogTailFramesAreUnnamedAndTheCursorOnlyMovesForward: log frames carry
+// no event name, and their RFC 3339 id never moves backwards, because Docker
+// interleaves a service's tasks and a backwards cursor would discard the
+// lines in between on the next resume.
+func TestLogTailFramesAreUnnamedAndTheCursorOnlyMovesForward(t *testing.T) {
+	c := cache.New(nil)
+	populateSpecFixtures(c)
+
+	var docker bytes.Buffer
+	docker.Write(buildFrame(1, "2026-01-01T00:00:02.000000000Z second\n"))
+	docker.Write(buildFrame(1, "2026-01-01T00:00:01.000000000Z out-of-order\n"))
+	docker.Write(buildFrame(1, "2026-01-01T00:00:03.000000000Z third\n"))
+
+	router := newTestRouterWithCache(
+		t, c,
+		withDockerClient(&mockLogStreamer{data: docker.Bytes()}),
+	)
+
+	for _, path := range []string{"/services/svc1/logs", "/tasks/task1/logs"} {
+		t.Run(path, func(t *testing.T) {
+			frames := streamUntilIdle(t, router, path, "", nil)
+
+			if len(frames) == 0 {
+				t.Fatal("no frames")
+			}
+
+			var previous string
+
+			for _, frame := range frames {
+				if frame.Event != "" {
+					t.Errorf("log frame is named %q; log frames are unnamed", frame.Event)
+				}
+
+				if frame.ID == "" {
+					continue
+				}
+
+				if _, err := time.Parse(time.RFC3339Nano, frame.ID); err != nil {
+					t.Errorf("id %q is not an RFC 3339 timestamp", frame.ID)
+				}
+
+				if previous != "" && frame.ID < previous {
+					t.Errorf(
+						"id moved backwards: %q after %q — a resume from the later "+
+							"cursor would discard the lines in between",
+						frame.ID, previous,
+					)
+				}
+
+				previous = frame.ID
+			}
+		})
+	}
+}
+
+// TestMetricsStreamEmitsTheDeclaredNames covers the third dialect: initial,
+// point and query_error, and no id at all.
+func TestMetricsStreamEmitsTheDeclaredNames(t *testing.T) {
+	t.Run("initial then point, with no id", func(t *testing.T) {
+		prometheus := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				if strings.HasSuffix(r.URL.Path, "/query_range") {
+					w.Write([]byte(
+						`{"status":"success","data":{"resultType":"matrix","result":[]}}`,
+					))
+
+					return
+				}
+
+				w.Write([]byte(
+					`{"status":"success","data":{"resultType":"vector","result":[]}}`,
+				))
+			},
+		))
+		t.Cleanup(prometheus.Close)
+
+		router := newTestRouterWithCache(
+			t, cache.New(nil),
+			withPromClient(promapi.NewClient(prometheus.URL)),
+			withTickerInterval(10*time.Millisecond),
+		)
+
+		frames := streamUntilIdle(t, router, "/metrics?query=up&step=5", "", nil)
+
+		if len(frames) == 0 {
+			t.Fatal("no frames")
+		}
+
+		if frames[0].Event != "initial" {
+			t.Errorf("first event = %q, want initial", frames[0].Event)
+		}
+
+		var points int
+
+		for _, frame := range frames {
+			if frame.Event == "point" {
+				points++
+			}
+
+			if frame.ID != "" {
+				t.Errorf("metrics frame carries id %q; this stream writes none", frame.ID)
+			}
+		}
+
+		if points == 0 {
+			t.Error("no point event; the stream declares one per tick")
+		}
+	})
+
+	t.Run("a failing query is named query_error", func(t *testing.T) {
+		prometheus := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+		))
+		t.Cleanup(prometheus.Close)
+
+		router := newTestRouterWithCache(
+			t, cache.New(nil),
+			withPromClient(promapi.NewClient(prometheus.URL)),
+			withTickerInterval(10*time.Millisecond),
+		)
+
+		frames := streamUntilIdle(t, router, "/metrics?query=up&step=5", "", nil)
+
+		if len(frames) == 0 {
+			t.Fatal("no frames")
+		}
+
+		if frames[0].Event != "query_error" {
+			t.Fatalf("first event = %q, want query_error", frames[0].Event)
+		}
+
+		var payload struct {
+			Error     string `json:"error"`
+			ErrorType string `json:"errorType"`
+		}
+
+		if err := json.Unmarshal([]byte(frames[0].Data), &payload); err != nil {
+			t.Fatalf("payload is not an object: %v", err)
+		}
+
+		if payload.ErrorType != "server_error" {
+			t.Errorf("errorType = %q, want server_error", payload.ErrorType)
+		}
+	})
+}

--- a/internal/api/asyncapi_test.go
+++ b/internal/api/asyncapi_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -415,4 +416,172 @@ func withAsyncAPISpec(t *testing.T) routerOption {
 	}
 
 	return func(cfg *RouterConfig) { cfg.AsyncAPISpec = raw }
+}
+
+// asyncAPIRequest fetches the document under one Accept header.
+func asyncAPIRequest(
+	t *testing.T,
+	router http.Handler,
+	path, accept string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "cetacean.example.com"
+
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s (Accept: %q) = %d; body: %s", path, accept, rec.Code, rec.Body.String())
+	}
+
+	return rec
+}
+
+// TestAsyncAPIYAMLIsTheSameDocument holds the two representations together.
+// The server block is spliced into a node tree for YAML and into a map for
+// JSON — two injection sites that would otherwise drift silently.
+func TestAsyncAPIYAMLIsTheSameDocument(t *testing.T) {
+	router := newTestRouterWithConfig(
+		t,
+		[]routerOption{withAsyncAPISpec(t)},
+		withCache(cache.New(nil)),
+	)
+
+	asJSON := asyncAPIRequest(t, router, asyncAPIPath, "application/json")
+	asYAML := asyncAPIRequest(t, router, asyncAPIYAMLPath, "")
+
+	// Both sides start from the same file, so normalising the YAML through the
+	// same conversion the JSON path uses has to land on identical bytes.
+	normalized, err := json.Marshal(loadYAMLDocument(t, "the served YAML", asYAML.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("marshal the served YAML: %v", err)
+	}
+
+	if !bytes.Equal(normalized, asJSON.Body.Bytes()) {
+		t.Errorf(
+			"the YAML and JSON representations are different documents\n yaml: %s\n json: %s",
+			truncate(normalized), truncate(asJSON.Body.Bytes()),
+		)
+	}
+}
+
+// TestAsyncAPIYAMLKeepsTheAuthoredDocument: the point of serving YAML is that
+// a person reads it, so the comments and the key order in api/asyncapi.yaml
+// have to survive. Re-encoding the map the JSON is built from loses both.
+func TestAsyncAPIYAMLKeepsTheAuthoredDocument(t *testing.T) {
+	router := newTestRouterWithConfig(
+		t,
+		[]routerOption{withAsyncAPISpec(t)},
+		withCache(cache.New(nil)),
+	)
+
+	body := asyncAPIRequest(t, router, asyncAPIYAMLPath, "").Body.String()
+
+	if !strings.HasPrefix(body, "asyncapi:") {
+		t.Errorf(
+			"the document does not open on asyncapi:, so the key order was rebuilt:\n%.120s",
+			body,
+		)
+	}
+
+	// A comment from the source file. A bare "#" would pass on any $ref, so
+	// this names one the file actually carries.
+	const comment = "# The /metrics stream forwards Prometheus' own response bodies unchanged."
+
+	if !strings.Contains(body, comment) {
+		t.Error("the served YAML dropped the source file's comments")
+	}
+
+	// The authored file indents by two; yaml.Marshal's default is four.
+	if !strings.Contains(body, "\ninfo:\n  title:") {
+		t.Error("the served YAML is not indented like the file it comes from")
+	}
+
+	// The placeholder in the file must not survive: the served document names
+	// the origin the request arrived on.
+	if strings.Contains(body, "localhost:9000") {
+		t.Error("the served YAML still names the file's placeholder host")
+	}
+
+	if !strings.Contains(body, "cetacean.example.com") {
+		t.Error("the served YAML does not name the request's origin")
+	}
+}
+
+// TestSpecDocumentsNegotiateYAML drives every spelling a client might send.
+func TestSpecDocumentsNegotiateYAML(t *testing.T) {
+	router := newTestRouterWithConfig(
+		t,
+		[]routerOption{withAsyncAPISpec(t), withAPIDocs([]byte("openapi: '3.1.0'\n"), nil)},
+		withCache(cache.New(nil)),
+	)
+
+	yamlTypes := []string{
+		"application/yaml",
+		"text/yaml",
+		"application/x-yaml",
+		"text/x-yaml",
+	}
+
+	t.Run("openapi", func(t *testing.T) {
+		for _, accept := range append(yamlTypes,
+			"application/vnd.oai.openapi", "application/openapi+yaml",
+		) {
+			t.Run(accept, func(t *testing.T) {
+				rec := asyncAPIRequest(t, router, "/api", accept)
+
+				if got := rec.Header().Get("Content-Type"); got != openAPIYAMLMediaType {
+					t.Errorf("Content-Type = %q, want %q", got, openAPIYAMLMediaType)
+				}
+
+				if !strings.HasPrefix(rec.Body.String(), "openapi:") {
+					t.Errorf("body is not the YAML source: %.60s", rec.Body.String())
+				}
+			})
+		}
+	})
+
+	t.Run("asyncapi", func(t *testing.T) {
+		for _, accept := range append(yamlTypes,
+			"application/vnd.aai.asyncapi+yaml", "application/asyncapi+yaml",
+		) {
+			t.Run(accept, func(t *testing.T) {
+				rec := asyncAPIRequest(t, router, asyncAPIPath, accept)
+
+				if got := rec.Header().Get("Content-Type"); got != asyncAPIYAMLMediaType {
+					t.Errorf("Content-Type = %q, want %q", got, asyncAPIYAMLMediaType)
+				}
+
+				if !strings.HasPrefix(rec.Body.String(), "asyncapi:") {
+					t.Errorf("body is not YAML: %.60s", rec.Body.String())
+				}
+			})
+		}
+	})
+
+	// The generic spellings ask for a format, not a document, so JSON must
+	// still be what an ordinary client gets.
+	t.Run("json is still the default", func(t *testing.T) {
+		for _, accept := range []string{"", "*/*", "application/json", "application/*"} {
+			rec := asyncAPIRequest(t, router, asyncAPIPath, accept)
+
+			if got := rec.Header().Get("Content-Type"); got != asyncAPIMediaType {
+				t.Errorf("Accept %q gave Content-Type %q, want %q", accept, got, asyncAPIMediaType)
+			}
+		}
+	})
+}
+
+func truncate(b []byte) string {
+	if len(b) > 200 {
+		return string(b[:200]) + "…"
+	}
+
+	return string(b)
 }

--- a/internal/api/asyncapi_test.go
+++ b/internal/api/asyncapi_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+// asyncAPISchema is the official AsyncAPI 3.0.0 meta-schema. It is embedded
+// from a _test.go file so it is never linked into the binary.
+//
+//go:embed testdata/asyncapi-3.0.0.json
+var asyncAPISchema []byte
+
+const asyncAPISpecPath = "../../api/asyncapi.yaml"
+
+// loadAsyncAPIDoc parses api/asyncapi.yaml into the JSON-shaped value every
+// test here reads. The served document is the same value, so a test that
+// passes against the file passes against the response.
+func loadAsyncAPIDoc(t *testing.T) map[string]any {
+	t.Helper()
+
+	return loadYAMLDocument(t, asyncAPISpecPath)
+}
+
+// TestAsyncAPIDocumentIsValid validates api/asyncapi.yaml against the official
+// AsyncAPI 3.0.0 meta-schema.
+//
+// The meta-schema's $refs are absolute http://asyncapi.com/ URLs, but every
+// one of them resolves inside the file: each entry under definitions carries
+// the matching $id. No loader is installed, so a ref that did not resolve
+// locally would fail the compile rather than reach the network.
+func TestAsyncAPIDocumentIsValid(t *testing.T) {
+	const metaURL = "http://asyncapi.com/definitions/3.0.0/asyncapi.json"
+
+	meta, err := jsonschema.UnmarshalJSON(bytes.NewReader(asyncAPISchema))
+	if err != nil {
+		t.Fatalf("the vendored meta-schema is not JSON: %v", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(metaURL, meta); err != nil {
+		t.Fatalf("add meta-schema: %v", err)
+	}
+
+	schema, err := compiler.Compile(metaURL)
+	if err != nil {
+		t.Fatalf("compile meta-schema: %v", err)
+	}
+
+	encoded, err := json.Marshal(loadAsyncAPIDoc(t))
+	if err != nil {
+		t.Fatalf("marshal document: %v", err)
+	}
+
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("re-parse document: %v", err)
+	}
+
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("api/asyncapi.yaml is not valid AsyncAPI 3.0.0:\n%v", err)
+	}
+}
+
+// TestAsyncAPISchemasMatchOpenAPI pins the two schemas asyncapi.yaml copies
+// from openapi.yaml. They are copied rather than $ref'd because the correct
+// reference differs between the file in the repository and the document as
+// served, and one reference with two correct spellings is the trap
+// /.well-known/jwks.json fell into from the other direction.
+func TestAsyncAPISchemasMatchOpenAPI(t *testing.T) {
+	openAPI := loadYAMLDocument(t, "../../api/openapi.yaml")
+	asyncAPI := loadAsyncAPIDoc(t)
+
+	for _, name := range []string{"SSEEvent", "LogLine"} {
+		t.Run(name, func(t *testing.T) {
+			want := schemaNamed(t, openAPI, name)
+			got := schemaNamed(t, asyncAPI, name)
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf(
+					"asyncapi.yaml's %s has drifted from openapi.yaml's\n got: %#v\nwant: %#v",
+					name, got, want,
+				)
+			}
+		})
+	}
+}
+
+// loadYAMLDocument parses any of the two specs into the same JSON shape.
+func loadYAMLDocument(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var parsed any
+	if err := yaml.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("%s is not valid YAML: %v", path, err)
+	}
+
+	doc, ok := convertYAMLToJSON(parsed).(map[string]any)
+	if !ok {
+		t.Fatalf("%s does not parse to an object", path)
+	}
+
+	return doc
+}
+
+// schemaNamed digs components.schemas.<name> out of either document.
+func schemaNamed(t *testing.T, doc map[string]any, name string) any {
+	t.Helper()
+
+	components, ok := doc["components"].(map[string]any)
+	if !ok {
+		t.Fatal("document has no components")
+	}
+
+	schemas, ok := components["schemas"].(map[string]any)
+	if !ok {
+		t.Fatal("document has no components.schemas")
+	}
+
+	schema, ok := schemas[name]
+	if !ok {
+		t.Fatalf("document has no components.schemas.%s", name)
+	}
+
+	return schema
+}

--- a/internal/api/asyncapi_test.go
+++ b/internal/api/asyncapi_test.go
@@ -576,6 +576,40 @@ func TestSpecDocumentsNegotiateYAML(t *testing.T) {
 			}
 		}
 	})
+
+	// A tool that names both registered spellings of its own document type
+	// gets the one it listed first. Registering only the +yaml half would let
+	// the YAML win by default, since the JSON half would match nothing.
+	t.Run("the json spellings are named too", func(t *testing.T) {
+		cases := []struct {
+			path, accept, want string
+		}{{
+			asyncAPIPath,
+			"application/vnd.aai.asyncapi+json;version=3.0.0," +
+				"application/vnd.aai.asyncapi+yaml;version=3.0.0",
+			asyncAPIMediaType,
+		}, {
+			asyncAPIPath, "application/asyncapi+json", asyncAPIMediaType,
+		}, {
+			"/api", "application/vnd.oai.openapi+json", "application/json",
+		}, {
+			"/api", "application/openapi+json", "application/json",
+		}}
+
+		for _, tc := range cases {
+			t.Run(tc.path+" "+tc.accept, func(t *testing.T) {
+				rec := asyncAPIRequest(t, router, tc.path, tc.accept)
+
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+				}
+
+				if got := rec.Header().Get("Content-Type"); got != tc.want {
+					t.Errorf("Content-Type = %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
 }
 
 func truncate(b []byte) string {

--- a/internal/api/asyncapi_test.go
+++ b/internal/api/asyncapi_test.go
@@ -2,14 +2,23 @@ package api
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gopkg.in/yaml.v3"
+
+	"github.com/radiergummi/cetacean/internal/api/sse"
+	"github.com/radiergummi/cetacean/internal/cache"
+	promapi "github.com/radiergummi/cetacean/internal/prometheus"
 )
 
 // asyncAPISchema is the official AsyncAPI 3.0.0 meta-schema. It is embedded
@@ -135,4 +144,295 @@ func schemaNamed(t *testing.T, doc map[string]any, name string) any {
 	}
 
 	return schema
+}
+
+// TestAsyncAPIIsServed drives the route the discovery links point at.
+func TestAsyncAPIIsServed(t *testing.T) {
+	router := newTestRouterWithConfig(
+		t,
+		[]routerOption{withAsyncAPISpec(t)},
+		withCache(cache.New(nil)),
+	)
+
+	for _, path := range []string{asyncAPIPath, asyncAPIPath + ".json"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Host = "cetacean.example.com"
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+			}
+
+			if got := rec.Header().Get("Content-Type"); got != asyncAPIMediaType {
+				t.Errorf("Content-Type = %q, want %q", got, asyncAPIMediaType)
+			}
+
+			if got := rec.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+				t.Errorf("Cache-Control = %q", got)
+			}
+
+			if rec.Header().Get("ETag") == "" {
+				t.Error("no ETag")
+			}
+
+			var doc map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+				t.Fatalf("body is not JSON: %v", err)
+			}
+
+			if doc["asyncapi"] != "3.0.0" {
+				t.Errorf("asyncapi = %v, want 3.0.0", doc["asyncapi"])
+			}
+		})
+	}
+}
+
+// TestAsyncAPINamesTheRequestOrigin: AsyncAPI 3.0 requires host on a server
+// object, so the served document has to name the deployment. The value comes
+// from the validated origin, never from a raw forwarding header.
+func TestAsyncAPINamesTheRequestOrigin(t *testing.T) {
+	router := newTestRouterWithConfig(
+		t,
+		[]routerOption{withAsyncAPISpec(t)},
+		withCache(cache.New(nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, asyncAPIPath, nil)
+	req.Host = "cetacean.example.com"
+	req.Header.Set("X-Forwarded-Host", "evil.example.com")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	var doc struct {
+		Servers map[string]struct {
+			Host     string `json:"host"`
+			Protocol string `json:"protocol"`
+			Pathname string `json:"pathname"`
+		} `json:"servers"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+
+	self, ok := doc.Servers["self"]
+	if !ok {
+		t.Fatal("the served document names no server")
+	}
+
+	if self.Host != "cetacean.example.com" {
+		t.Errorf("host = %q, want the request's own origin", self.Host)
+	}
+
+	if self.Protocol != "http" {
+		t.Errorf("protocol = %q, want http for a plaintext request", self.Protocol)
+	}
+}
+
+// TestAsyncAPICarriesTheBasePath: under CETACEAN_BASE_PATH every address the
+// document names is reached through the prefix, so the server object has to
+// carry it as a pathname.
+func TestAsyncAPICarriesTheBasePath(t *testing.T) {
+	router := newTestRouterWithConfig(
+		t,
+		[]routerOption{withBasePath("/cetacean"), withAsyncAPISpec(t)},
+		withCache(cache.New(nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/cetacean"+asyncAPIPath, nil)
+	req.Host = "cetacean.example.com"
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var doc struct {
+		Servers map[string]struct {
+			Pathname string `json:"pathname"`
+		} `json:"servers"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+
+	if got := doc.Servers["self"].Pathname; got != "/cetacean" {
+		t.Errorf("pathname = %q, want /cetacean", got)
+	}
+}
+
+// TestAsyncAPIIsDiscoverable pins both places the spec names: a typed
+// service-desc Link on every non-meta response, and a matching target in the
+// API catalog.
+func TestAsyncAPIIsDiscoverable(t *testing.T) {
+	// The stub document testRouterConfig defaults to is enough here: the Link
+	// header says nothing about the document's content.
+	router := newTestRouterWithCache(t, cache.New(nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/nodes", nil)
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	want := `<` + asyncAPIPath + `>; rel="service-desc"; type="` + asyncAPIMediaType + `"`
+
+	if !slices.Contains(rec.Header().Values("Link"), want) {
+		t.Errorf("no Link header %q; got %q", want, rec.Header().Values("Link"))
+	}
+}
+
+// asyncAPIChannels returns the channels block, keyed as the document keys it.
+func asyncAPIChannels(t *testing.T) map[string]map[string]any {
+	t.Helper()
+
+	raw, ok := loadAsyncAPIDoc(t)["channels"].(map[string]any)
+	if !ok {
+		t.Fatal("the document declares no channels")
+	}
+
+	channels := make(map[string]map[string]any, len(raw))
+
+	for name, value := range raw {
+		channel, ok := value.(map[string]any)
+		if !ok {
+			t.Fatalf("channel %q is not an object", name)
+		}
+
+		channels[name] = channel
+	}
+
+	return channels
+}
+
+// asyncAPIAddresses returns every channel address, keyed by channel name.
+func asyncAPIAddresses(t *testing.T) map[string]string {
+	t.Helper()
+
+	addresses := make(map[string]string)
+
+	for name, channel := range asyncAPIChannels(t) {
+		address, ok := channel["address"].(string)
+		if !ok {
+			t.Fatalf("channel %q has no address", name)
+		}
+
+		addresses[name] = address
+	}
+
+	return addresses
+}
+
+// TestAsyncAPIChannelsAnswerAsStreams drives every channel address the
+// document declares and requires it to open a stream.
+//
+// The assertion is the content type, not the status: the SPA fallback answers
+// 200 for any unrouted path, so a bogus address would pass a status check. It
+// answers text/html, which this fails on.
+func TestAsyncAPIChannelsAnswerAsStreams(t *testing.T) {
+	c := cache.New(nil)
+	populateSpecFixtures(c)
+
+	broadcaster := sse.NewBroadcaster(0, noopErrorWriter, c.History())
+	t.Cleanup(broadcaster.Close)
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+	}))
+	t.Cleanup(prometheus.Close)
+
+	var frames bytes.Buffer
+	frames.Write(buildFrame(1, "2026-01-01T00:00:00.000000000Z hello\n"))
+
+	router := newTestRouterWithCache(
+		t, c,
+		withBroadcaster(broadcaster),
+		withDockerClient(&mockLogStreamer{data: frames.Bytes()}),
+		withPromClient(promapi.NewClient(prometheus.URL)),
+	)
+
+	for name, address := range asyncAPIAddresses(t) {
+		t.Run(name, func(t *testing.T) {
+			path, ok := resolvePath(address)
+			if !ok {
+				t.Fatalf(
+					"no fixture resolves %q — add one to pathFixtures so the walk "+
+						"covers this channel instead of skipping it",
+					address,
+				)
+			}
+
+			query, ok := asyncAPIProbeQuery[name]
+			if !ok {
+				t.Fatalf(
+					"channel %q has no entry in asyncAPIProbeQuery — add one (an "+
+						"empty string is fine) so a new channel cannot join the "+
+						"document without being probed",
+					name,
+				)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, path+query, nil)
+			req.Header.Set("Accept", "text/event-stream")
+
+			ctx, cancel := context.WithTimeout(req.Context(), 200*time.Millisecond)
+			defer cancel()
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req.WithContext(ctx))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+			}
+
+			if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+				t.Fatalf(
+					"Content-Type = %q, want text/event-stream — this address does "+
+						"not open a stream, so the document is describing one that "+
+						"does not exist",
+					got,
+				)
+			}
+		})
+	}
+}
+
+// asyncAPIProbeQuery is the query string each channel needs to open. Only
+// /metrics needs one; every other channel streams on its address alone. The
+// walk above fails on a channel missing from this map rather than skipping
+// it, so this cannot fall behind the document.
+var asyncAPIProbeQuery = map[string]string{
+	"nodes": "", "nodeDetail": "",
+	"services": "", "serviceDetail": "",
+	"tasks": "", "taskDetail": "",
+	"stacks": "", "stackDetail": "",
+	"configs": "", "configDetail": "",
+	"secrets": "", "secretDetail": "",
+	"networks": "", "networkDetail": "",
+	"volumes": "", "volumeDetail": "",
+	"events":      "",
+	"serviceLogs": "",
+	"taskLogs":    "",
+	"metrics":     "?query=up&step=15",
+}
+
+// withAsyncAPISpec wires the real document into the test router, so the tests
+// drive the document that ships rather than a stub.
+func withAsyncAPISpec(t *testing.T) routerOption {
+	t.Helper()
+
+	raw, err := os.ReadFile(asyncAPISpecPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", asyncAPISpecPath, err)
+	}
+
+	return func(cfg *RouterConfig) { cfg.AsyncAPISpec = raw }
 }

--- a/internal/api/asyncapi_test.go
+++ b/internal/api/asyncapi_test.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
-	"gopkg.in/yaml.v3"
 
-	"github.com/radiergummi/cetacean/internal/api/sse"
 	"github.com/radiergummi/cetacean/internal/cache"
 	promapi "github.com/radiergummi/cetacean/internal/prometheus"
 )
@@ -35,7 +33,12 @@ const asyncAPISpecPath = "../../api/asyncapi.yaml"
 func loadAsyncAPIDoc(t *testing.T) map[string]any {
 	t.Helper()
 
-	return loadYAMLDocument(t, asyncAPISpecPath)
+	raw, err := os.ReadFile(asyncAPISpecPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", asyncAPISpecPath, err)
+	}
+
+	return loadYAMLDocument(t, asyncAPISpecPath, raw)
 }
 
 // TestAsyncAPIDocumentIsValid validates api/asyncapi.yaml against the official
@@ -84,7 +87,8 @@ func TestAsyncAPIDocumentIsValid(t *testing.T) {
 // served, and one reference with two correct spellings is the trap
 // /.well-known/jwks.json fell into from the other direction.
 func TestAsyncAPISchemasMatchOpenAPI(t *testing.T) {
-	openAPI := loadYAMLDocument(t, "../../api/openapi.yaml")
+	specYAML, _, _ := loadTestSpec(t)
+	openAPI := loadYAMLDocument(t, "openapi.yaml", specYAML)
 	asyncAPI := loadAsyncAPIDoc(t)
 
 	for _, name := range []string{"SSEEvent", "LogLine"} {
@@ -102,23 +106,14 @@ func TestAsyncAPISchemasMatchOpenAPI(t *testing.T) {
 	}
 }
 
-// loadYAMLDocument parses any of the two specs into the same JSON shape.
-func loadYAMLDocument(t *testing.T, path string) map[string]any {
+// loadYAMLDocument parses either spec into the same JSON shape. name only
+// names the source in a failure.
+func loadYAMLDocument(t *testing.T, name string, raw []byte) map[string]any {
 	t.Helper()
 
-	raw, err := os.ReadFile(path)
+	doc, err := yamlDocument(raw)
 	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-
-	var parsed any
-	if err := yaml.Unmarshal(raw, &parsed); err != nil {
-		t.Fatalf("%s is not valid YAML: %v", path, err)
-	}
-
-	doc, ok := convertYAMLToJSON(parsed).(map[string]any)
-	if !ok {
-		t.Fatalf("%s does not parse to an object", path)
+		t.Fatalf("%s: %v", name, err)
 	}
 
 	return doc
@@ -190,29 +185,30 @@ func TestAsyncAPIIsServed(t *testing.T) {
 	}
 }
 
-// TestAsyncAPINamesTheRequestOrigin: AsyncAPI 3.0 requires host on a server
-// object, so the served document has to name the deployment. The value comes
-// from the validated origin, never from a raw forwarding header.
-func TestAsyncAPINamesTheRequestOrigin(t *testing.T) {
-	router := newTestRouterWithConfig(
-		t,
-		[]routerOption{withAsyncAPISpec(t)},
-		withCache(cache.New(nil)),
-	)
+// asyncAPIServer is the server block of the served document.
+type asyncAPIServer struct {
+	Host     string `json:"host"`
+	Protocol string `json:"protocol"`
+	Pathname string `json:"pathname"`
+}
 
-	req := httptest.NewRequest(http.MethodGet, asyncAPIPath, nil)
-	req.Host = "cetacean.example.com"
+// asyncAPIServerOf fetches the document and returns the server it names.
+func asyncAPIServerOf(t *testing.T, router http.Handler, path, host string) asyncAPIServer {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = host
 	req.Header.Set("X-Forwarded-Host", "evil.example.com")
 	rec := httptest.NewRecorder()
 
 	router.ServeHTTP(rec, req)
 
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
 	var doc struct {
-		Servers map[string]struct {
-			Host     string `json:"host"`
-			Protocol string `json:"protocol"`
-			Pathname string `json:"pathname"`
-		} `json:"servers"`
+		Servers map[string]asyncAPIServer `json:"servers"`
 	}
 
 	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
@@ -224,53 +220,72 @@ func TestAsyncAPINamesTheRequestOrigin(t *testing.T) {
 		t.Fatal("the served document names no server")
 	}
 
-	if self.Host != "cetacean.example.com" {
-		t.Errorf("host = %q, want the request's own origin", self.Host)
-	}
-
-	if self.Protocol != "http" {
-		t.Errorf("protocol = %q, want http for a plaintext request", self.Protocol)
-	}
+	return self
 }
 
-// TestAsyncAPICarriesTheBasePath: under CETACEAN_BASE_PATH every address the
-// document names is reached through the prefix, so the server object has to
-// carry it as a pathname.
-func TestAsyncAPICarriesTheBasePath(t *testing.T) {
-	router := newTestRouterWithConfig(
-		t,
-		[]routerOption{withBasePath("/cetacean"), withAsyncAPISpec(t)},
-		withCache(cache.New(nil)),
-	)
+// TestAsyncAPINamesTheDeployment: AsyncAPI 3.0 requires host on a server
+// object, so the served document has to name the deployment — from the
+// validated origin, never from a raw forwarding header — and to carry the
+// base path every address is reached through.
+func TestAsyncAPINamesTheDeployment(t *testing.T) {
+	t.Run("the request's own origin, not a forwarding header", func(t *testing.T) {
+		router := newTestRouterWithConfig(
+			t,
+			[]routerOption{withAsyncAPISpec(t)},
+			withCache(cache.New(nil)),
+		)
 
-	req := httptest.NewRequest(http.MethodGet, "/cetacean"+asyncAPIPath, nil)
-	req.Host = "cetacean.example.com"
-	rec := httptest.NewRecorder()
+		self := asyncAPIServerOf(t, router, asyncAPIPath, "cetacean.example.com")
 
-	router.ServeHTTP(rec, req)
+		if self.Host != "cetacean.example.com" {
+			t.Errorf("host = %q, want the request's own origin", self.Host)
+		}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
-	}
+		if self.Protocol != "http" {
+			t.Errorf("protocol = %q, want http for a plaintext request", self.Protocol)
+		}
 
-	var doc struct {
-		Servers map[string]struct {
-			Pathname string `json:"pathname"`
-		} `json:"servers"`
-	}
+		if self.Pathname != "" {
+			t.Errorf("pathname = %q, want none without a base path", self.Pathname)
+		}
+	})
 
-	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
-		t.Fatalf("body is not JSON: %v", err)
-	}
+	t.Run("the base path as a pathname", func(t *testing.T) {
+		router := newTestRouterWithConfig(
+			t,
+			[]routerOption{withBasePath("/cetacean"), withAsyncAPISpec(t)},
+			withCache(cache.New(nil)),
+		)
 
-	if got := doc.Servers["self"].Pathname; got != "/cetacean" {
-		t.Errorf("pathname = %q, want /cetacean", got)
-	}
+		self := asyncAPIServerOf(
+			t, router, "/cetacean"+asyncAPIPath, "cetacean.example.com",
+		)
+
+		if self.Pathname != "/cetacean" {
+			t.Errorf("pathname = %q, want /cetacean", self.Pathname)
+		}
+	})
+
+	// One rendering is retained per origin, so a second origin has to displace
+	// the first rather than be served it.
+	t.Run("a second origin is not served the first one's document", func(t *testing.T) {
+		router := newTestRouterWithConfig(
+			t,
+			[]routerOption{withAsyncAPISpec(t)},
+			withCache(cache.New(nil)),
+		)
+
+		for _, host := range []string{"one.example.com", "two.example.com", "one.example.com"} {
+			if got := asyncAPIServerOf(t, router, asyncAPIPath, host).Host; got != host {
+				t.Errorf("host = %q, want %q — a retained rendering outlived its origin", got, host)
+			}
+		}
+	})
 }
 
-// TestAsyncAPIIsDiscoverable pins both places the spec names: a typed
-// service-desc Link on every non-meta response, and a matching target in the
-// API catalog.
+// TestAsyncAPIIsDiscoverable pins the typed service-desc Link every non-meta
+// response carries. The catalog's target is walked by
+// TestAPICatalogTargetsAnswerAsAdvertised.
 func TestAsyncAPIIsDiscoverable(t *testing.T) {
 	// The stub document testRouterConfig defaults to is enough here: the Link
 	// header says nothing about the document's content.
@@ -289,8 +304,8 @@ func TestAsyncAPIIsDiscoverable(t *testing.T) {
 	}
 }
 
-// asyncAPIChannels returns the channels block, keyed as the document keys it.
-func asyncAPIChannels(t *testing.T) map[string]map[string]any {
+// asyncAPIAddresses returns every channel address, keyed by channel name.
+func asyncAPIAddresses(t *testing.T) map[string]string {
 	t.Helper()
 
 	raw, ok := loadAsyncAPIDoc(t)["channels"].(map[string]any)
@@ -298,7 +313,7 @@ func asyncAPIChannels(t *testing.T) map[string]map[string]any {
 		t.Fatal("the document declares no channels")
 	}
 
-	channels := make(map[string]map[string]any, len(raw))
+	addresses := make(map[string]string, len(raw))
 
 	for name, value := range raw {
 		channel, ok := value.(map[string]any)
@@ -306,19 +321,6 @@ func asyncAPIChannels(t *testing.T) map[string]map[string]any {
 			t.Fatalf("channel %q is not an object", name)
 		}
 
-		channels[name] = channel
-	}
-
-	return channels
-}
-
-// asyncAPIAddresses returns every channel address, keyed by channel name.
-func asyncAPIAddresses(t *testing.T) map[string]string {
-	t.Helper()
-
-	addresses := make(map[string]string)
-
-	for name, channel := range asyncAPIChannels(t) {
 		address, ok := channel["address"].(string)
 		if !ok {
 			t.Fatalf("channel %q has no address", name)
@@ -337,30 +339,18 @@ func asyncAPIAddresses(t *testing.T) map[string]string {
 // 200 for any unrouted path, so a bogus address would pass a status check. It
 // answers text/html, which this fails on.
 func TestAsyncAPIChannelsAnswerAsStreams(t *testing.T) {
-	c := cache.New(nil)
-	populateSpecFixtures(c)
-
-	broadcaster := sse.NewBroadcaster(0, noopErrorWriter, c.History())
-	t.Cleanup(broadcaster.Close)
-
 	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
 	}))
 	t.Cleanup(prometheus.Close)
 
-	var frames bytes.Buffer
-	frames.Write(buildFrame(1, "2026-01-01T00:00:00.000000000Z hello\n"))
-
-	router := newTestRouterWithCache(
-		t, c,
-		withBroadcaster(broadcaster),
-		withDockerClient(&mockLogStreamer{data: frames.Bytes()}),
-		withPromClient(promapi.NewClient(prometheus.URL)),
-	)
+	router, _, _ := streamTestRouter(t, 0, withPromClient(promapi.NewClient(prometheus.URL)))
 
 	for name, address := range asyncAPIAddresses(t) {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			path, ok := resolvePath(address)
 			if !ok {
 				t.Fatalf(
@@ -370,17 +360,7 @@ func TestAsyncAPIChannelsAnswerAsStreams(t *testing.T) {
 				)
 			}
 
-			query, ok := asyncAPIProbeQuery[name]
-			if !ok {
-				t.Fatalf(
-					"channel %q has no entry in asyncAPIProbeQuery — add one (an "+
-						"empty string is fine) so a new channel cannot join the "+
-						"document without being probed",
-					name,
-				)
-			}
-
-			req := httptest.NewRequest(http.MethodGet, path+query, nil)
+			req := httptest.NewRequest(http.MethodGet, path+asyncAPIProbeQuery[name], nil)
 			req.Header.Set("Accept", "text/event-stream")
 
 			ctx, cancel := context.WithTimeout(req.Context(), 200*time.Millisecond)

--- a/internal/api/auth_proxy_test.go
+++ b/internal/api/auth_proxy_test.go
@@ -39,6 +39,7 @@ func newProxyRouter(t *testing.T, provider auth.Provider, trusted []netip.Prefix
 		Handlers:       h,
 		Broadcaster:    b,
 		SPA:            NewSPAHandler(fs.FS(fsys), ""),
+		AsyncAPISpec:   []byte("asyncapi: '3.0.0'"),
 		AuthProvider:   provider,
 		TrustedProxies: trusted,
 	})

--- a/internal/api/csrf.go
+++ b/internal/api/csrf.go
@@ -44,6 +44,11 @@ func crossOriginProtection(cfg *CORSConfig, publicURL string) Constructor {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if carriesItsOwnProof(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			// Check rather than Handler: the stdlib's own deny path writes a
 			// plain-text 403, and its error names which branch refused the
 			// request, which is what an operator needs to fix the deployment.
@@ -54,5 +59,28 @@ func crossOriginProtection(cfg *CORSConfig, publicURL string) Constructor {
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// carriesItsOwnProof names the endpoints that authenticate from the request
+// itself — a PKCE verifier, a refresh token, a registration request, an MCP
+// bearer token — and never from a credential the browser attaches on its own.
+//
+// There is no ambient authority for a cross-origin page to borrow, so the
+// protection defends nothing here and costs the thing the MCP authorization
+// profile depends on: a browser-based client completing a token exchange from
+// its own origin. RFC 7591 registration is the case that cannot be configured
+// around, since its whole point is a client the operator has never heard of.
+//
+// Deliberately not /oauth/authorize: consent runs under the user's session
+// cookie, which is exactly the ambient credential this protects.
+func carriesItsOwnProof(path string) bool {
+	// Spelled here rather than imported: internal/api and internal/mcp
+	// deliberately do not import each other, as oauthProtectedResourcePath is.
+	switch path {
+	case "/mcp", "/oauth/token", "/oauth/revoke", "/oauth/register":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/api/csrf.go
+++ b/internal/api/csrf.go
@@ -63,20 +63,11 @@ func crossOriginProtection(cfg *CORSConfig, publicURL string) Constructor {
 }
 
 // carriesItsOwnProof names the endpoints that authenticate from the request
-// itself — a PKCE verifier, a refresh token, a registration request, an MCP
-// bearer token — and never from a credential the browser attaches on its own.
-//
-// There is no ambient authority for a cross-origin page to borrow, so the
-// protection defends nothing here and costs the thing the MCP authorization
-// profile depends on: a browser-based client completing a token exchange from
-// its own origin. RFC 7591 registration is the case that cannot be configured
-// around, since its whole point is a client the operator has never heard of.
-//
-// Deliberately not /oauth/authorize: consent runs under the user's session
-// cookie, which is exactly the ambient credential this protects.
+// body, with no ambient credential for a cross-origin page to borrow — so the
+// protection defends nothing and only breaks browser-based MCP clients.
+// /oauth/authorize is excluded: consent runs under the session cookie.
 func carriesItsOwnProof(path string) bool {
-	// Spelled here rather than imported: internal/api and internal/mcp
-	// deliberately do not import each other, as oauthProtectedResourcePath is.
+	// Spelled out because internal/api does not import internal/mcp.
 	switch path {
 	case "/mcp", "/oauth/token", "/oauth/revoke", "/oauth/register":
 		return true

--- a/internal/api/csrf.go
+++ b/internal/api/csrf.go
@@ -62,10 +62,9 @@ func crossOriginProtection(cfg *CORSConfig, publicURL string) Constructor {
 	}
 }
 
-// carriesItsOwnProof names the endpoints that authenticate from the request
-// body, with no ambient credential for a cross-origin page to borrow — so the
-// protection defends nothing and only breaks browser-based MCP clients.
-// /oauth/authorize is excluded: consent runs under the session cookie.
+// carriesItsOwnProof names endpoints that authenticate from the request body
+// rather than a cookie, so there is no ambient credential to protect.
+// /oauth/authorize is absent: consent runs under the session cookie.
 func carriesItsOwnProof(path string) bool {
 	// Spelled out because internal/api does not import internal/mcp.
 	switch path {

--- a/internal/api/csrf_test.go
+++ b/internal/api/csrf_test.go
@@ -232,3 +232,45 @@ func TestPublicURLIsTrusted(t *testing.T) {
 		})
 	}
 }
+
+// TestMachineEndpointsAreNotCrossOriginChecked: the OAuth machine endpoints
+// and the MCP transport authenticate from the request body, so there is no
+// ambient credential for a cross-origin page to borrow — and refusing them
+// breaks the browser-based MCP client the authorization profile expects.
+// /oauth/authorize is the opposite case and has to stay checked.
+func TestMachineEndpointsAreNotCrossOriginChecked(t *testing.T) {
+	for _, path := range []string{"/mcp", "/oauth/token", "/oauth/revoke", "/oauth/register"} {
+		t.Run(path, func(t *testing.T) {
+			if !carriesItsOwnProof(path) {
+				t.Errorf("%s is cross-origin checked; a browser-based client cannot reach it", path)
+			}
+		})
+	}
+
+	for _, path := range []string{"/oauth/authorize", "/services/svc1/restart", "/auth/logout"} {
+		t.Run("still checked: "+path, func(t *testing.T) {
+			if carriesItsOwnProof(path) {
+				t.Errorf("%s runs under an ambient credential and must stay checked", path)
+			}
+		})
+	}
+}
+
+// TestExemptMachineEndpointPassesTheAssembledChain drives the composed router,
+// so a cross-site POST to an exempt path is visibly not refused by CSR001.
+func TestExemptMachineEndpointPassesTheAssembledChain(t *testing.T) {
+	router := newCSRFTestRouter(t)
+
+	req := httptest.NewRequest("POST", "/oauth/token", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", "https://inspector.example.com")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	// MCP is off in this fixture, so the route is absent — 404 is fine. What
+	// must not happen is a cross-origin refusal.
+	if rec.Code == http.StatusForbidden {
+		t.Errorf("the token endpoint was refused cross-origin: %s", rec.Body.String())
+	}
+}

--- a/internal/api/csv_columns.go
+++ b/internal/api/csv_columns.go
@@ -110,11 +110,6 @@ func csvTableForRecommendations(results []recommendations.Recommendation) csvTab
 	}
 
 	for _, result := range results {
-		suggested := ""
-		if result.Suggested != nil {
-			suggested = csvNumber(*result.Suggested)
-		}
-
 		table.records = append(table.records, []string{
 			string(result.Severity),
 			string(result.Category),
@@ -124,21 +119,22 @@ func csvTableForRecommendations(results []recommendations.Recommendation) csvTab
 			result.Message,
 			csvNumber(result.Current),
 			csvNumber(result.Configured),
-			suggested,
+			csvNumber(result.Suggested),
 		})
 	}
 
 	return table
 }
 
-// csvNumber leaves an absent measurement blank: a column of zeroes would read
-// as measured.
-func csvNumber(value float64) string {
-	if value == 0 {
+// csvNumber leaves an absent measurement blank and writes a present one, zero
+// included: a service using no CPU measured zero, and blanking that reads as
+// though nothing was measured.
+func csvNumber(value *float64) string {
+	if value == nil {
 		return ""
 	}
 
-	return strconv.FormatFloat(value, 'f', -1, 64)
+	return strconv.FormatFloat(*value, 'f', -1, 64)
 }
 
 func csvTableForRows(resourceType string, rows []cluster.Row) csvTable {

--- a/internal/api/csv_test.go
+++ b/internal/api/csv_test.go
@@ -471,6 +471,67 @@ func TestHistoryCSV(t *testing.T) {
 	}
 }
 
+// TestRecommendationCSVDistinguishesZeroFromAbsent: a service using no CPU
+// measures zero, and blanking that reads as though nothing was measured — the
+// confusion the blank is there to avoid, inverted.
+func TestRecommendationCSVDistinguishesZeroFromAbsent(t *testing.T) {
+	engine := recommendations.NewEngine(&stubChecker{results: []recommendations.Recommendation{
+		{
+			Category:   recommendations.CategoryOverProvisioned,
+			Severity:   recommendations.SeverityWarning,
+			Scope:      recommendations.ScopeService,
+			TargetID:   "s1",
+			TargetName: "idle",
+			Resource:   "cpu",
+			Message:    "idle uses no CPU at all",
+			Current:    new(float64(0)),
+			Configured: new(float64(1e9)),
+		},
+		{
+			Category:   recommendations.CategoryNoLimits,
+			Severity:   recommendations.SeverityWarning,
+			Scope:      recommendations.ScopeService,
+			TargetID:   "s2",
+			TargetName: "unmeasured",
+			Resource:   "cpu",
+			Message:    "unmeasured has no CPU limit set",
+		},
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	engine.Run(ctx)
+
+	router := newTestRouterWithCache(t, cache.New(nil), withRecEngine(engine))
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest("GET", "/recommendations.csv", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	records := csvRecords(t, rec.Body.String())
+	if len(records) != 3 {
+		t.Fatalf("got %d records, want a header and two findings", len(records))
+	}
+
+	const current = 6
+
+	byTarget := map[string][]string{}
+	for _, record := range records[1:] {
+		byTarget[record[3]] = record
+	}
+
+	if got := byTarget["idle"][current]; got != "0" {
+		t.Errorf("a measured zero renders as %q, want \"0\"", got)
+	}
+
+	if got := byTarget["unmeasured"][current]; got != "" {
+		t.Errorf("an unmeasured value renders as %q, want blank", got)
+	}
+}
+
 func TestRecommendationsCSV(t *testing.T) {
 	suggested := 512.0
 	engine := recommendations.NewEngine(&stubChecker{results: []recommendations.Recommendation{{
@@ -481,8 +542,8 @@ func TestRecommendationsCSV(t *testing.T) {
 		TargetName: "api",
 		Resource:   "memory",
 		Message:    "api is over-provisioned, by a lot",
-		Current:    128,
-		Configured: 1024,
+		Current:    new(float64(128)),
+		Configured: new(float64(1024)),
 		Suggested:  &suggested,
 	}}})
 

--- a/internal/api/dispatch.go
+++ b/internal/api/dispatch.go
@@ -20,8 +20,8 @@ type feedHandlers struct {
 	// has already prepared.
 	csv bool
 
-	// csvParams names the query parameters the CSV reads, for the alternate
-	// link. Empty on a sub-collection that takes none.
+	// csvParams names what the CSV reads, for the alternate link. Empty on a
+	// sub-collection that takes none.
 	csvParams []string
 
 	queryParams []string

--- a/internal/api/dispatch.go
+++ b/internal/api/dispatch.go
@@ -20,6 +20,10 @@ type feedHandlers struct {
 	// has already prepared.
 	csv bool
 
+	// csvParams names the query parameters the CSV reads, for the alternate
+	// link. Empty on a sub-collection that takes none.
+	csvParams []string
+
 	queryParams []string
 }
 
@@ -166,10 +170,9 @@ func addFeedLinks(w http.ResponseWriter, r *http.Request, feeds feedHandlers) {
 	basePath := absPath(r.Context(), r.URL.Path)
 
 	if feeds.csv {
-		// No query: the CSV reads the same parameters this request did.
 		w.Header().Add("Link", fmt.Sprintf(
 			`<%s>; rel="alternate"; type="text/csv"`,
-			basePath+".csv",
+			feedHref(basePath+".csv", keptQuery(r, feeds.csvParams)),
 		))
 	}
 

--- a/internal/api/dispatch_test.go
+++ b/internal/api/dispatch_test.go
@@ -335,4 +335,35 @@ func TestContentNegotiatedCSV(t *testing.T) {
 			t.Errorf("expected a text/csv alternate in Link, got %q", links)
 		}
 	})
+
+	// The CSV comes off the list the JSON handler prepared, so an alternate
+	// that dropped the query would hand back every row instead of the ones
+	// the caller is looking at.
+	t.Run("the CSV alternate carries the parameters the CSV reads", func(t *testing.T) {
+		handler := contentNegotiated(
+			jsonH,
+			feedHandlers{csv: true, csvParams: listCSVParams},
+			spa,
+		)
+		req := withContentType(
+			httptest.NewRequest("GET", "/services?search=web&sort=name&nonsense=x", nil),
+			ContentTypeJSON,
+		)
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		links := strings.Join(rec.Header().Values("Link"), ", ")
+
+		for _, want := range []string{"search=web", "sort=name"} {
+			if !strings.Contains(links, want) {
+				t.Errorf("the CSV alternate drops %q: %q", want, links)
+			}
+		}
+
+		// Only the declared parameters: the rest of the raw query is not
+		// reflected back into a compressed response.
+		if strings.Contains(links, "nonsense") {
+			t.Errorf("the CSV alternate reflects an undeclared parameter: %q", links)
+		}
+	})
 }

--- a/internal/api/dispatch_test.go
+++ b/internal/api/dispatch_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/radiergummi/cetacean/internal/cache"
 )
 
 func TestContentNegotiatedAtom(t *testing.T) {
@@ -366,4 +368,29 @@ func TestContentNegotiatedCSV(t *testing.T) {
 			t.Errorf("the CSV alternate reflects an undeclared parameter: %q", links)
 		}
 	})
+}
+
+// TestAssembledRouterCarriesCSVParams drives the real router, because the test
+// above builds feedHandlers itself and so cannot see a route that forgot to
+// declare csvParams — which is exactly what a rebase dropped once.
+func TestAssembledRouterCarriesCSVParams(t *testing.T) {
+	router := newTestRouterWithCache(t, cache.New(nil))
+
+	for path, want := range map[string]string{
+		"/services?search=web&sort=name": "search=web",
+		"/history?type=service":          "type=service",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", path, nil)
+			req.Header.Set("Accept", "application/json")
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			links := strings.Join(rec.Header().Values("Link"), ", ")
+			if !strings.Contains(links, want) {
+				t.Errorf("the CSV alternate drops %q: %q", want, links)
+			}
+		})
+	}
 }

--- a/internal/api/feed_handlers.go
+++ b/internal/api/feed_handlers.go
@@ -451,25 +451,37 @@ var feedPaginationParams = []string{"before", "limit"}
 // searchFeedParams names the parameter only the search feed reads.
 var searchFeedParams = []string{"q"}
 
+// listCSVParams names the query parameters a list endpoint reads (searchFilter,
+// exprFilter, parsePagination). The CSV comes off the list its JSON handler
+// prepared, so its advertised alternate has to carry them or it points at a
+// different set of rows.
+var listCSVParams = []string{"search", "filter", "sort", "dir", "limit", "offset"}
+
+// historyCSVParams names what HandleHistory reads.
+var historyCSVParams = []string{"type", "resourceId", "limit"}
+
 // feedQuery returns the subset of r's query a feed's links may carry: the
 // pagination pair every feed reads, plus whatever else the caller declares.
-//
-// Reflecting the rest of the raw query into a compressed feed beside
-// ACL-filtered resource names is the BREACH shape.
 func feedQuery(r *http.Request, extra []string) url.Values {
-	source := r.URL.Query()
-	kept := make(url.Values, len(feedPaginationParams)+len(extra))
+	return keptQuery(r, feedPaginationParams, extra)
+}
 
-	keep := func(names []string) {
-		for _, name := range names {
+// keptQuery returns the values of the named parameters, and nothing else.
+//
+// Reflecting the rest of the raw query into a compressed response beside
+// ACL-filtered resource names is the BREACH shape, so every link built here
+// names what it carries.
+func keptQuery(r *http.Request, names ...[]string) url.Values {
+	source := r.URL.Query()
+	kept := url.Values{}
+
+	for _, set := range names {
+		for _, name := range set {
 			if values, ok := source[name]; ok {
 				kept[name] = values
 			}
 		}
 	}
-
-	keep(feedPaginationParams)
-	keep(extra)
 
 	return kept
 }

--- a/internal/api/feed_handlers.go
+++ b/internal/api/feed_handlers.go
@@ -451,10 +451,8 @@ var feedPaginationParams = []string{"before", "limit"}
 // searchFeedParams names the parameter only the search feed reads.
 var searchFeedParams = []string{"q"}
 
-// listCSVParams names the query parameters a list endpoint reads (searchFilter,
-// exprFilter, parsePagination). The CSV comes off the list its JSON handler
-// prepared, so its advertised alternate has to carry them or it points at a
-// different set of rows.
+// listCSVParams names what a list endpoint reads. The CSV comes off the list
+// its JSON handler prepared, so the alternate link has to carry them.
 var listCSVParams = []string{"search", "filter", "sort", "dir", "limit", "offset"}
 
 // historyCSVParams names what HandleHistory reads.
@@ -466,11 +464,8 @@ func feedQuery(r *http.Request, extra []string) url.Values {
 	return keptQuery(r, feedPaginationParams, extra)
 }
 
-// keptQuery returns the values of the named parameters, and nothing else.
-//
-// Reflecting the rest of the raw query into a compressed response beside
-// ACL-filtered resource names is the BREACH shape, so every link built here
-// names what it carries.
+// keptQuery returns the values of the named parameters, and nothing else:
+// reflecting a raw query into a compressed response is the BREACH shape.
 func keptQuery(r *http.Request, names ...[]string) url.Values {
 	source := r.URL.Query()
 	kept := url.Values{}

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/klauspost/compress/zstd"
 
@@ -29,6 +30,7 @@ type testHandlersConfig struct {
 	pluginClient    DockerPluginClient
 	ready           <-chan struct{}
 	promClient      *prometheus.Client
+	tickerInterval  time.Duration
 	operationsLevel config.OperationsLevel
 	aclEval         *acl.Evaluator
 	recEngine       *recommendations.Engine
@@ -50,6 +52,12 @@ func withOpsLevel(level config.OperationsLevel) testHandlersOption {
 
 func withPromClient(pc *prometheus.Client) testHandlersOption {
 	return func(cfg *testHandlersConfig) { cfg.promClient = pc }
+}
+
+// withTickerInterval shortens the metrics stream's poll so a test sees a
+// point event. Unset, the stream ticks every `step` seconds.
+func withTickerInterval(d time.Duration) testHandlersOption {
+	return func(cfg *testHandlersConfig) { cfg.tickerInterval = d }
 }
 
 func withReady(ch <-chan struct{}) testHandlersOption {
@@ -96,7 +104,7 @@ func newTestHandlers(t testing.TB, opts ...testHandlersOption) *Handlers {
 		opt(&cfg)
 	}
 
-	return NewHandlers(
+	h := NewHandlers(
 		cfg.cache,
 		cfg.broadcaster,
 		cfg.dockerClient,
@@ -109,6 +117,10 @@ func newTestHandlers(t testing.TB, opts ...testHandlersOption) *Handlers {
 		cfg.recEngine,
 		cfg.aclEval,
 	)
+
+	h.tickerInterval = cfg.tickerInterval
+
+	return h
 }
 
 // decodeZstd decompresses a zstd response body, failing the test if it is

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 	"testing/fstest"
-	"time"
 
 	"github.com/klauspost/compress/zstd"
 
@@ -30,7 +29,6 @@ type testHandlersConfig struct {
 	pluginClient    DockerPluginClient
 	ready           <-chan struct{}
 	promClient      *prometheus.Client
-	tickerInterval  time.Duration
 	operationsLevel config.OperationsLevel
 	aclEval         *acl.Evaluator
 	recEngine       *recommendations.Engine
@@ -52,12 +50,6 @@ func withOpsLevel(level config.OperationsLevel) testHandlersOption {
 
 func withPromClient(pc *prometheus.Client) testHandlersOption {
 	return func(cfg *testHandlersConfig) { cfg.promClient = pc }
-}
-
-// withTickerInterval shortens the metrics stream's poll so a test sees a
-// point event. Unset, the stream ticks every `step` seconds.
-func withTickerInterval(d time.Duration) testHandlersOption {
-	return func(cfg *testHandlersConfig) { cfg.tickerInterval = d }
 }
 
 func withReady(ch <-chan struct{}) testHandlersOption {
@@ -104,7 +96,7 @@ func newTestHandlers(t testing.TB, opts ...testHandlersOption) *Handlers {
 		opt(&cfg)
 	}
 
-	h := NewHandlers(
+	return NewHandlers(
 		cfg.cache,
 		cfg.broadcaster,
 		cfg.dockerClient,
@@ -117,10 +109,6 @@ func newTestHandlers(t testing.TB, opts ...testHandlersOption) *Handlers {
 		cfg.recEngine,
 		cfg.aclEval,
 	)
-
-	h.tickerInterval = cfg.tickerInterval
-
-	return h
 }
 
 // decodeZstd decompresses a zstd response body, failing the test if it is

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -264,6 +264,7 @@ func testRouterConfig(
 		Broadcaster:       b,
 		SPA:               spa,
 		OpenAPISpec:       []byte("openapi: '3.1.0'"),
+		AsyncAPISpec:      []byte("asyncapi: '3.0.0'"),
 		EnableSelfMetrics: true,
 		AuthProvider:      &auth.NoneProvider{},
 	}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -48,6 +48,7 @@ func setupIntegrationRouter(t *testing.T) http.Handler {
 		Broadcaster:       b,
 		SPA:               spa,
 		OpenAPISpec:       specBytes,
+		AsyncAPISpec:      []byte("asyncapi: '3.0.0'"),
 		ScalarJS:          []byte("/* scalar */"),
 		EnableSelfMetrics: true,
 		AuthProvider:      &auth.NoneProvider{},

--- a/internal/api/metricsstream_test.go
+++ b/internal/api/metricsstream_test.go
@@ -85,6 +85,9 @@ func TestMetricsStream_StreamsEvents(t *testing.T) {
 	if !strings.Contains(body, "event: point") {
 		t.Error("expected at least one point event in body")
 	}
+	if strings.Contains(body, "\nid: ") {
+		t.Error("metrics frames carry no id; this stream writes none")
+	}
 	if queryCount.Load() < 2 {
 		t.Errorf(
 			"expected at least 2 Prometheus calls (range + instant), got %d",
@@ -171,5 +174,8 @@ func TestMetricsStream_ErrorEvent(t *testing.T) {
 	}
 	if !strings.Contains(body, "server_error") {
 		t.Error("expected errorType in error event data")
+	}
+	if strings.Contains(body, "\nid: ") {
+		t.Error("metrics frames carry no id; this stream writes none")
 	}
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -100,9 +100,12 @@ func discoveryLinks(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/-/") {
 			ctx := r.Context()
-			w.Header().Add("Link", fmt.Sprintf(`<%s>; rel="service-desc"`, absPath(ctx, "/api")))
 			// RFC 8631 does not limit service-desc to one link; the type
-			// parameter tells a client which description it is offered.
+			// parameter is what tells the two descriptions apart, so both
+			// carry one.
+			w.Header().Add("Link", fmt.Sprintf(
+				`<%s>; rel="service-desc"; type="application/json"`, absPath(ctx, "/api"),
+			))
 			w.Header().Add("Link", fmt.Sprintf(
 				`<%s>; rel="service-desc"; type="%s"`,
 				absPath(ctx, asyncAPIPath), asyncAPIMediaType,

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -101,6 +101,12 @@ func discoveryLinks(next http.Handler) http.Handler {
 		if !strings.HasPrefix(r.URL.Path, "/-/") {
 			ctx := r.Context()
 			w.Header().Add("Link", fmt.Sprintf(`<%s>; rel="service-desc"`, absPath(ctx, "/api")))
+			// RFC 8631 does not limit service-desc to one link; the type
+			// parameter tells a client which description it is offered.
+			w.Header().Add("Link", fmt.Sprintf(
+				`<%s>; rel="service-desc"; type="%s"`,
+				absPath(ctx, asyncAPIPath), asyncAPIMediaType,
+			))
 			w.Header().Add("Link", fmt.Sprintf(
 				`<%s>; rel="describedby"`, absPath(ctx, "/api/context.jsonld"),
 			))

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -185,7 +185,7 @@ func TestDiscoveryLinks_AddedToAPIRoutes(t *testing.T) {
 		"api-catalog":           false,
 	}
 	for _, link := range links {
-		if link == `</api>; rel="service-desc"` {
+		if link == `</api>; rel="service-desc"; type="application/json"` {
 			found["service-desc"] = true
 		}
 		if link == `</api/asyncapi>; rel="service-desc"; type="`+asyncAPIMediaType+`"` {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -175,17 +175,21 @@ func TestDiscoveryLinks_AddedToAPIRoutes(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	links := w.Header().Values("Link")
-	if len(links) != 3 {
-		t.Fatalf("expected 3 Link headers, got %d: %v", len(links), links)
+	if len(links) != 4 {
+		t.Fatalf("expected 4 Link headers, got %d: %v", len(links), links)
 	}
 	found := map[string]bool{
-		"service-desc": false,
-		"describedby":  false,
-		"api-catalog":  false,
+		"service-desc":          false,
+		"service-desc-asyncapi": false,
+		"describedby":           false,
+		"api-catalog":           false,
 	}
 	for _, link := range links {
 		if link == `</api>; rel="service-desc"` {
 			found["service-desc"] = true
+		}
+		if link == `</api/asyncapi>; rel="service-desc"; type="`+asyncAPIMediaType+`"` {
+			found["service-desc-asyncapi"] = true
 		}
 		if link == `</api/context.jsonld>; rel="describedby"` {
 			found["describedby"] = true
@@ -311,6 +315,7 @@ func TestNewRouter_Smoke(t *testing.T) {
 		MetricsProxy:      prom,
 		SPA:               spa,
 		OpenAPISpec:       []byte("openapi: '3.1.0'"),
+		AsyncAPISpec:      []byte("asyncapi: '3.0.0'"),
 		EnableSelfMetrics: true,
 		AuthProvider:      &auth.NoneProvider{},
 	})
@@ -395,6 +400,7 @@ func TestVaryAccumulatesAcrossMiddleware(t *testing.T) {
 		Broadcaster:       b,
 		SPA:               spa,
 		OpenAPISpec:       []byte("openapi: '3.1.0'"),
+		AsyncAPISpec:      []byte("asyncapi: '3.0.0'"),
 		EnableSelfMetrics: true,
 		AuthProvider:      &auth.NoneProvider{},
 		CORS:              &CORSConfig{AllowedOrigins: []string{"https://example.test"}},

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -21,9 +21,7 @@ const (
 	ContentTypeDOT
 	ContentTypeCSV
 
-	// ContentTypeYAML is the form both specification documents are authored
-	// in. Only /api and /api/asyncapi serve it; nothing else in the API has a
-	// YAML representation.
+	// ContentTypeYAML is served by the two specification documents only.
 	ContentTypeYAML
 
 	// ContentTypeUnsupported means no supported media type matched. What to
@@ -117,11 +115,9 @@ var supportedTypes = []struct {
 	{"text", "vnd.graphviz", ContentTypeDOT},
 	// After text/html, so a text/* wildcard still resolves to HTML.
 	{"text", "csv", ContentTypeCSV},
-	// The specification documents. A client naming a vendor type is asking
-	// for that document; the generic spellings ask only for the format, and
-	// each endpoint answers with its own document and says so in the response
-	// Content-Type. All of them after application/json, so an application/*
-	// wildcard still resolves to JSON.
+	// The specification documents, served by /api and /api/asyncapi only.
+	// After application/json, so an application/* wildcard still resolves to
+	// JSON.
 	{"application", "vnd.oai.openapi", ContentTypeYAML},
 	{"application", "openapi+yaml", ContentTypeYAML},
 	{"application", "vnd.aai.asyncapi+yaml", ContentTypeYAML},

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -118,6 +118,16 @@ var supportedTypes = []struct {
 	// The specification documents, served by /api and /api/asyncapi only.
 	// After application/json, so an application/* wildcard still resolves to
 	// JSON.
+	//
+	// Both halves of each pair are named. Registering only the +yaml spelling
+	// would resolve `Accept: …+json, …+yaml` — the pair an AsyncAPI tool sends
+	// — to YAML, since the JSON half would match nothing and the YAML half
+	// would win by default; and it would leave /api answering 406 to the
+	// registered JSON type for an OpenAPI document.
+	{"application", "vnd.oai.openapi+json", ContentTypeJSON},
+	{"application", "openapi+json", ContentTypeJSON},
+	{"application", "vnd.aai.asyncapi+json", ContentTypeJSON},
+	{"application", "asyncapi+json", ContentTypeJSON},
 	{"application", "vnd.oai.openapi", ContentTypeYAML},
 	{"application", "openapi+yaml", ContentTypeYAML},
 	{"application", "vnd.aai.asyncapi+yaml", ContentTypeYAML},

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -21,6 +21,11 @@ const (
 	ContentTypeDOT
 	ContentTypeCSV
 
+	// ContentTypeYAML is the form both specification documents are authored
+	// in. Only /api and /api/asyncapi serve it; nothing else in the API has a
+	// YAML representation.
+	ContentTypeYAML
+
 	// ContentTypeUnsupported means no supported media type matched. What to
 	// do about it is the endpoint's to decide.
 	ContentTypeUnsupported ContentType = -1
@@ -46,6 +51,8 @@ func (ct ContentType) String() string {
 		return "DOT"
 	case ContentTypeCSV:
 		return "CSV"
+	case ContentTypeYAML:
+		return "YAML"
 	case ContentTypeUnsupported:
 		return "Unsupported"
 	default:
@@ -110,6 +117,20 @@ var supportedTypes = []struct {
 	{"text", "vnd.graphviz", ContentTypeDOT},
 	// After text/html, so a text/* wildcard still resolves to HTML.
 	{"text", "csv", ContentTypeCSV},
+	// The specification documents. A client naming a vendor type is asking
+	// for that document; the generic spellings ask only for the format, and
+	// each endpoint answers with its own document and says so in the response
+	// Content-Type. All of them after application/json, so an application/*
+	// wildcard still resolves to JSON.
+	{"application", "vnd.oai.openapi", ContentTypeYAML},
+	{"application", "openapi+yaml", ContentTypeYAML},
+	{"application", "vnd.aai.asyncapi+yaml", ContentTypeYAML},
+	{"application", "asyncapi+yaml", ContentTypeYAML},
+	{"application", "yaml", ContentTypeYAML},
+	{"application", "x-yaml", ContentTypeYAML},
+	// After text/html and text/csv, for the same wildcard reason.
+	{"text", "yaml", ContentTypeYAML},
+	{"text", "x-yaml", ContentTypeYAML},
 }
 
 // extensionTypes maps URL extension suffixes to content types.

--- a/internal/api/openapi_exhaustive_test.go
+++ b/internal/api/openapi_exhaustive_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 
 	"github.com/radiergummi/cetacean/internal/api/sbom"
@@ -154,6 +155,45 @@ func TestEveryReadEndpointMatchesSpec(t *testing.T) {
 		"validated=%d non-2xx=%d unresolved-params=%d",
 		validated, nonSuccess, unresolved,
 	)
+}
+
+// The two description documents answer with their own registered media types,
+// which kin-openapi has no decoder for — it would report the document as an
+// undecodable body rather than validating it against the spec that declares
+// it. Registering them here is what brings /api/openapi.yaml, /api/asyncapi
+// and /api/asyncapi.yaml into the walk instead of being skipped out of it.
+func init() {
+	yamlDecoder := func(
+		body io.Reader,
+		_ http.Header,
+		_ *openapi3.SchemaRef,
+		_ openapi3filter.EncodingFn,
+	) (any, error) {
+		raw, err := io.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
+
+		return string(raw), nil
+	}
+
+	jsonDecoder := func(
+		body io.Reader,
+		_ http.Header,
+		_ *openapi3.SchemaRef,
+		_ openapi3filter.EncodingFn,
+	) (any, error) {
+		var decoded any
+		if err := json.NewDecoder(body).Decode(&decoded); err != nil {
+			return nil, err
+		}
+
+		return decoded, nil
+	}
+
+	openapi3filter.RegisterBodyDecoder(openAPIYAMLMediaType, yamlDecoder)
+	openapi3filter.RegisterBodyDecoder("application/vnd.aai.asyncapi+yaml", yamlDecoder)
+	openapi3filter.RegisterBodyDecoder(asyncAPIMediaTypeBase, jsonDecoder)
 }
 
 // skipEndpoint returns true for paths that can't be exercised by a generic

--- a/internal/api/openapi_exhaustive_test.go
+++ b/internal/api/openapi_exhaustive_test.go
@@ -157,11 +157,9 @@ func TestEveryReadEndpointMatchesSpec(t *testing.T) {
 	)
 }
 
-// The two description documents answer with their own registered media types,
-// which kin-openapi has no decoder for — it would report the document as an
-// undecodable body rather than validating it against the spec that declares
-// it. Registering them here is what brings /api/openapi.yaml, /api/asyncapi
-// and /api/asyncapi.yaml into the walk instead of being skipped out of it.
+// kin-openapi has no decoder for the descriptions' own media types, and would
+// call them undecodable bodies rather than validate them. Registering these is
+// what keeps the three /api documents in the walk.
 func init() {
 	yamlDecoder := func(
 		body io.Reader,

--- a/internal/api/openapi_helpers_test.go
+++ b/internal/api/openapi_helpers_test.go
@@ -108,6 +108,7 @@ func newTestRouter(
 		Broadcaster:       broadcaster,
 		SPA:               noopSPA,
 		OpenAPISpec:       specBytes,
+		AsyncAPISpec:      []byte("asyncapi: '3.0.0'"),
 		EnableSelfMetrics: true,
 		AuthProvider:      &auth.NoneProvider{},
 	})

--- a/internal/api/opensearch_test.go
+++ b/internal/api/opensearch_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/radiergummi/cetacean/internal/cache"
 )
 
 // parsedOpenSearch is the document read back off the wire, declared separately
@@ -183,4 +185,46 @@ func TestOpenSearchIsAbsoluteUnderABasePath(t *testing.T) {
 			t.Errorf("the %s template %q does not carry the base path", u.Type, u.Template)
 		}
 	}
+}
+
+// TestDiscoveryDocumentsAnswerWhileDockerIsDown: these read no cluster state,
+// and a client probing a server it cannot reach is exactly when they are worth
+// having. requireReady used to refuse them with ENG001.
+func TestDiscoveryDocumentsAnswerWhileDockerIsDown(t *testing.T) {
+	// A ready channel nobody closes is a server whose first sync has not
+	// landed, which is what an unreachable Docker socket looks like.
+	notReady := make(chan struct{})
+
+	router := newTestRouterWithCache(t, cache.New(nil), withReady(notReady))
+
+	for _, path := range []string{openSearchPath, apiCatalogPath} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Accept", "*/*")
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+			}
+
+			if strings.Contains(rec.Body.String(), "ENG001") {
+				t.Errorf("refused as unready: %s", rec.Body.String())
+			}
+		})
+	}
+
+	// The exemption is for the discovery documents, not a hole in readiness.
+	t.Run("a resource path is still refused", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/nodes", nil)
+		req.Header.Set("Accept", "application/json")
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		if !strings.Contains(rec.Body.String(), "ENG001") {
+			t.Errorf("a resource path answered while unready: %d %s", rec.Code, rec.Body.String())
+		}
+	})
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -63,9 +63,10 @@ type RouterConfig struct {
 // them renders its rows as CSV.
 func (h *Handlers) listFeeds(title string, eventType cache.EventType) feedHandlers {
 	return feedHandlers{
-		atom:     h.feedListHandler(title, eventType, renderAtom),
-		jsonFeed: h.feedListHandler(title, eventType, renderJSONFeed),
-		csv:      true,
+		atom:      h.feedListHandler(title, eventType, renderAtom),
+		jsonFeed:  h.feedListHandler(title, eventType, renderJSONFeed),
+		csv:       true,
+		csvParams: listCSVParams,
 	}
 }
 
@@ -598,9 +599,10 @@ func newRouter(cfg RouterConfig) (http.Handler, []string) {
 
 	// History
 	mux.HandleFunc("GET /history", contentNegotiated(h.HandleHistory, feedHandlers{
-		atom:     h.feedHistoryHandler(renderAtom),
-		jsonFeed: h.feedHistoryHandler(renderJSONFeed),
-		csv:      true,
+		atom:      h.feedHistoryHandler(renderAtom),
+		jsonFeed:  h.feedHistoryHandler(renderJSONFeed),
+		csv:       true,
+		csvParams: historyCSVParams,
 	}, spa))
 
 	// Stacks

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -249,10 +249,14 @@ func newRouter(cfg RouterConfig) (http.Handler, []string) {
 	))
 
 	// API documentation (content-negotiated)
-	mux.HandleFunc("GET /api", HandleAPIDoc(cfg.OpenAPISpec))
+	apiDoc, openAPIYAML := HandleAPIDoc(cfg.OpenAPISpec)
+	mux.HandleFunc("GET /api", apiDoc)
+	mux.HandleFunc("GET "+openAPIYAMLPath, openAPIYAML)
 	mux.HandleFunc("GET /api/scalar.js", HandleScalarJS(cfg.ScalarJS))
 	mux.HandleFunc("GET /api/context.jsonld", HandleContext)
-	mux.HandleFunc("GET "+asyncAPIPath, HandleAsyncAPI(cfg.AsyncAPISpec))
+	asyncAPI, asyncAPIYAML := HandleAsyncAPI(cfg.AsyncAPISpec)
+	mux.HandleFunc("GET "+asyncAPIPath, asyncAPI)
+	mux.HandleFunc("GET "+asyncAPIYAMLPath, asyncAPIYAML)
 	mux.HandleFunc("GET "+openSearchPath, HandleOpenSearch)
 	mux.HandleFunc("GET "+apiCatalogPath, HandleAPICatalog(catalogMounts{
 		mcp:           cfg.MCPHandler != nil,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -32,6 +32,7 @@ type RouterConfig struct {
 	MetricsProxy      *prometheus.Proxy
 	SPA               http.Handler
 	OpenAPISpec       []byte
+	AsyncAPISpec      []byte
 	ScalarJS          []byte
 	EnablePprof       bool
 	EnableSelfMetrics bool
@@ -251,6 +252,7 @@ func newRouter(cfg RouterConfig) (http.Handler, []string) {
 	mux.HandleFunc("GET /api", HandleAPIDoc(cfg.OpenAPISpec))
 	mux.HandleFunc("GET /api/scalar.js", HandleScalarJS(cfg.ScalarJS))
 	mux.HandleFunc("GET /api/context.jsonld", HandleContext)
+	mux.HandleFunc("GET "+asyncAPIPath, HandleAsyncAPI(cfg.AsyncAPISpec))
 	mux.HandleFunc("GET "+openSearchPath, HandleOpenSearch)
 	mux.HandleFunc("GET "+apiCatalogPath, HandleAPICatalog(catalogMounts{
 		mcp:           cfg.MCPHandler != nil,

--- a/internal/api/testdata/asyncapi-3.0.0.json
+++ b/internal/api/testdata/asyncapi-3.0.0.json
@@ -1,0 +1,9077 @@
+{
+    "$id": "http://asyncapi.com/definitions/3.0.0/asyncapi.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "AsyncAPI 3.0.0 schema.",
+    "type": "object",
+    "required": [
+        "asyncapi",
+        "info"
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+        }
+    },
+    "properties": {
+        "asyncapi": {
+            "type": "string",
+            "const": "3.0.0",
+            "description": "The AsyncAPI specification version of this document."
+        },
+        "id": {
+            "type": "string",
+            "description": "A unique id representing the application.",
+            "format": "uri"
+        },
+        "info": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/info.json"
+        },
+        "servers": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/servers.json"
+        },
+        "defaultContentType": {
+            "type": "string",
+            "description": "Default content type to use when encoding/decoding a message's payload."
+        },
+        "channels": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/channels.json"
+        },
+        "operations": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/operations.json"
+        },
+        "components": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/components.json"
+        }
+    },
+    "definitions": {
+        "http://asyncapi.com/definitions/3.0.0/specificationExtension.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json",
+            "description": "Any property starting with x- is valid.",
+            "additionalProperties": true,
+            "additionalItems": true
+        },
+        "http://asyncapi.com/definitions/3.0.0/info.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/info.json",
+            "description": "The object provides metadata about the API. The metadata can be used by the clients if needed.",
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "version",
+                        "title"
+                    ],
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "A unique and precise title of the API."
+                        },
+                        "version": {
+                            "type": "string",
+                            "description": "A semantic version number of the API."
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
+                        },
+                        "termsOfService": {
+                            "type": "string",
+                            "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+                            "format": "uri"
+                        },
+                        "contact": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/contact.json"
+                        },
+                        "license": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/license.json"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "description": "A list of tags for application API documentation control. Tags can be used for logical grouping of applications.",
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                    },
+                                    {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/infoExtensions.json"
+                }
+            ],
+            "examples": [
+                {
+                    "title": "AsyncAPI Sample App",
+                    "version": "1.0.1",
+                    "description": "This is a sample app.",
+                    "termsOfService": "https://asyncapi.org/terms/",
+                    "contact": {
+                        "name": "API Support",
+                        "url": "https://www.asyncapi.org/support",
+                        "email": "support@asyncapi.org"
+                    },
+                    "license": {
+                        "name": "Apache 2.0",
+                        "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                    },
+                    "externalDocs": {
+                        "description": "Find more info here",
+                        "url": "https://www.asyncapi.org"
+                    },
+                    "tags": [
+                        {
+                            "name": "e-commerce"
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/contact.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/contact.json",
+            "type": "object",
+            "description": "Contact information for the exposed API.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The identifying name of the contact person/organization."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the contact information.",
+                    "format": "uri"
+                },
+                "email": {
+                    "type": "string",
+                    "description": "The email address of the contact person/organization.",
+                    "format": "email"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "API Support",
+                    "url": "https://www.example.com/support",
+                    "email": "support@example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/license.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/license.json",
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the license.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "Apache 2.0",
+                    "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/Reference.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/Reference.json",
+            "type": "object",
+            "description": "A simple object to allow referencing other components in the specification, internally and externally.",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "description": "The reference string.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "$ref": "#/components/schemas/Pet"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json",
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "http://asyncapi.com/definitions/3.0.0/tag.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/tag.json",
+            "type": "object",
+            "description": "Allows adding metadata to a single tag.",
+            "additionalProperties": false,
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the tag."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for the tag. CommonMark syntax can be used for rich text representation."
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "user",
+                    "description": "User-related messages"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/externalDocs.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/externalDocs.json",
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Allows referencing an external resource for extended documentation.",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A short description of the target documentation. CommonMark syntax can be used for rich text representation."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL for the target documentation. This MUST be in the form of an absolute URL.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Find more info here",
+                    "url": "https://example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/infoExtensions.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/infoExtensions.json",
+            "type": "object",
+            "description": "The object that lists all the extensions of Info",
+            "properties": {
+                "x-x": {
+                    "$ref": "http://asyncapi.com/extensions/x/0.1.0/schema.json"
+                },
+                "x-linkedin": {
+                    "$ref": "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json"
+                }
+            }
+        },
+        "http://asyncapi.com/extensions/x/0.1.0/schema.json": {
+            "$id": "http://asyncapi.com/extensions/x/0.1.0/schema.json",
+            "type": "string",
+            "description": "This extension allows you to provide the Twitter username of the account representing the team/company of the API.",
+            "example": [
+                "sambhavgupta75",
+                "AsyncAPISpec"
+            ]
+        },
+        "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json": {
+            "$id": "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json",
+            "type": "string",
+            "pattern": "^http(s)?://(www\\.)?linkedin\\.com.*$",
+            "description": "This extension allows you to provide the Linkedin profile URL of the account representing the team/company of the API.",
+            "example": [
+                "https://www.linkedin.com/company/asyncapi/",
+                "https://www.linkedin.com/in/sambhavgupta0705/"
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/servers.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/servers.json",
+            "description": "An object representing multiple servers.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/server.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "development": {
+                        "host": "localhost:5672",
+                        "description": "Development AMQP broker.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:development",
+                                "description": "This environment is meant for developers to run their own tests."
+                            }
+                        ]
+                    },
+                    "staging": {
+                        "host": "rabbitmq-staging.in.mycompany.com:5672",
+                        "description": "RabbitMQ broker for the staging environment.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:staging",
+                                "description": "This environment is a replica of the production environment."
+                            }
+                        ]
+                    },
+                    "production": {
+                        "host": "rabbitmq.in.mycompany.com:5672",
+                        "description": "RabbitMQ broker for the production environment.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:production",
+                                "description": "This environment is the live environment available for final users."
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/server.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/server.json",
+            "type": "object",
+            "description": "An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data.",
+            "required": [
+                "host",
+                "protocol"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "The server host name. It MAY include the port. This field supports Server Variables. Variable substitutions will be made when a variable is named in {braces}."
+                },
+                "pathname": {
+                    "type": "string",
+                    "description": "The path to a resource in the host. This field supports Server Variables. Variable substitutions will be made when a variable is named in {braces}."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the server."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the server."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the server. CommonMark is allowed."
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "The protocol this server supports for connection."
+                },
+                "protocolVersion": {
+                    "type": "string",
+                    "description": "An optional string describing the server. CommonMark syntax MAY be used for rich text representation."
+                },
+                "variables": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariables.json"
+                },
+                "security": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/securityRequirements.json"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "host": "kafka.in.mycompany.com:9092",
+                    "description": "Production Kafka broker.",
+                    "protocol": "kafka",
+                    "protocolVersion": "3.2"
+                },
+                {
+                    "host": "rabbitmq.in.mycompany.com:5672",
+                    "pathname": "/production",
+                    "protocol": "amqp",
+                    "description": "Production RabbitMQ broker (uses the `production` vhost)."
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/serverVariables.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/serverVariables.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariable.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/serverVariable.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/serverVariable.json",
+            "type": "object",
+            "description": "An object representing a Server Variable for server URL template substitution.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "default": {
+                    "type": "string",
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional description for the server variable. CommonMark syntax MAY be used for rich text representation."
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "An array of examples of the server variable.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "host": "rabbitmq.in.mycompany.com:5672",
+                    "pathname": "/{env}",
+                    "protocol": "amqp",
+                    "description": "RabbitMQ broker. Use the `env` variable to point to either `production` or `staging`.",
+                    "variables": {
+                        "env": {
+                            "description": "Environment to connect to. It can be either `production` or `staging`.",
+                            "enum": [
+                                "production",
+                                "staging"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/securityRequirements.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/securityRequirements.json",
+            "description": "An array representing security requirements.",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json",
+            "description": "Defines a security scheme that can be used by the operations.",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/userPassword.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/apiKey.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/X509.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/symmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/asymmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/HTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flows.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/openIdConnect.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslSecurityScheme.json"
+                }
+            ],
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/userPassword.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/userPassword.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "userPassword"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/apiKey.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/apiKey.json",
+            "type": "object",
+            "required": [
+                "type",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "in": {
+                    "type": "string",
+                    "description": " The location of the API key.",
+                    "enum": [
+                        "user",
+                        "password"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "apiKey",
+                    "in": "user"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/X509.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/X509.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "X509"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "X509"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/symmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/symmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "symmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "symmetricEncryption"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/asymmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/asymmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "asymmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/HTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/HTTPSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/NonBearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/BearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/APIKeyHTTPSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/NonBearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/NonBearerHTTPSecurityScheme.json",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "description": "A short description for security scheme.",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "http"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/BearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/BearerHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235.",
+                    "enum": [
+                        "bearer"
+                    ]
+                },
+                "bearerFormat": {
+                    "type": "string",
+                    "description": "A hint to the client to identify how the bearer token is formatted. Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/APIKeyHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/APIKeyHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "httpApiKey"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the header, query or cookie parameter to be used."
+                },
+                "in": {
+                    "type": "string",
+                    "description": "The location of the API key",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "httpApiKey",
+                    "name": "api_key",
+                    "in": "header"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/oauth2Flows.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/oauth2Flows.json",
+            "type": "object",
+            "description": "Allows configuration of the supported OAuth Flows.",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                },
+                "flows": {
+                    "type": "object",
+                    "properties": {
+                        "implicit": {
+                            "description": "Configuration for the OAuth Implicit flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "tokenUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "password": {
+                            "description": "Configuration for the OAuth Resource Owner Protected Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "clientCredentials": {
+                            "description": "Configuration for the OAuth Client Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "authorizationCode": {
+                            "description": "Configuration for the OAuth Authorization Code flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "scopes": {
+                    "type": "array",
+                    "description": "List of the needed scope names.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json",
+            "type": "object",
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The authorization URL to be used for this flow. This MUST be in the form of an absolute URL."
+                },
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The token URL to be used for this flow. This MUST be in the form of an absolute URL."
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of an absolute URL."
+                },
+                "availableScopes": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Scopes.json",
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "authorizationUrl": "https://example.com/api/oauth/dialog",
+                    "tokenUrl": "https://example.com/api/oauth/token",
+                    "availableScopes": {
+                        "write:pets": "modify pets in your account",
+                        "read:pets": "read your pets"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/oauth2Scopes.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/oauth2Scopes.json",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/openIdConnect.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/openIdConnect.json",
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                },
+                "openIdConnectUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of an absolute URL."
+                },
+                "scopes": {
+                    "type": "array",
+                    "description": "List of the needed scope names. An empty array means no scopes are needed.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslPlainSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslScramSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslGssapiSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslPlainSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslPlainSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. Valid values",
+                    "enum": [
+                        "plain"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslScramSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslScramSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "scramSha256",
+                        "scramSha512"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslGssapiSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslGssapiSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "gssapi"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a server.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {},
+                "ws": {},
+                "amqp": {},
+                "amqp1": {},
+                "mqtt": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {},
+                "nats": {},
+                "jms": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {},
+                "sqs": {},
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "solace": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.4.0",
+                                "0.3.0",
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.3.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.2.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "googlepubsub": {},
+                "pulsar": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains information about the server representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "clientId": {
+                    "type": "string",
+                    "description": "The client identifier."
+                },
+                "cleanSession": {
+                    "type": "boolean",
+                    "description": "Whether to create a persistent connection or not. When 'false', the connection will be persistent. This is called clean start in MQTTv5."
+                },
+                "lastWill": {
+                    "type": "object",
+                    "description": "Last Will and Testament configuration.",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "The topic where the Last Will and Testament message will be sent."
+                        },
+                        "qos": {
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2
+                            ],
+                            "description": "Defines how hard the broker/client will try to ensure that the Last Will and Testament message is received. Its value MUST be either 0, 1 or 2."
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Last Will message."
+                        },
+                        "retain": {
+                            "type": "boolean",
+                            "description": "Whether the broker should retain the Last Will and Testament message or not."
+                        }
+                    }
+                },
+                "keepAlive": {
+                    "type": "integer",
+                    "description": "Interval in seconds of the longest period of time the broker and the client can endure without sending a message."
+                },
+                "sessionExpiryInterval": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Interval time in seconds or a Schema Object containing the definition of the interval.  The broker maintains a session for a disconnected client until this interval expires."
+                },
+                "maximumPacketSize": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4294967295
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Number of bytes or a Schema Object representing the Maximum Packet Size the Client is willing to accept."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "clientId": "guest",
+                    "cleanSession": true,
+                    "lastWill": {
+                        "topic": "/last-wills",
+                        "qos": 2,
+                        "message": "Guest gone offline.",
+                        "retain": false
+                    },
+                    "keepAlive": 60,
+                    "sessionExpiryInterval": 120,
+                    "maximumPacketSize": 1024,
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/schema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/schema.json",
+            "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is a superset of the JSON Schema Specification Draft 07. The empty schema (which allows any instance to validate) MAY be represented by the boolean value true and a schema which allows no instance to validate MAY be represented by the boolean value false.",
+            "allOf": [
+                {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                },
+                {
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                    }
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "allOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "oneOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "anyOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "not": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "patternProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "propertyNames": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "contains": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "discriminator": {
+                            "type": "string",
+                            "description": "Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the required property list. When used, the value MUST be the name of this schema or any schema that inherits it. See Composition and Inheritance for more details."
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        },
+                        "deprecated": {
+                            "type": "boolean",
+                            "description": "Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is false.",
+                            "default": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://json-schema.org/draft-07/schema": {
+            "$id": "http://json-schema.org/draft-07/schema",
+            "title": "Core schema meta-schema",
+            "definitions": {
+                "schemaArray": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#"
+                    }
+                },
+                "nonNegativeInteger": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nonNegativeIntegerDefault0": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/nonNegativeInteger"
+                        },
+                        {
+                            "default": 0
+                        }
+                    ]
+                },
+                "simpleTypes": {
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "null",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "stringArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": []
+                }
+            },
+            "type": [
+                "object",
+                "boolean"
+            ],
+            "properties": {
+                "$id": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$schema": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "$ref": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$comment": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": true,
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "items": true
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "number"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "number"
+                },
+                "maxLength": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minLength": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "additionalItems": {
+                    "$ref": "#"
+                },
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/schemaArray"
+                        }
+                    ],
+                    "default": true
+                },
+                "maxItems": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minItems": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "contains": {
+                    "$ref": "#"
+                },
+                "maxProperties": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minProperties": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "required": {
+                    "$ref": "#/definitions/stringArray"
+                },
+                "additionalProperties": {
+                    "$ref": "#"
+                },
+                "definitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "patternProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "propertyNames": {
+                        "format": "regex"
+                    },
+                    "default": {}
+                },
+                "dependencies": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/stringArray"
+                            }
+                        ]
+                    }
+                },
+                "propertyNames": {
+                    "$ref": "#"
+                },
+                "const": true,
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/simpleTypes"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/simpleTypes"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "format": {
+                    "type": "string"
+                },
+                "contentMediaType": {
+                    "type": "string"
+                },
+                "contentEncoding": {
+                    "type": "string"
+                },
+                "if": {
+                    "$ref": "#"
+                },
+                "then": {
+                    "$ref": "#"
+                },
+                "else": {
+                    "$ref": "#"
+                },
+                "allOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "anyOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "oneOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "not": {
+                    "$ref": "#"
+                }
+            },
+            "default": true
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/server.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/server.json",
+            "title": "Server Schema",
+            "description": "This object contains configuration for describing a JMS broker as an AsyncAPI server. This objects only contains configuration that can not be provided in the AsyncAPI standard server object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "jmsConnectionFactory"
+            ],
+            "properties": {
+                "jmsConnectionFactory": {
+                    "type": "string",
+                    "description": "The classname of the ConnectionFactory implementation for the JMS Provider."
+                },
+                "properties": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json#/definitions/property"
+                    },
+                    "description": "Additional properties to set on the JMS ConnectionFactory implementation for the JMS Provider."
+                },
+                "clientID": {
+                    "type": "string",
+                    "description": "A client identifier for applications that use this JMS connection factory. If the Client ID Policy is set to 'Restricted' (the default), then configuring a Client ID on the ConnectionFactory prevents more than one JMS client from using a connection from this factory."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "definitions": {
+                "property": {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of a property"
+                        },
+                        "value": {
+                            "type": [
+                                "string",
+                                "boolean",
+                                "number",
+                                "null"
+                            ],
+                            "description": "The name of a property"
+                        }
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "jmsConnectionFactory": "org.apache.activemq.ActiveMQConnectionFactory",
+                    "properties": [
+                        {
+                            "name": "disableTimeStampsByDefault",
+                            "value": false
+                        }
+                    ],
+                    "clientID": "my-application-1",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json",
+            "title": "IBM MQ server bindings object",
+            "description": "This object contains server connection information about the IBM MQ server, referred to as an IBM MQ queue manager. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "type": "string",
+                    "description": "Defines a logical group of IBM MQ server objects. This is necessary to specify multi-endpoint configurations used in high availability deployments. If omitted, the server object is not part of a group."
+                },
+                "ccdtQueueManagerName": {
+                    "type": "string",
+                    "default": "*",
+                    "description": "The name of the IBM MQ queue manager to bind to in the CCDT file."
+                },
+                "cipherSpec": {
+                    "type": "string",
+                    "description": "The recommended cipher specification used to establish a TLS connection between the client and the IBM MQ queue manager. More information on SSL/TLS cipher specifications supported by IBM MQ can be found on this page in the IBM MQ Knowledge Center."
+                },
+                "multiEndpointServer": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If 'multiEndpointServer' is 'true' then multiple connections can be workload balanced and applications should not make assumptions as to where messages are processed. Where message ordering, or affinity to specific message resources is necessary, a single endpoint ('multiEndpointServer' = 'false') may be required."
+                },
+                "heartBeatInterval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 999999,
+                    "default": 300,
+                    "description": "The recommended value (in seconds) for the heartbeat sent to the queue manager during periods of inactivity. A value of zero means that no heart beats are sent. A value of 1 means that the client will use the value defined by the queue manager. More information on heart beat interval can be found on this page in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": "PRODCLSTR1",
+                    "cipherSpec": "ANY_TLS12_OR_HIGHER",
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "groupId": "PRODCLSTR1",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.4.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.4.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msgVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "clientName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160,
+                    "description": "A unique client name to use to register to the appliance. If specified, it must be a valid Topic name, and a maximum of 160 bytes in length when encoded as UTF-8."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.3.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.3.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msgVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.2.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.2.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msvVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/pulsar/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server information of Pulsar broker, which covers cluster and tenant admin configuration. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "tenant": {
+                    "type": "string",
+                    "description": "The pulsar tenant. If omitted, 'public' MUST be assumed."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "tenant": "contoso",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channels.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channels.json",
+            "type": "object",
+            "description": "An object containing all the Channel Object definitions the Application MUST use during runtime.",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/channel.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "userSignedUp": {
+                        "address": "user.signedup",
+                        "messages": {
+                            "userSignedUp": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channel.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channel.json",
+            "type": "object",
+            "description": "Describes a shared communication channel.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "address": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "An optional string representation of this channel's address. The address is typically the \"topic name\", \"routing key\", \"event type\", or \"path\". When `null` or absent, it MUST be interpreted as unknown. This is useful when the address is generated dynamically at runtime or can't be known upfront. It MAY contain Channel Address Expressions."
+                },
+                "messages": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/channelMessages.json"
+                },
+                "parameters": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/parameters.json"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the channel."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the channel."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the channel. CommonMark is allowed."
+                },
+                "servers": {
+                    "type": "array",
+                    "description": "The references of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    "uniqueItems": true
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping of channels.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "address": "users.{userId}",
+                    "title": "Users channel",
+                    "description": "This channel is used to exchange messages about user events.",
+                    "messages": {
+                        "userSignedUp": {
+                            "$ref": "#/components/messages/userSignedUp"
+                        },
+                        "userCompletedOrder": {
+                            "$ref": "#/components/messages/userCompletedOrder"
+                        }
+                    },
+                    "parameters": {
+                        "userId": {
+                            "$ref": "#/components/parameters/userId"
+                        }
+                    },
+                    "servers": [
+                        {
+                            "$ref": "#/servers/rabbitmqInProd"
+                        },
+                        {
+                            "$ref": "#/servers/rabbitmqInStaging"
+                        }
+                    ],
+                    "bindings": {
+                        "amqp": {
+                            "is": "queue",
+                            "queue": {
+                                "exclusive": true
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "name": "user",
+                            "description": "User-related messages"
+                        }
+                    ],
+                    "externalDocs": {
+                        "description": "Find more info here",
+                        "url": "https://example.com"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channelMessages.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channelMessages.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageObject.json"
+                    }
+                ]
+            },
+            "description": "A map of the messages that will be sent to this channel by any application at any time. **Every message sent to this channel MUST be valid against one, and only one, of the message objects defined in this map.**"
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageObject.json",
+            "type": "object",
+            "description": "Describes a message received on a given channel and operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentType": {
+                    "type": "string",
+                    "description": "The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. application/json). When omitted, the value MUST be the one specified on the defaultContentType field."
+                },
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                },
+                "payload": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/correlationId.json"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the message."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the message."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "List of examples.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
+                    }
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+                        }
+                    ]
+                },
+                "traits": {
+                    "type": "array",
+                    "description": "A list of traits to apply to the message object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Message Object.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/messageTrait.json"
+                            },
+                            {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                            },
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/3.0.0/messageTrait.json"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "additionalItems": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "messageId": "userSignup",
+                    "name": "UserSignup",
+                    "title": "User signup",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "contentType": "application/json",
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "correlationId": {
+                                "description": "Correlation ID set by application",
+                                "type": "string"
+                            },
+                            "applicationInstanceId": {
+                                "description": "Unique identifier for a given instance of the publishing application",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "payload": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "$ref": "#/components/schemas/userCreate"
+                            },
+                            "signup": {
+                                "$ref": "#/components/schemas/signup"
+                            }
+                        }
+                    },
+                    "correlationId": {
+                        "description": "Default Correlation ID",
+                        "location": "$message.header#/correlationId"
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/messageTraits/commonHeaders"
+                        }
+                    ],
+                    "examples": [
+                        {
+                            "name": "SimpleSignup",
+                            "summary": "A simple UserSignup example message",
+                            "headers": {
+                                "correlationId": "my-correlation-id",
+                                "applicationInstanceId": "myInstanceId"
+                            },
+                            "payload": {
+                                "user": {
+                                    "someUserKey": "someUserValue"
+                                },
+                                "signup": {
+                                    "someSignupKey": "someSignupValue"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/anySchema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/anySchema.json",
+            "if": {
+                "required": [
+                    "schema"
+                ]
+            },
+            "then": {
+                "$ref": "http://asyncapi.com/definitions/3.0.0/multiFormatSchema.json"
+            },
+            "else": {
+                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            },
+            "description": "An object representing either a schema or a multiFormatSchema based on the existence of the 'schema' property. If the property 'schema' is present, use the multi-format schema. Use the default AsyncAPI Schema otherwise."
+        },
+        "http://asyncapi.com/definitions/3.0.0/multiFormatSchema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/multiFormatSchema.json",
+            "description": "The Multi Format Schema Object represents a schema definition. It differs from the Schema Object in that it supports multiple schema formats or languages (e.g., JSON Schema, Avro, etc.).",
+            "type": "object",
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "if": {
+                "not": {
+                    "type": "object"
+                }
+            },
+            "then": {
+                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            },
+            "else": {
+                "properties": {
+                    "schemaFormat": {
+                        "description": "A string containing the name of the schema format that is used to define the information. If schemaFormat is missing, it MUST default to application/vnd.aai.asyncapi+json;version={{asyncapi}} where {{asyncapi}} matches the AsyncAPI Version String. In such a case, this would make the Multi Format Schema Object equivalent to the Schema Object. When using Reference Object within the schema, the schemaFormat of the resource being referenced MUST match the schemaFormat of the schema that contains the initial reference. For example, if you reference Avro schema, then schemaFormat of referencing resource and the resource being reference MUST match.",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "description": "All the schema formats tooling MUST support",
+                                "enum": [
+                                    "application/schema+json;version=draft-07",
+                                    "application/schema+yaml;version=draft-07",
+                                    "application/vnd.aai.asyncapi;version=3.0.0",
+                                    "application/vnd.aai.asyncapi+json;version=3.0.0",
+                                    "application/vnd.aai.asyncapi+yaml;version=3.0.0"
+                                ]
+                            },
+                            {
+                                "description": "All the schema formats tools are RECOMMENDED to support",
+                                "enum": [
+                                    "application/vnd.oai.openapi;version=3.0.0",
+                                    "application/vnd.oai.openapi+json;version=3.0.0",
+                                    "application/vnd.oai.openapi+yaml;version=3.0.0",
+                                    "application/vnd.apache.avro;version=1.9.0",
+                                    "application/vnd.apache.avro+json;version=1.9.0",
+                                    "application/vnd.apache.avro+yaml;version=1.9.0",
+                                    "application/raml+yaml;version=1.0"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "not": {
+                                "description": "If no schemaFormat has been defined, default to schema or reference",
+                                "required": [
+                                    "schemaFormat"
+                                ]
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "description": "If schemaFormat has been defined check if it's one of the AsyncAPI Schema Object formats",
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.aai.asyncapi;version=2.0.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.0.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.0.0",
+                                        "application/vnd.aai.asyncapi;version=2.1.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.1.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.1.0",
+                                        "application/vnd.aai.asyncapi;version=2.2.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.2.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.2.0",
+                                        "application/vnd.aai.asyncapi;version=2.3.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.3.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.3.0",
+                                        "application/vnd.aai.asyncapi;version=2.4.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.4.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.4.0",
+                                        "application/vnd.aai.asyncapi;version=2.5.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.5.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.5.0",
+                                        "application/vnd.aai.asyncapi;version=2.6.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.6.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.6.0",
+                                        "application/vnd.aai.asyncapi;version=3.0.0",
+                                        "application/vnd.aai.asyncapi+json;version=3.0.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=3.0.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/schema+json;version=draft-07",
+                                        "application/schema+yaml;version=draft-07"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://json-schema.org/draft-07/schema"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.oai.openapi;version=3.0.0",
+                                        "application/vnd.oai.openapi+json;version=3.0.0",
+                                        "application/vnd.oai.openapi+yaml;version=3.0.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.apache.avro;version=1.9.0",
+                                        "application/vnd.apache.avro+json;version=1.9.0",
+                                        "application/vnd.apache.avro+yaml;version=1.9.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json",
+            "type": "object",
+            "definitions": {
+                "ExternalDocumentation": {
+                    "type": "object",
+                    "required": [
+                        "url"
+                    ],
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                },
+                "Discriminator": {
+                    "type": "object",
+                    "required": [
+                        "propertyName"
+                    ],
+                    "properties": {
+                        "propertyName": {
+                            "type": "string"
+                        },
+                        "mapping": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "Reference": {
+                    "type": "object",
+                    "required": [
+                        "$ref"
+                    ],
+                    "patternProperties": {
+                        "^\\$ref$": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    }
+                },
+                "XML": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "attribute": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "wrapped": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "maxItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "not": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "default": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "default": true,
+                "nullable": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/Discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "example": true,
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xml": {
+                    "$ref": "#/definitions/XML"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json",
+            "definitions": {
+                "avroSchema": {
+                    "title": "Avro Schema",
+                    "description": "Root Schema",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/types"
+                        }
+                    ]
+                },
+                "types": {
+                    "title": "Avro Types",
+                    "description": "Allowed Avro types",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/primitiveType"
+                        },
+                        {
+                            "$ref": "#/definitions/primitiveTypeWithMetadata"
+                        },
+                        {
+                            "$ref": "#/definitions/customTypeReference"
+                        },
+                        {
+                            "$ref": "#/definitions/avroRecord"
+                        },
+                        {
+                            "$ref": "#/definitions/avroEnum"
+                        },
+                        {
+                            "$ref": "#/definitions/avroArray"
+                        },
+                        {
+                            "$ref": "#/definitions/avroMap"
+                        },
+                        {
+                            "$ref": "#/definitions/avroFixed"
+                        },
+                        {
+                            "$ref": "#/definitions/avroUnion"
+                        }
+                    ]
+                },
+                "primitiveType": {
+                    "title": "Primitive Type",
+                    "description": "Basic type primitives.",
+                    "type": "string",
+                    "enum": [
+                        "null",
+                        "boolean",
+                        "int",
+                        "long",
+                        "float",
+                        "double",
+                        "bytes",
+                        "string"
+                    ]
+                },
+                "primitiveTypeWithMetadata": {
+                    "title": "Primitive Type With Metadata",
+                    "description": "A primitive type with metadata attached.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "$ref": "#/definitions/primitiveType"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "customTypeReference": {
+                    "title": "Custom Type",
+                    "description": "Reference to a ComplexType",
+                    "not": {
+                        "$ref": "#/definitions/primitiveType"
+                    },
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+                },
+                "avroUnion": {
+                    "title": "Union",
+                    "description": "A Union of types",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/avroSchema"
+                    },
+                    "minItems": 1
+                },
+                "avroField": {
+                    "title": "Field",
+                    "description": "A field within a Record",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/types"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "default": true,
+                        "order": {
+                            "enum": [
+                                "ascending",
+                                "descending",
+                                "ignore"
+                            ]
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "type"
+                    ]
+                },
+                "avroRecord": {
+                    "title": "Record",
+                    "description": "A Record",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "record"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/avroField"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "fields"
+                    ]
+                },
+                "avroEnum": {
+                    "title": "Enum",
+                    "description": "An enumeration",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "enum"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "symbols": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "symbols"
+                    ]
+                },
+                "avroArray": {
+                    "title": "Array",
+                    "description": "An array",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "array"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "items": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "items"
+                    ]
+                },
+                "avroMap": {
+                    "title": "Map",
+                    "description": "A map of values",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "map"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "values": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "values"
+                    ]
+                },
+                "avroFixed": {
+                    "title": "Fixed",
+                    "description": "A fixed sized array of bytes",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "fixed"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "size": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "size"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                },
+                "namespace": {
+                    "type": "string",
+                    "pattern": "^([A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*)*$"
+                }
+            },
+            "description": "Json-Schema definition for Avro AVSC files.",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/avroSchema"
+                }
+            ],
+            "title": "Avro Schema Definition"
+        },
+        "http://asyncapi.com/definitions/3.0.0/correlationId.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/correlationId.json",
+            "type": "object",
+            "description": "An object that specifies an identifier at design time that can used for message tracing and correlation.",
+            "required": [
+                "location"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the correlation ID",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Default Correlation ID",
+                    "location": "$message.header#/correlationId"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json",
+            "type": "object",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "payload"
+                    ]
+                },
+                {
+                    "required": [
+                        "headers"
+                    ]
+                }
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Machine readable name of the message example."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message example."
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Example of the application headers. It MUST be a map of key-value pairs."
+                },
+                "payload": {
+                    "type": [
+                        "number",
+                        "string",
+                        "boolean",
+                        "object",
+                        "array",
+                        "null"
+                    ],
+                    "description": "Example of the message payload. It can be of any type."
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a message.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "ws": {},
+                "amqp": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp1": {},
+                "mqtt": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json"
+                            }
+                        }
+                    ]
+                },
+                "nats": {},
+                "jms": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/message.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {},
+                "sqs": {},
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "solace": {},
+                "googlepubsub": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/http/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.3.0/message.json",
+            "title": "HTTP message bindings object",
+            "description": "This object contains information about the message representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "\tA Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "statusCode": {
+                    "type": "number",
+                    "description": "The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes). `statusCode` is only relevant for messages referenced by the [Operation Reply Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject), as it defines the status code for the response. In all other cases, this value can be safely ignored."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "Content-Type": {
+                                "type": "string",
+                                "enum": [
+                                    "application/json"
+                                ]
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.2.0/message.json",
+            "title": "HTTP message bindings object",
+            "description": "This object contains information about the message representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "\tA Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "Content-Type": {
+                                "type": "string",
+                                "enum": [
+                                    "application/json"
+                                ]
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/message.json",
+            "title": "AMQP message bindings object",
+            "description": "This object contains information about the message representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentEncoding": {
+                    "type": "string",
+                    "description": "A MIME encoding for the message content."
+                },
+                "messageType": {
+                    "type": "string",
+                    "description": "Application-specific message type."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "contentEncoding": "gzip",
+                    "messageType": "user.signup",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json",
+            "title": "MQTT message bindings object",
+            "description": "This object contains information about the message representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "payloadFormatIndicator": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1
+                    ],
+                    "description": "1 indicates that the payload is UTF-8 encoded character data.  0 indicates that the payload format is unspecified.",
+                    "default": 0
+                },
+                "correlationData": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Correlation Data is used by the sender of the request message to identify which request the response message is for when it is received."
+                },
+                "contentType": {
+                    "type": "string",
+                    "description": "String describing the content type of the message payload. This should not conflict with the contentType field of the associated AsyncAPI Message object."
+                },
+                "responseTopic": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "uri-template",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "The topic (channel URI) to be used for a response message."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.2.0"
+                },
+                {
+                    "contentType": "application/json",
+                    "correlationData": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "responseTopic": "application/responses",
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.5.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.4.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json": {
+            "$id": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json",
+            "title": "Anypoint MQ message bindings object",
+            "description": "This object contains configuration for describing an Anypoint MQ message as an AsyncAPI message. This objects only contains configuration that can not be provided in the AsyncAPI standard message object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions for Anypoint MQ-specific headers (protocol headers). This schema MUST be of type 'object' and have a 'properties' key. Examples of Anypoint MQ protocol headers are 'messageId' and 'messageGroupId'."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "messageId": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/message.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/message.json",
+            "title": "Message Schema",
+            "description": "This object contains configuration for describing a JMS message as an AsyncAPI message. This objects only contains configuration that can not be provided in the AsyncAPI standard message object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for JMS headers (protocol headers). This schema MUST be of type 'object' and have a 'properties' key. Examples of JMS protocol headers are 'JMSMessageID', 'JMSTimestamp', and 'JMSCorrelationID'."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "required": [
+                            "JMSMessageID"
+                        ],
+                        "properties": {
+                            "JMSMessageID": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A unique message identifier. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSTimestamp": {
+                                "type": "integer",
+                                "description": "The time the message was sent. This may be set by your JMS Provider on your behalf. The time the message was sent. The value of the timestamp is the amount of time, measured in milliseconds, that has elapsed since midnight, January 1, 1970, UTC."
+                            },
+                            "JMSDeliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "PERSISTENT",
+                                    "NON_PERSISTENT"
+                                ],
+                                "default": "PERSISTENT",
+                                "description": "Denotes the delivery mode for the message. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSPriority": {
+                                "type": "integer",
+                                "default": 4,
+                                "description": "The priority of the message. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSExpires": {
+                                "type": "integer",
+                                "description": "The time at which the message expires. This may be set by your JMS Provider on your behalf. A value of zero means that the message does not expire. Any non-zero value is the amount of time, measured in milliseconds, that has elapsed since midnight, January 1, 1970, UTC, at which the message will expire."
+                            },
+                            "JMSType": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The type of message. Some JMS providers use a message repository that contains the definitions of messages sent by applications. The 'JMSType' header field may reference a message's definition in the provider's repository. The JMS API does not define a standard message definition repository, nor does it define a naming policy for the definitions it contains. Some messaging systems require that a message type definition for each application message be created and that each message specify its type. In order to work with such JMS providers, JMS clients should assign a value to 'JMSType', whether the application makes use of it or not. This ensures that the field is properly set for those providers that require it."
+                            },
+                            "JMSCorrelationID": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The correlation identifier of the message. A client can use the 'JMSCorrelationID' header field to link one message with another. A typical use is to link a response message with its request message. Since each message sent by a JMS provider is assigned a message ID value, it is convenient to link messages via message ID, such message ID values must start with the 'ID:' prefix. Conversely, application-specified values must not start with the 'ID:' prefix; this is reserved for provider-generated message ID values."
+                            },
+                            "JMSReplyTo": {
+                                "type": "string",
+                                "description": "The queue or topic that the message sender expects replies to."
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json",
+            "title": "IBM MQ message bindings object",
+            "description": "This object contains information about the message representation in IBM MQ.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "jms",
+                        "binary"
+                    ],
+                    "default": "string",
+                    "description": "The type of the message."
+                },
+                "headers": {
+                    "type": "string",
+                    "description": "Defines the IBM MQ message headers to include with this message. More than one header can be specified as a comma separated list. Supporting information on IBM MQ message formats can be found on this [page](https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqmd-format-mqchar8) in the IBM MQ Knowledge Center."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Provides additional information for application developers: describes the message type or format."
+                },
+                "expiry": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "The recommended setting the client should use for the TTL (Time-To-Live) of the message. This is a period of time expressed in milliseconds and set by the application that puts the message. 'expiry' values are API dependant e.g., MQI and JMS use different units of time and default values for 'unlimited'. General information on IBM MQ message expiry can be found on this [page](https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqmd-expiry-mqlong) in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "const": "binary"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "const": "jms"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "const": "string"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "type": "string",
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "type": "jms",
+                    "description": "JMS stream message",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json",
+            "title": "Cloud Pub/Sub Channel Schema",
+            "description": "This object contains information about the message representation for Google Cloud Pub/Sub.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                },
+                "attributes": {
+                    "type": "object"
+                },
+                "orderingKey": {
+                    "type": "string"
+                },
+                "schema": {
+                    "type": "object",
+                    "additionalItems": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "schema": {
+                        "name": "projects/your-project-id/schemas/your-avro-schema-id"
+                    }
+                },
+                {
+                    "schema": {
+                        "name": "projects/your-project-id/schemas/your-protobuf-schema-id"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageTrait.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageTrait.json",
+            "type": "object",
+            "description": "Describes a trait that MAY be applied to a Message Object. This object MAY contain any property from the Message Object, except payload and traits.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentType": {
+                    "type": "string",
+                    "description": "The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. application/json). When omitted, the value MUST be the one specified on the defaultContentType field."
+                },
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/correlationId.json"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the message."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the message."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "List of examples.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
+                    }
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "contentType": "application/json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/parameters.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/parameters.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/parameter.json"
+                    }
+                ]
+            },
+            "description": "JSON objects describing re-usable channel parameters.",
+            "examples": [
+                {
+                    "address": "user/{userId}/signedup",
+                    "parameters": {
+                        "userId": {
+                            "description": "Id of the user."
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/parameter.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/parameter.json",
+            "description": "Describes a parameter included in a channel address.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
+                },
+                "enum": {
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied.",
+                    "type": "string"
+                },
+                "examples": {
+                    "description": "An array of examples of the parameter value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the parameter value",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "examples": [
+                {
+                    "address": "user/{userId}/signedup",
+                    "parameters": {
+                        "userId": {
+                            "description": "Id of the user.",
+                            "location": "$message.payload#/user/id"
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a channel.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {},
+                "ws": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp1": {},
+                "mqtt": {},
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "nats": {},
+                "jms": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "sqs": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "solace": {},
+                "googlepubsub": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "pulsar": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/websockets/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json",
+            "title": "WebSockets channel bindings object",
+            "description": "When using WebSockets, the channel represents the connection. Unlike other protocols that support multiple virtual channels (topics, routing keys, etc.) per connection, WebSockets doesn't support virtual channels or, put it another way, there's only one channel and its characteristics are strongly related to the protocol used for the handshake, i.e., HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "POST"
+                    ],
+                    "description": "The HTTP method to use when establishing the connection. Its value MUST be either 'GET' or 'POST'."
+                },
+                "query": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "headers": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "method": "POST",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json",
+            "title": "AMQP channel bindings object",
+            "description": "This object contains information about the channel representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "is": {
+                    "type": "string",
+                    "enum": [
+                        "queue",
+                        "routingKey"
+                    ],
+                    "description": "Defines what type of channel is it. Can be either 'queue' or 'routingKey' (default)."
+                },
+                "exchange": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "The name of the exchange. It MUST NOT exceed 255 characters long."
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "topic",
+                                "direct",
+                                "fanout",
+                                "default",
+                                "headers"
+                            ],
+                            "description": "The type of the exchange. Can be either 'topic', 'direct', 'fanout', 'default' or 'headers'."
+                        },
+                        "durable": {
+                            "type": "boolean",
+                            "description": "Whether the exchange should survive broker restarts or not."
+                        },
+                        "autoDelete": {
+                            "type": "boolean",
+                            "description": "Whether the exchange should be deleted when the last queue is unbound from it."
+                        },
+                        "vhost": {
+                            "type": "string",
+                            "default": "/",
+                            "description": "The virtual host of the exchange. Defaults to '/'."
+                        }
+                    },
+                    "description": "When is=routingKey, this object defines the exchange properties."
+                },
+                "queue": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "The name of the queue. It MUST NOT exceed 255 characters long."
+                        },
+                        "durable": {
+                            "type": "boolean",
+                            "description": "Whether the queue should survive broker restarts or not."
+                        },
+                        "exclusive": {
+                            "type": "boolean",
+                            "description": "Whether the queue should be used only by one connection or not."
+                        },
+                        "autoDelete": {
+                            "type": "boolean",
+                            "description": "Whether the queue should be deleted when the last consumer unsubscribes."
+                        },
+                        "vhost": {
+                            "type": "string",
+                            "default": "/",
+                            "description": "The virtual host of the queue. Defaults to '/'."
+                        }
+                    },
+                    "description": "When is=queue, this object defines the queue properties."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "is": {
+                            "const": "routingKey"
+                        }
+                    },
+                    "required": [
+                        "exchange"
+                    ],
+                    "not": {
+                        "required": [
+                            "queue"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "is": {
+                            "const": "queue"
+                        }
+                    },
+                    "required": [
+                        "queue"
+                    ],
+                    "not": {
+                        "required": [
+                            "exchange"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "is": "routingKey",
+                    "exchange": {
+                        "name": "myExchange",
+                        "type": "topic",
+                        "durable": true,
+                        "autoDelete": false,
+                        "vhost": "/"
+                    },
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "is": "queue",
+                    "queue": {
+                        "name": "my-queue-name",
+                        "durable": true,
+                        "exclusive": true,
+                        "autoDelete": false,
+                        "vhost": "/"
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json": {
+            "$id": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json",
+            "title": "Anypoint MQ channel bindings object",
+            "description": "This object contains configuration for describing an Anypoint MQ exchange, queue, or FIFO queue as an AsyncAPI channel. This objects only contains configuration that can not be provided in the AsyncAPI standard channel object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "The destination (queue or exchange) name for this channel. SHOULD only be specified if the channel name differs from the actual destination name, such as when the channel name is not a valid destination name in Anypoint MQ. Defaults to the channel name."
+                },
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "exchange",
+                        "queue",
+                        "fifo-queue"
+                    ],
+                    "default": "queue",
+                    "description": "The type of destination. SHOULD be specified to document the messaging model (publish/subscribe, point-to-point, strict message ordering) supported by this channel."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "destination": "user-signup-exchg",
+                    "destinationType": "exchange",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/channel.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains configuration for describing a JMS queue, or FIFO queue as an AsyncAPI channel. This objects only contains configuration that can not be provided in the AsyncAPI standard channel object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "The destination (queue) name for this channel. SHOULD only be specified if the channel name differs from the actual destination name, such as when the channel name is not a valid destination name according to the JMS Provider. Defaults to the channel name."
+                },
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "queue",
+                        "fifo-queue"
+                    ],
+                    "default": "queue",
+                    "description": "The type of destination. SHOULD be specified to document the messaging model (point-to-point, or strict message ordering) supported by this channel."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "destination": "user-signed-up",
+                    "destinationType": "fifo-queue",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sns/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/sns/0.1.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in SNS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the topic. Can be different from the channel name to allow flexibility around AWS resource naming limitations."
+                },
+                "ordering": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/ordering"
+                },
+                "policy": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/policy"
+                },
+                "tags": {
+                    "type": "object",
+                    "description": "Key-value pairs that represent AWS tags on the topic."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "description": "The version of this binding.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "definitions": {
+                "ordering": {
+                    "type": "object",
+                    "description": "By default, we assume an unordered SNS topic. This field allows configuration of a FIFO SNS Topic.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Defines the type of SNS Topic.",
+                            "enum": [
+                                "standard",
+                                "FIFO"
+                            ]
+                        },
+                        "contentBasedDeduplication": {
+                            "type": "boolean",
+                            "description": "True to turn on de-duplication of messages for a channel."
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SNS Topic.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this topic",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SNS permission being allowed or denied e.g. sns:Publish",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "name": "my-sns-topic",
+                    "policy": {
+                        "statements": [
+                            {
+                                "effect": "Allow",
+                                "principal": "*",
+                                "action": "SNS:Publish"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sqs/0.2.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in SQS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queue": {
+                    "description": "A definition of the queue that will be used as the channel.",
+                    "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/queue"
+                },
+                "deadLetterQueue": {
+                    "description": "A definition of the queue that will be used for un-processable messages.",
+                    "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/queue"
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0",
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "queue"
+            ],
+            "definitions": {
+                "queue": {
+                    "type": "object",
+                    "description": "A definition of a queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the queue. When an SNS Operation Binding Object references an SQS queue by name, the identifier should be the one in this field."
+                        },
+                        "fifoQueue": {
+                            "type": "boolean",
+                            "description": "Is this a FIFO queue?",
+                            "default": false
+                        },
+                        "deduplicationScope": {
+                            "type": "string",
+                            "enum": [
+                                "queue",
+                                "messageGroup"
+                            ],
+                            "description": "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).",
+                            "default": "queue"
+                        },
+                        "fifoThroughputLimit": {
+                            "type": "string",
+                            "enum": [
+                                "perQueue",
+                                "perMessageGroupId"
+                            ],
+                            "description": "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.",
+                            "default": "perQueue"
+                        },
+                        "deliveryDelay": {
+                            "type": "integer",
+                            "description": "The number of seconds to delay before a message sent to the queue can be received. used to create a delay queue.",
+                            "minimum": 0,
+                            "maximum": 900,
+                            "default": 0
+                        },
+                        "visibilityTimeout": {
+                            "type": "integer",
+                            "description": "The length of time, in seconds, that a consumer locks a message - hiding it from reads - before it is unlocked and can be read again.",
+                            "minimum": 0,
+                            "maximum": 43200,
+                            "default": 30
+                        },
+                        "receiveMessageWaitTime": {
+                            "type": "integer",
+                            "description": "Determines if the queue uses short polling or long polling. Set to zero the queue reads available messages and returns immediately. Set to a non-zero integer, long polling waits the specified number of seconds for messages to arrive before returning.",
+                            "default": 0
+                        },
+                        "messageRetentionPeriod": {
+                            "type": "integer",
+                            "description": "How long to retain a message on the queue in seconds, unless deleted.",
+                            "minimum": 60,
+                            "maximum": 1209600,
+                            "default": 345600
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/redrivePolicy"
+                        },
+                        "policy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/policy"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "description": "Key-value pairs that represent AWS tags on the queue."
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "fifoQueue"
+                    ]
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/identifier"
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                },
+                "identifier": {
+                    "type": "object",
+                    "description": "The SQS queue to use as a dead letter queue (DLQ).",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding."
+                        }
+                    }
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SQS Queue",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this queue.",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SQS permission being allowed or denied e.g. sqs:ReceiveMessage",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "queue": {
+                        "name": "myQueue",
+                        "fifoQueue": true,
+                        "deduplicationScope": "messageGroup",
+                        "fifoThroughputLimit": "perMessageGroupId",
+                        "deliveryDelay": 15,
+                        "visibilityTimeout": 60,
+                        "receiveMessageWaitTime": 0,
+                        "messageRetentionPeriod": 86400,
+                        "redrivePolicy": {
+                            "deadLetterQueue": {
+                                "arn": "arn:aws:SQS:eu-west-1:0000000:123456789"
+                            },
+                            "maxReceiveCount": 15
+                        },
+                        "policy": {
+                            "statements": [
+                                {
+                                    "effect": "Deny",
+                                    "principal": "arn:aws:iam::123456789012:user/dec.kolakowski",
+                                    "action": [
+                                        "sqs:SendMessage",
+                                        "sqs:ReceiveMessage"
+                                    ]
+                                }
+                            ]
+                        },
+                        "tags": {
+                            "owner": "AsyncAPI.NET",
+                            "platform": "AsyncAPIOrg"
+                        }
+                    },
+                    "deadLetterQueue": {
+                        "name": "myQueue_error",
+                        "deliveryDelay": 0,
+                        "visibilityTimeout": 0,
+                        "receiveMessageWaitTime": 0,
+                        "messageRetentionPeriod": 604800
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json",
+            "title": "IBM MQ channel bindings object",
+            "description": "This object contains information about the channel representation in IBM MQ. Each channel corresponds to a Queue or Topic within IBM MQ.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "topic",
+                        "queue"
+                    ],
+                    "default": "topic",
+                    "description": "Defines the type of AsyncAPI channel."
+                },
+                "queue": {
+                    "type": "object",
+                    "description": "Defines the properties of a queue.",
+                    "properties": {
+                        "objectName": {
+                            "type": "string",
+                            "maxLength": 48,
+                            "description": "Defines the name of the IBM MQ queue associated with the channel."
+                        },
+                        "isPartitioned": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Defines if the queue is a cluster queue and therefore partitioned. If 'true', a binding option MAY be specified when accessing the queue. More information on binding options can be found on this page in the IBM MQ Knowledge Center."
+                        },
+                        "exclusive": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Specifies if it is recommended to open the queue exclusively."
+                        }
+                    },
+                    "required": [
+                        "objectName"
+                    ]
+                },
+                "topic": {
+                    "type": "object",
+                    "description": "Defines the properties of a topic.",
+                    "properties": {
+                        "string": {
+                            "type": "string",
+                            "maxLength": 10240,
+                            "description": "The value of the IBM MQ topic string to be used."
+                        },
+                        "objectName": {
+                            "type": "string",
+                            "maxLength": 48,
+                            "description": "The name of the IBM MQ topic object."
+                        },
+                        "durablePermitted": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Defines if the subscription may be durable."
+                        },
+                        "lastMsgRetained": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Defines if the last message published will be made available to new subscriptions."
+                        }
+                    }
+                },
+                "maxMsgLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 104857600,
+                    "description": "The maximum length of the physical message (in bytes) accepted by the Topic or Queue. Messages produced that are greater in size than this value may fail to be delivered. More information on the maximum message length can be found on this [page](https://www.ibm.com/support/knowledgecenter/SSFKSJ_latest/com.ibm.mq.ref.dev.doc/q097520_.html) in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "destinationType": {
+                            "const": "topic"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "queue"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "destinationType": {
+                            "const": "queue"
+                        }
+                    },
+                    "required": [
+                        "queue"
+                    ],
+                    "not": {
+                        "required": [
+                            "topic"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "destinationType": "topic",
+                    "topic": {
+                        "objectName": "myTopicName"
+                    },
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "destinationType": "queue",
+                    "queue": {
+                        "objectName": "myQueueName",
+                        "exclusive": true
+                    },
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json",
+            "title": "Cloud Pub/Sub Channel Schema",
+            "description": "This object contains information about the channel representation for Google Cloud Pub/Sub.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "messageRetentionDuration": {
+                    "type": "string"
+                },
+                "messageStoragePolicy": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "allowedPersistenceRegions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "schemaSettings": {
+                    "type": "object",
+                    "additionalItems": false,
+                    "properties": {
+                        "encoding": {
+                            "type": "string"
+                        },
+                        "firstRevisionId": {
+                            "type": "string"
+                        },
+                        "lastRevisionId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoding",
+                        "name"
+                    ]
+                }
+            },
+            "required": [
+                "schemaSettings"
+            ],
+            "examples": [
+                {
+                    "labels": {
+                        "label1": "value1",
+                        "label2": "value2"
+                    },
+                    "messageRetentionDuration": "86400s",
+                    "messageStoragePolicy": {
+                        "allowedPersistenceRegions": [
+                            "us-central1",
+                            "us-east1"
+                        ]
+                    },
+                    "schemaSettings": {
+                        "encoding": "json",
+                        "name": "projects/your-project-id/schemas/your-schema"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Pulsar, which covers namespace and topic level admin configuration. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "namespace",
+                "persistence"
+            ],
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace, the channel is associated with."
+                },
+                "persistence": {
+                    "type": "string",
+                    "enum": [
+                        "persistent",
+                        "non-persistent"
+                    ],
+                    "description": "persistence of the topic in Pulsar."
+                },
+                "compaction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Topic compaction threshold given in MB"
+                },
+                "geo-replication": {
+                    "type": "array",
+                    "description": "A list of clusters the topic is replicated to.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "retention": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "time": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Time given in Minutes. `0` = Disable message retention."
+                        },
+                        "size": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Size given in MegaBytes. `0` = Disable message retention."
+                        }
+                    }
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "TTL in seconds for the specified topic"
+                },
+                "deduplication": {
+                    "type": "boolean",
+                    "description": "Whether deduplication of events is enabled or not."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "namespace": "ns1",
+                    "persistence": "persistent",
+                    "compaction": 1000,
+                    "retention": {
+                        "time": 15,
+                        "size": 1000
+                    },
+                    "ttl": 360,
+                    "geo-replication": [
+                        "us-west",
+                        "us-east"
+                    ],
+                    "deduplication": true,
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operations.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operations.json",
+            "type": "object",
+            "description": "Holds a dictionary with all the operations this application MUST implement.",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "onUserSignUp": {
+                        "title": "User sign up",
+                        "summary": "Action to sign a user up.",
+                        "description": "A longer description",
+                        "channel": {
+                            "$ref": "#/channels/userSignup"
+                        },
+                        "action": "send",
+                        "tags": [
+                            {
+                                "name": "user"
+                            },
+                            {
+                                "name": "signup"
+                            },
+                            {
+                                "name": "register"
+                            }
+                        ],
+                        "bindings": {
+                            "amqp": {
+                                "ack": false
+                            }
+                        },
+                        "traits": [
+                            {
+                                "$ref": "#/components/operationTraits/kafka"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operation.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operation.json",
+            "type": "object",
+            "description": "Describes a specific operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "action",
+                "channel"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Allowed values are send and receive. Use send when it's expected that the application will send a message to the given channel, and receive when the application should expect receiving messages from the given channel.",
+                    "enum": [
+                        "send",
+                        "receive"
+                    ]
+                },
+                "channel": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "A list of $ref pointers pointing to the supported Message Objects that can be processed by this operation. It MUST contain a subset of the messages defined in the channel referenced in this operation. Every message processed by this operation MUST be valid against one, and only one, of the message objects referenced in this list. Please note the messages property value MUST be a list of Reference Objects and, therefore, MUST NOT contain Message Objects. However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    }
+                },
+                "reply": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationReply.json"
+                        }
+                    ]
+                },
+                "traits": {
+                    "type": "array",
+                    "description": "A list of traits to apply to the operation object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Operation Object.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/operationTrait.json"
+                            }
+                        ]
+                    }
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the operation."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the operation."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the operation. CommonMark is allowed."
+                },
+                "security": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/securityRequirements.json"
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "title": "User sign up",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "channel": {
+                        "$ref": "#/channels/userSignup"
+                    },
+                    "action": "send",
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/operationTraits/kafka"
+                        }
+                    ],
+                    "messages": [
+                        {
+                            "$ref": "#/components/messages/userSignedUp"
+                        }
+                    ],
+                    "reply": {
+                        "address": {
+                            "location": "$message.header#/replyTo"
+                        },
+                        "channel": {
+                            "$ref": "#/channels/userSignupReply"
+                        },
+                        "messages": [
+                            {
+                                "$ref": "#/components/messages/userSignedUpReply"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationReply.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationReply.json",
+            "type": "object",
+            "description": "Describes the reply part that MAY be applied to an Operation Object. If an operation implements the request/reply pattern, the reply object represents the response message.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "address": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json"
+                        }
+                    ]
+                },
+                "channel": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "A list of $ref pointers pointing to the supported Message Objects that can be processed by this operation as reply. It MUST contain a subset of the messages defined in the channel referenced in this operation reply. Every message processed by this operation MUST be valid against one, and only one, of the message objects referenced in this list. Please note the messages property value MUST be a list of Reference Objects and, therefore, MUST NOT contain Message Objects. However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    }
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json",
+            "type": "object",
+            "description": "An object that specifies where an operation has to send the reply",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "location"
+            ],
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the reply address.",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional description of the address. CommonMark is allowed."
+                }
+            },
+            "examples": [
+                {
+                    "description": "Consumer inbox",
+                    "location": "$message.header#/replyTo"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationTrait.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationTrait.json",
+            "type": "object",
+            "description": "Describes a trait that MAY be applied to an Operation Object. This object MAY contain any property from the Operation Object, except the action, channel and traits ones.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the operation.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/title"
+                },
+                "summary": {
+                    "description": "A short summary of what the operation is about.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/summary"
+                },
+                "description": {
+                    "description": "A verbose explanation of the operation. CommonMark syntax can be used for rich text representation.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/description"
+                },
+                "security": {
+                    "description": "A declaration of which security schemes are associated with this operation. Only one of the security scheme objects MUST be satisfied to authorize an operation. In cases where Server Security also applies, it MUST also be satisfied.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/security"
+                },
+                "tags": {
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/tags"
+                },
+                "externalDocs": {
+                    "description": "Additional external documentation for this operation.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/externalDocs"
+                },
+                "bindings": {
+                    "description": "A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for an operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "ws": {},
+                "amqp": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp1": {},
+                "mqtt": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {},
+                "nats": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/nats/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/nats/0.1.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "jms": {},
+                "sns": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "sqs": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {},
+                "solace": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.4.0",
+                                "0.3.0",
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.2.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "googlepubsub": {}
+            }
+        },
+        "http://asyncapi.com/bindings/http/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.3.0/operation.json",
+            "title": "HTTP operation bindings object",
+            "description": "This object contains information about the operation representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "PUT",
+                        "POST",
+                        "PATCH",
+                        "DELETE",
+                        "HEAD",
+                        "OPTIONS",
+                        "CONNECT",
+                        "TRACE"
+                    ],
+                    "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+                },
+                "query": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "method": "GET",
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.2.0/operation.json",
+            "title": "HTTP operation bindings object",
+            "description": "This object contains information about the operation representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "PUT",
+                        "POST",
+                        "PATCH",
+                        "DELETE",
+                        "HEAD",
+                        "OPTIONS",
+                        "CONNECT",
+                        "TRACE"
+                    ],
+                    "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+                },
+                "query": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.2.0"
+                },
+                {
+                    "method": "GET",
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json",
+            "title": "AMQP operation bindings object",
+            "description": "This object contains information about the operation representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "expiration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "TTL (Time-To-Live) for the message. It MUST be greater than or equal to zero."
+                },
+                "userId": {
+                    "type": "string",
+                    "description": "Identifies the user who has sent the message."
+                },
+                "cc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The routing keys the message should be routed to at the time of publishing."
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "A priority for the message."
+                },
+                "deliveryMode": {
+                    "type": "integer",
+                    "enum": [
+                        1,
+                        2
+                    ],
+                    "description": "Delivery mode of the message. Its value MUST be either 1 (transient) or 2 (persistent)."
+                },
+                "mandatory": {
+                    "type": "boolean",
+                    "description": "Whether the message is mandatory or not."
+                },
+                "bcc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Like cc but consumers will not receive this information."
+                },
+                "timestamp": {
+                    "type": "boolean",
+                    "description": "Whether the message should include a timestamp or not."
+                },
+                "ack": {
+                    "type": "boolean",
+                    "description": "Whether the consumer should ack the message or not."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "expiration": 100000,
+                    "userId": "guest",
+                    "cc": [
+                        "user.logs"
+                    ],
+                    "priority": 10,
+                    "deliveryMode": 2,
+                    "mandatory": false,
+                    "bcc": [
+                        "external.audit"
+                    ],
+                    "timestamp": true,
+                    "ack": false,
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json",
+            "title": "MQTT operation bindings object",
+            "description": "This object contains information about the operation representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "qos": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "description": "Defines the Quality of Service (QoS) levels for the message flow between client and server. Its value MUST be either 0 (At most once delivery), 1 (At least once delivery), or 2 (Exactly once delivery)."
+                },
+                "retain": {
+                    "type": "boolean",
+                    "description": "Whether the broker should retain the message or not."
+                },
+                "messageExpiryInterval": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 4294967295
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Lifetime of the message in seconds"
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "qos": 2,
+                    "retain": true,
+                    "messageExpiryInterval": 60,
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/nats/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/nats/0.1.0/operation.json",
+            "title": "NATS operation bindings object",
+            "description": "This object contains information about the operation representation in NATS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queue": {
+                    "type": "string",
+                    "description": "Defines the name of the queue to use. It MUST NOT exceed 255 characters.",
+                    "maxLength": 255
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "queue": "MyCustomQueue",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sns/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/sns/0.1.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in SNS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier",
+                    "description": "Often we can assume that the SNS Topic is the channel name-we provide this field in case the you need to supply the ARN, or the Topic name is not the channel name in the AsyncAPI document."
+                },
+                "consumers": {
+                    "type": "array",
+                    "description": "The protocols that listen to this topic and their endpoints.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/consumer"
+                    },
+                    "minItems": 1
+                },
+                "deliveryPolicy": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/deliveryPolicy",
+                    "description": "Policy for retries to HTTP. The field is the default for HTTP receivers of the SNS Topic which may be overridden by a specific consumer."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "description": "The version of this binding.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "consumers"
+            ],
+            "definitions": {
+                "identifier": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "The endpoint is a URL."
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "The endpoint is an email address."
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": "The endpoint is a phone number."
+                        },
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding. We don't use $ref because we are referring, not including."
+                        }
+                    }
+                },
+                "consumer": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "protocol": {
+                            "description": "The protocol that this endpoint receives messages by.",
+                            "type": "string",
+                            "enum": [
+                                "http",
+                                "https",
+                                "email",
+                                "email-json",
+                                "sms",
+                                "sqs",
+                                "application",
+                                "lambda",
+                                "firehose"
+                            ]
+                        },
+                        "endpoint": {
+                            "description": "The endpoint messages are delivered to.",
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier"
+                        },
+                        "filterPolicy": {
+                            "type": "object",
+                            "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
+                            "patternProperties": {
+                                "^x-[\\w\\d\\.\\x2d_]+$": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                                }
+                            },
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "filterPolicyScope": {
+                            "type": "string",
+                            "description": "Determines whether the FilterPolicy applies to MessageAttributes or MessageBody.",
+                            "enum": [
+                                "MessageAttributes",
+                                "MessageBody"
+                            ],
+                            "default": "MessageAttributes"
+                        },
+                        "rawMessageDelivery": {
+                            "type": "boolean",
+                            "description": "If true AWS SNS attributes are removed from the body, and for SQS, SNS message attributes are copied to SQS message attributes. If false the SNS attributes are included in the body."
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/redrivePolicy"
+                        },
+                        "deliveryPolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/deliveryPolicy",
+                            "description": "Policy for retries to HTTP. The parameter is for that SNS Subscription and overrides any policy on the SNS Topic."
+                        },
+                        "displayName": {
+                            "type": "string",
+                            "description": "The display name to use with an SNS subscription"
+                        }
+                    },
+                    "required": [
+                        "protocol",
+                        "endpoint",
+                        "rawMessageDelivery"
+                    ]
+                },
+                "deliveryPolicy": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "minDelayTarget": {
+                            "type": "integer",
+                            "description": "The minimum delay for a retry in seconds."
+                        },
+                        "maxDelayTarget": {
+                            "type": "integer",
+                            "description": "The maximum delay for a retry in seconds."
+                        },
+                        "numRetries": {
+                            "type": "integer",
+                            "description": "The total number of retries, including immediate, pre-backoff, backoff, and post-backoff retries."
+                        },
+                        "numNoDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of immediate retries (with no delay)."
+                        },
+                        "numMinDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of immediate retries (with delay)."
+                        },
+                        "numMaxDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of post-backoff phase retries, with the maximum delay between retries."
+                        },
+                        "backoffFunction": {
+                            "type": "string",
+                            "description": "The algorithm for backoff between retries.",
+                            "enum": [
+                                "arithmetic",
+                                "exponential",
+                                "geometric",
+                                "linear"
+                            ]
+                        },
+                        "maxReceivesPerSecond": {
+                            "type": "integer",
+                            "description": "The maximum number of deliveries per second, per subscription."
+                        }
+                    }
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier",
+                            "description": "The SQS queue to use as a dead letter queue (DLQ)."
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "topic": {
+                        "name": "someTopic"
+                    },
+                    "consumers": [
+                        {
+                            "protocol": "sqs",
+                            "endpoint": {
+                                "name": "someQueue"
+                            },
+                            "filterPolicy": {
+                                "store": [
+                                    "asyncapi_corp"
+                                ],
+                                "event": [
+                                    {
+                                        "anything-but": "order_cancelled"
+                                    }
+                                ],
+                                "customer_interests": [
+                                    "rugby",
+                                    "football",
+                                    "baseball"
+                                ]
+                            },
+                            "filterPolicyScope": "MessageAttributes",
+                            "rawMessageDelivery": false,
+                            "redrivePolicy": {
+                                "deadLetterQueue": {
+                                    "arn": "arn:aws:SQS:eu-west-1:0000000:123456789"
+                                },
+                                "maxReceiveCount": 25
+                            },
+                            "deliveryPolicy": {
+                                "minDelayTarget": 10,
+                                "maxDelayTarget": 100,
+                                "numRetries": 5,
+                                "numNoDelayRetries": 2,
+                                "numMinDelayRetries": 3,
+                                "numMaxDelayRetries": 5,
+                                "backoffFunction": "linear",
+                                "maxReceivesPerSecond": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sqs/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in SQS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queues": {
+                    "type": "array",
+                    "description": "Queue objects that are either the endpoint for an SNS Operation Binding Object, or the deadLetterQueue of the SQS Operation Binding Object.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/queue"
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0",
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "queues"
+            ],
+            "definitions": {
+                "queue": {
+                    "type": "object",
+                    "description": "A definition of a queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "$ref": {
+                            "type": "string",
+                            "description": "Allows for an external definition of a queue. The referenced structure MUST be in the format of a Queue. If there are conflicts between the referenced definition and this Queue's definition, the behavior is undefined."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the queue. When an SNS Operation Binding Object references an SQS queue by name, the identifier should be the one in this field."
+                        },
+                        "fifoQueue": {
+                            "type": "boolean",
+                            "description": "Is this a FIFO queue?",
+                            "default": false
+                        },
+                        "deduplicationScope": {
+                            "type": "string",
+                            "enum": [
+                                "queue",
+                                "messageGroup"
+                            ],
+                            "description": "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).",
+                            "default": "queue"
+                        },
+                        "fifoThroughputLimit": {
+                            "type": "string",
+                            "enum": [
+                                "perQueue",
+                                "perMessageGroupId"
+                            ],
+                            "description": "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.",
+                            "default": "perQueue"
+                        },
+                        "deliveryDelay": {
+                            "type": "integer",
+                            "description": "The number of seconds to delay before a message sent to the queue can be received. Used to create a delay queue.",
+                            "minimum": 0,
+                            "maximum": 900,
+                            "default": 0
+                        },
+                        "visibilityTimeout": {
+                            "type": "integer",
+                            "description": "The length of time, in seconds, that a consumer locks a message - hiding it from reads - before it is unlocked and can be read again.",
+                            "minimum": 0,
+                            "maximum": 43200,
+                            "default": 30
+                        },
+                        "receiveMessageWaitTime": {
+                            "type": "integer",
+                            "description": "Determines if the queue uses short polling or long polling. Set to zero the queue reads available messages and returns immediately. Set to a non-zero integer, long polling waits the specified number of seconds for messages to arrive before returning.",
+                            "default": 0
+                        },
+                        "messageRetentionPeriod": {
+                            "type": "integer",
+                            "description": "How long to retain a message on the queue in seconds, unless deleted.",
+                            "minimum": 60,
+                            "maximum": 1209600,
+                            "default": 345600
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/redrivePolicy"
+                        },
+                        "policy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/policy"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "description": "Key-value pairs that represent AWS tags on the queue."
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/identifier"
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                },
+                "identifier": {
+                    "type": "object",
+                    "description": "The SQS queue to use as a dead letter queue (DLQ).",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding."
+                        }
+                    }
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SQS Queue",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this queue.",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SQS permission being allowed or denied e.g. sqs:ReceiveMessage",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "queues": [
+                        {
+                            "name": "myQueue",
+                            "fifoQueue": true,
+                            "deduplicationScope": "messageGroup",
+                            "fifoThroughputLimit": "perMessageGroupId",
+                            "deliveryDelay": 10,
+                            "redrivePolicy": {
+                                "deadLetterQueue": {
+                                    "name": "myQueue_error"
+                                },
+                                "maxReceiveCount": 15
+                            },
+                            "policy": {
+                                "statements": [
+                                    {
+                                        "effect": "Deny",
+                                        "principal": "arn:aws:iam::123456789012:user/dec.kolakowski",
+                                        "action": [
+                                            "sqs:SendMessage",
+                                            "sqs:ReceiveMessage"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "myQueue_error",
+                            "deliveryDelay": 10
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.4.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.4.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                },
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            },
+                                            "maxTtl": {
+                                                "type": "string",
+                                                "description": "The maximum TTL to apply to messages to be spooled."
+                                            },
+                                            "maxMsgSpoolUsage": {
+                                                "type": "string",
+                                                "description": "The maximum amount of message spool that the given queue may use"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "timeToLive": {
+                    "type": "integer",
+                    "description": "Interval in milliseconds or a Schema Object containing the definition of the lifetime of the message."
+                },
+                "priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255,
+                    "description": "The valid priority value range is 0-255 with 0 as the lowest priority and 255 as the highest or a Schema Object containing the definition of the priority."
+                },
+                "dmqEligible": {
+                    "type": "boolean",
+                    "description": "Set the message to be eligible to be moved to a Dead Message Queue. The default value is false."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.4.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.3.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            },
+                                            "maxTtl": {
+                                                "type": "string",
+                                                "description": "The maximum TTL to apply to messages to be spooled."
+                                            },
+                                            "maxMsgSpoolUsage": {
+                                                "type": "string",
+                                                "description": "The maximum amount of message spool that the given queue may use"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.3.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.2.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.2.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/components.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/components.json",
+            "type": "object",
+            "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI specification. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemas": {
+                    "type": "object",
+                    "description": "An object to hold reusable Schema Object. If this is a Schema Object, then the schemaFormat will be assumed to be 'application/vnd.aai.asyncapi+json;version=asyncapi' where the version is equal to the AsyncAPI Version String.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                        }
+                    }
+                },
+                "servers": {
+                    "type": "object",
+                    "description": "An object to hold reusable Server Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/server.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "channels": {
+                    "type": "object",
+                    "description": "An object to hold reusable Channel Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/channel.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "serverVariables": {
+                    "type": "object",
+                    "description": "An object to hold reusable Server Variable Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariable.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operations": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messages": {
+                    "type": "object",
+                    "description": "An object to hold reusable Message Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/messageObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "securitySchemes": {
+                    "type": "object",
+                    "description": "An object to hold reusable Security Scheme Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "An object to hold reusable Parameter Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/parameter.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "correlationIds": {
+                    "type": "object",
+                    "description": "An object to hold reusable Correlation ID Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/correlationId.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationTraits": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Trait Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationTrait.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messageTraits": {
+                    "type": "object",
+                    "description": "An object to hold reusable Message Trait Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/messageTrait.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "replies": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Reply Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationReply.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "replyAddresses": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Reply Address Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "serverBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Server Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "channelBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Channel Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messageBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Message Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "tags": {
+                    "type": "object",
+                    "description": "An object to hold reusable Tag Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "type": "object",
+                    "description": "An object to hold reusable External Documentation Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "components": {
+                        "schemas": {
+                            "Category": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "Tag": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "AvroExample": {
+                                "schemaFormat": "application/vnd.apache.avro+json;version=1.9.0",
+                                "schema": {
+                                    "$ref": "path/to/user-create.avsc#/UserCreate"
+                                }
+                            }
+                        },
+                        "servers": {
+                            "development": {
+                                "host": "{stage}.in.mycompany.com:{port}",
+                                "description": "RabbitMQ broker",
+                                "protocol": "amqp",
+                                "protocolVersion": "0-9-1",
+                                "variables": {
+                                    "stage": {
+                                        "$ref": "#/components/serverVariables/stage"
+                                    },
+                                    "port": {
+                                        "$ref": "#/components/serverVariables/port"
+                                    }
+                                }
+                            }
+                        },
+                        "serverVariables": {
+                            "stage": {
+                                "default": "demo",
+                                "description": "This value is assigned by the service provider, in this example `mycompany.com`"
+                            },
+                            "port": {
+                                "enum": [
+                                    "5671",
+                                    "5672"
+                                ],
+                                "default": "5672"
+                            }
+                        },
+                        "channels": {
+                            "user/signedup": {
+                                "subscribe": {
+                                    "message": {
+                                        "$ref": "#/components/messages/userSignUp"
+                                    }
+                                }
+                            }
+                        },
+                        "messages": {
+                            "userSignUp": {
+                                "summary": "Action to sign a user up.",
+                                "description": "Multiline description of what this action does.\nHere you have another line.\n",
+                                "tags": [
+                                    {
+                                        "name": "user"
+                                    },
+                                    {
+                                        "name": "signup"
+                                    }
+                                ],
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "applicationInstanceId": {
+                                            "description": "Unique identifier for a given instance of the publishing application",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "properties": {
+                                        "user": {
+                                            "$ref": "#/components/schemas/userCreate"
+                                        },
+                                        "signup": {
+                                            "$ref": "#/components/schemas/signup"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "userId": {
+                                "description": "Id of the user."
+                            }
+                        },
+                        "correlationIds": {
+                            "default": {
+                                "description": "Default Correlation ID",
+                                "location": "$message.header#/correlationId"
+                            }
+                        },
+                        "messageTraits": {
+                            "commonHeaders": {
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "my-app-header": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 100
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "description": "!!Auto generated!! \n Do not manually edit. "
+}

--- a/internal/recommendations/sizing_evaluate.go
+++ b/internal/recommendations/sizing_evaluate.go
@@ -106,8 +106,6 @@ func evaluate(
 			TargetName: spec.name,
 			Resource:   "cpu+memory",
 			Message:    "Service has no CPU or memory limits set",
-			Current:    0,
-			Configured: 0,
 		})
 	} else {
 		if noCPULimit {
@@ -119,8 +117,6 @@ func evaluate(
 				TargetName: spec.name,
 				Resource:   "cpu",
 				Message:    "Service has no CPU limit set",
-				Current:    0,
-				Configured: 0,
 			})
 		}
 
@@ -133,8 +129,6 @@ func evaluate(
 				TargetName: spec.name,
 				Resource:   "memory",
 				Message:    "Service has no memory limit set",
-				Current:    0,
-				Configured: 0,
 			})
 		}
 	}
@@ -152,8 +146,6 @@ func evaluate(
 			TargetName: spec.name,
 			Resource:   "cpu+memory",
 			Message:    "Service has limits but no CPU or memory reservations set",
-			Current:    0,
-			Configured: 0,
 		})
 	} else {
 		if !noCPULimit && noCPUReservation {
@@ -165,8 +157,6 @@ func evaluate(
 				TargetName: spec.name,
 				Resource:   "cpu",
 				Message:    "Service has a CPU limit but no reservation set",
-				Current:    0,
-				Configured: 0,
 			})
 		}
 
@@ -179,8 +169,6 @@ func evaluate(
 				TargetName: spec.name,
 				Resource:   "memory",
 				Message:    "Service has a memory limit but no reservation set",
-				Current:    0,
-				Configured: 0,
 			})
 		}
 	}
@@ -206,8 +194,8 @@ func evaluate(
 					TargetName: spec.name,
 					Resource:   "cpu",
 					Message:    fmt.Sprintf("CPU usage is at %.0f%% of limit", cpuRatio*100),
-					Current:    nanoCPUsFromPercent(instant.cpu),
-					Configured: float64(spec.cpuLimit),
+					Current:    new(nanoCPUsFromPercent(instant.cpu)),
+					Configured: new(float64(spec.cpuLimit)),
 					Suggested:  &suggested,
 					FixAction:  resourcesFixAction,
 				})
@@ -222,8 +210,8 @@ func evaluate(
 					TargetName: spec.name,
 					Resource:   "cpu",
 					Message:    fmt.Sprintf("CPU usage is at %.0f%% of limit", cpuRatio*100),
-					Current:    nanoCPUsFromPercent(instant.cpu),
-					Configured: float64(spec.cpuLimit),
+					Current:    new(nanoCPUsFromPercent(instant.cpu)),
+					Configured: new(float64(spec.cpuLimit)),
 					Suggested:  &suggested,
 					FixAction:  resourcesFixAction,
 				})
@@ -244,8 +232,8 @@ func evaluate(
 					TargetName: spec.name,
 					Resource:   "memory",
 					Message:    fmt.Sprintf("Memory usage is at %.0f%% of limit", memRatio*100),
-					Current:    instant.memory,
-					Configured: float64(spec.memoryLimit),
+					Current:    new(instant.memory),
+					Configured: new(float64(spec.memoryLimit)),
 					Suggested:  &suggested,
 					FixAction:  resourcesFixAction,
 				})
@@ -260,8 +248,8 @@ func evaluate(
 					TargetName: spec.name,
 					Resource:   "memory",
 					Message:    fmt.Sprintf("Memory usage is at %.0f%% of limit", memRatio*100),
-					Current:    instant.memory,
-					Configured: float64(spec.memoryLimit),
+					Current:    new(instant.memory),
+					Configured: new(float64(spec.memoryLimit)),
 					Suggested:  &suggested,
 					FixAction:  resourcesFixAction,
 				})
@@ -290,8 +278,8 @@ func evaluate(
 						formatDuration(cfg.Lookback),
 						cpuResRatio*100,
 					),
-					Current:    nanoCPUsFromPercent(p95.cpu),
-					Configured: float64(spec.cpuReservation),
+					Current:    new(nanoCPUsFromPercent(p95.cpu)),
+					Configured: new(float64(spec.cpuReservation)),
 					Suggested:  &suggested,
 					FixAction:  resourcesFixAction,
 				})
@@ -315,8 +303,8 @@ func evaluate(
 						formatDuration(cfg.Lookback),
 						memResRatio*100,
 					),
-					Current:    p95.memory,
-					Configured: float64(spec.memoryReservation),
+					Current:    new(p95.memory),
+					Configured: new(float64(spec.memoryReservation)),
 					Suggested:  &suggested,
 					FixAction:  resourcesFixAction,
 				})

--- a/internal/recommendations/sizing_evaluate_test.go
+++ b/internal/recommendations/sizing_evaluate_test.go
@@ -329,7 +329,7 @@ func TestEvaluate_OverProvisioned_ReservationNotLimit(t *testing.T) {
 
 	// Configured must be the reservation, not the limit — in NanoCPUs, the unit
 	// Suggested and the fixAction's PATCH body both use.
-	if cpuHint.Configured != float64(spec.cpuReservation) {
+	if cpuHint.Configured == nil || *cpuHint.Configured != float64(spec.cpuReservation) {
 		t.Errorf("cpu Configured = %v, want reservation %v NanoCPUs (not limit %v)",
 			cpuHint.Configured, float64(spec.cpuReservation), float64(spec.cpuLimit))
 	}
@@ -339,7 +339,7 @@ func TestEvaluate_OverProvisioned_ReservationNotLimit(t *testing.T) {
 	}
 
 	// Configured must be the reservation bytes, not the limit bytes.
-	if memHint.Configured != float64(spec.memoryReservation) {
+	if memHint.Configured == nil || *memHint.Configured != float64(spec.memoryReservation) {
 		t.Errorf("memory Configured = %v, want reservation %v (not limit %v)",
 			memHint.Configured, float64(spec.memoryReservation), float64(spec.memoryLimit))
 	}
@@ -410,14 +410,14 @@ func TestOverProvisionedCPUReportsNanoCPUs(t *testing.T) {
 
 	hint := findHint(t, evaluate(spec, nil, p95, defaultConfig()), CategoryOverProvisioned, "cpu")
 
-	if hint.Configured != 250e6 {
+	if hint.Configured == nil || *hint.Configured != 250e6 {
 		t.Errorf(
 			"configured = %v, want 250000000 NanoCPUs to match suggested's unit",
 			hint.Configured,
 		)
 	}
 
-	if hint.Current != 20e6 {
+	if hint.Current == nil || *hint.Current != 20e6 {
 		t.Errorf("current = %v, want 20000000 NanoCPUs (2%% of a core)", hint.Current)
 	}
 }

--- a/internal/recommendations/types.go
+++ b/internal/recommendations/types.go
@@ -49,8 +49,7 @@ type Recommendation struct {
 	TargetName string   `json:"targetName"`
 	Resource   string   `json:"resource,omitempty"`
 	Message    string   `json:"message"`
-	// Current and Configured are pointers for the same reason Suggested is:
-	// nil is "not measured", and a service using no CPU measures zero.
+	// nil is "not measured"; zero is a measurement.
 	Current    *float64 `json:"current,omitempty"`
 	Configured *float64 `json:"configured,omitempty"`
 	Suggested  *float64 `json:"suggested,omitempty"`

--- a/internal/recommendations/types.go
+++ b/internal/recommendations/types.go
@@ -49,8 +49,10 @@ type Recommendation struct {
 	TargetName string   `json:"targetName"`
 	Resource   string   `json:"resource,omitempty"`
 	Message    string   `json:"message"`
-	Current    float64  `json:"current,omitempty"`
-	Configured float64  `json:"configured,omitempty"`
+	// Current and Configured are pointers for the same reason Suggested is:
+	// nil is "not measured", and a service using no CPU measures zero.
+	Current    *float64 `json:"current,omitempty"`
+	Configured *float64 `json:"configured,omitempty"`
 	Suggested  *float64 `json:"suggested,omitempty"`
 	FixAction  *string  `json:"fixAction,omitempty"`
 }

--- a/main.go
+++ b/main.go
@@ -51,6 +51,9 @@ var widgetDist embed.FS
 //go:embed api/openapi.yaml
 var openapiSpec []byte
 
+//go:embed api/asyncapi.yaml
+var asyncapiSpec []byte
+
 // scalarJS is the Scalar API reference bundle served at /api/scalar.js, copied
 // out of node_modules into frontend/dist by the frontend build's postbuild
 // step. It comes from npm rather than a copy committed here so that one
@@ -482,6 +485,7 @@ func main() {
 		SPA:                spa,
 		InlineScriptHashes: inlineScriptHashes,
 		OpenAPISpec:        openapiSpec,
+		AsyncAPISpec:       asyncapiSpec,
 		ScalarJS:           scalarJS,
 		EnablePprof:        cfg.Pprof,
 		EnableSelfMetrics:  cfg.SelfMetrics,


### PR DESCRIPTION
Cetacean serves **twenty SSE streams**. OpenAPI described four of them, three only partially — it can say what a URL returns as JSON, and has no way to say that the same URL also streams. This adds an AsyncAPI 3.0 document that does.

## What it adds

`GET /api/asyncapi` serves an AsyncAPI 3.0 description of every stream: the eight resource list URLs and eight detail URLs, the global `/events` stream, both log tails and the metrics stream. It names the events each one sends, the shape of their payloads, and which of three cursor dialects its `id:` belongs to — a monotonic history id on the resource streams, an RFC 3339 timestamp that only moves forward on the log tails, and no id at all on `/metrics`.

Two things the document states that the examples alone get wrong: a `batch` frame's payload is an **array** of envelopes rather than one, and a **replayed** event carries no `resource`, because replay reads the change history, which stores identity and not payload.

Every response now carries a second `service-desc` Link beside the OpenAPI one, distinguished by its `type` parameter, and the API catalogue lists it. Cetacean ships no renderer — paste the document into [AsyncAPI Studio](https://studio.asyncapi.com/).

## How it is kept honest

The document is validated against the official AsyncAPI 3.0.0 meta-schema, and three walks hold it to the running server rather than to a list someone maintains:

- every channel address it declares is driven and must actually open a stream;
- every `GET` route the **router** registers is probed with `Accept: text/event-stream`, and anything that streams must appear in the document — the direction that catches a stream added after the document was written;
- the per-type messages are compared against the `cache.EventType` constants read out of the source, so a ninth resource type cannot be added without the contract following.

Frame-level tests drive the real transport for each dialect: event naming and batching on the resource streams, the aged-out-cursor `sync`, the missing `resource` on replay, and the log tail's unnamed, forward-only frames.

## Review fixes riding along

A review of the whole branch turned up six defects, none of them in the AsyncAPI work — they are in code it sits on top of. They are in their own commit (`79a06e8c`) and can be split out if you would rather they landed separately:

- **A filtered listing's CSV link downloaded everything.** `GET /services?search=web` advertised `</services.csv>` with the query dropped, so following the link — the obvious way to hand a filtered view to somebody who would rather read it in a spreadsheet — returned every service.
- **The discovery documents were refused while Docker was down.** `/.well-known/api-catalog` and `/opensearch.xml` read no cluster state, yet both answered ENG001 until the first sync landed — the moment a client probing an unresponsive server most needs them.
- **Cross-origin protection broke browser-based MCP clients.** `/oauth/token`, `/oauth/revoke`, `/oauth/register` and `POST /mcp` authenticate from the request itself, so there is no ambient credential for a cross-origin page to borrow and nothing for the check to defend. RFC 7591 registration is the case that cannot be worked around, since its whole point is a client nobody can list in advance. Consent at `/oauth/authorize` runs under the session cookie and stays checked.
- **The dashboard could not be installed as an app under OIDC.** A web app manifest is fetched with credentials omitted unless the page says otherwise, and `/manifest.webmanifest` is not exempt from authentication.
- **A recommendation that measured zero read as one that measured nothing.** `Current` and `Configured` were `float64` with `omitempty`, so an idle service's zero CPU vanished from the JSON and the CSV alike. They are pointers now, like `Suggested` already was.
- **An upgrade note, not a code change.** Deciding proxy trust at the edge means a deployment behind a TLS-terminating proxy with no `server.trusted_proxies` now names its own internal address in feed links and identifiers, the OpenSearch templates and the API catalogue. Documented in the changelog and on the setting.

## Also in here

The AsyncAPI handler rebuilt the entire ~18 KB document on every request in order to write one `servers` block. The body is a pure function of scheme, host and base path, so it now renders into the same `staticBody` every other served document uses, behind a single-slot cache. Measured on an M3 Pro: **96.9 µs/365 allocs → 6.7 µs/22** identity, **197.5 µs → 2.6 µs** with zstd. Conditional GETs gain the most, since the endpoint sets `max-age=3600` and therefore serves mostly revalidations.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues), `-race` on the changed packages, `tsc -b --noEmit`, `oxlint`, `oxfmt --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpeaKthnEpS78QyZ7YLLzM
